### PR TITLE
Don't log an error invalid coil address

### DIFF
--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -167,6 +167,8 @@ class NibeGW(asyncio.DatagramProtocol, Connection):
     def _on_raw_coil_value(self, coil_address: int, raw_value: bytes):
         coil = self._heatpump.get_coil_by_address(coil_address)
         if not coil:
+            if coil_address == 65535:
+                return
             raise DecodeException(f"Unable to decode: {coil_address} not found")
 
         coil.raw_value = raw_value

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -167,7 +167,7 @@ class NibeGW(asyncio.DatagramProtocol, Connection):
     def _on_raw_coil_value(self, coil_address: int, raw_value: bytes):
         coil = self._heatpump.get_coil_by_address(coil_address)
         if not coil:
-            if coil_address == 65535:
+            if coil_address == 65535:  # 0xffff
                 return
             raise DecodeException(f"Unable to decode: {coil_address} not found")
 


### PR DESCRIPTION
On Nibe F370 when no registers are configure for automatic reading
the heatpump sends data using the coil address 65535. We don't want
to log this, as it makes for a very noisy error log.