### PR TITLE
Yield to queued tasks for closing

### DIFF
--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -217,6 +217,7 @@ class NibeGW(asyncio.DatagramProtocol, Connection):
     async def stop(self):
         self._transport.close()
         self._transport = None
+        await asyncio.sleep(0)
 
 
 def xor8(data: bytes) -> int:


### PR DESCRIPTION
transport.close() will only queue up the command to close socket until next loop schedule. yield to make sure it's executed to avoid udp socket still being in used on restart.