### PR TITLE
Drop udp packets from unknown hosts

### DIFF
--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -61,6 +61,12 @@ class NibeGW(asyncio.DatagramProtocol, Connection):
         self._transport = transport
 
     def datagram_received(self, data, addr):
+        if addr[0] != self._remote_ip:
+            logger.warning(
+                f"Ignoring packet from unknown host: {addr}"
+            )
+            return
+
         logger.debug(f"Received {hexlify(data)} from {addr}")
         try:
             msg = Response.parse(data)


### PR DESCRIPTION
Check that incoming udp packets have been sent from the system
running nibegw, otherwise drop the packets.