### PR TITLE
Parse and signal coil updates on rmu data

### DIFF
--- a/nibe/coil.py
+++ b/nibe/coil.py
@@ -11,7 +11,7 @@ from construct import (
     Padded,
 )
 
-from nibe.exceptions import DecodeException, EncodeException
+from nibe.exceptions import DecodeException, EncodeException, NoMappingException
 from nibe.parsers import WordSwapped
 
 parser_map = {
@@ -162,13 +162,15 @@ class Coil:
         if self.mappings is None:
             return value
 
-        mapped_value = self.mappings.get(str(value))
-        if mapped_value is None:
-            raise DecodeException(
+        return self.get_mapping_for(value)
+
+    def get_mapping_for(self, value: int):
+        try:
+            return self.mappings[str(value)]
+        except KeyError:
+            raise NoMappingException(
                 f"Mapping not found for {self.name} coil for value: {value}"
             )
-
-        return mapped_value
 
     def _is_hitting_integer_limit(self, int_value: int):
         if self.size == "u8" and int_value == 0xFF:

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -38,7 +38,8 @@ from construct import (
     Pointer,
     IfThenElse,
     Select,
-    Union as UnionConstruct
+    Union as UnionConstruct,
+    Prefixed
 )
 
 from nibe.coil import Coil
@@ -566,14 +567,12 @@ GenericRequestData = Switch(
     default=Bytes(this.length),
 )
 
-
 GenericRequest = Struct(
     "fields" / RawCopy(
         Struct(
             "start_byte" / Const(0xC0, Int8ub),
             "cmd" / Command,
-            "length" / Int8ub,
-            "data" / FixedSized(this.length, Dedupe5C(GenericRequestData))
+            "data" / Prefixed(Int8ub, GenericRequestData)
         )
     ),
     "checksum" / Checksum(Int8ub, xor8, this.fields.data),

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -368,13 +368,14 @@ ProductInfoData = Struct(
     "_unknown" / Bytes(1), "version" / Int16ub, "model" / GreedyString("ASCII")
 )
 class FixedPoint(Adapter):
-    def __init__(self, subcon, scale, offset) -> None:
+    def __init__(self, subcon, scale, offset, ndigits=1) -> None:
         super().__init__(subcon)
         self._offset = offset
         self._scale = scale
+        self._ndigits = ndigits
 
     def _decode(self, obj, context, path):
-        return obj * self._scale + self._offset
+        return round(obj * self._scale + self._offset, self._ndigits)
 
     def _encode(self, obj, context, path):
         return (obj - self._offset) / self._scale

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -36,7 +36,9 @@ from construct import (
     Bitwise,
     Adapter,
     Pointer,
-    IfThenElse
+    IfThenElse,
+    FlagsEnum,
+    Byte
 )
 
 from nibe.coil import Coil
@@ -189,6 +191,7 @@ class NibeGW(asyncio.DatagramProtocol, Connection, EventServer):
 
                 self._on_coil_value(48132, data.temporary_lux)
                 self._on_coil_value(45001, data.alarm)
+                self._on_coil_value(47137, data.operational_mode)
 
                 address_to_room_temp_coil = {
                     Address.RMU40_S1: 40033,
@@ -382,16 +385,24 @@ class FixedPoint(Adapter):
         return (obj - self._offset) / self._scale
 
 RmuData = Struct(
-    "flags" / Pointer(16,
+    "flags" / Pointer(15,
         BitStruct(
+            "unknown_8000" / Flag,
+            "unknown_4000" / Flag,
+            "unknown_2000" / Flag,
+            "unknown_1000" / Flag,
+            "unknown_0800" / Flag,
+            "unknown_0400" / Flag,
+            "unknown_0200" / Flag,
+            "unknown_0100" / Flag,
             "use_room_sensor_s4" / Flag,
             "use_room_sensor_s3" / Flag,
             "use_room_sensor_s2" / Flag,
             "use_room_sensor_s1" / Flag,
-            "unknown_1" / Flag,
-            "unknown_2" / Flag,
-            "unknown_3" / Flag,
-            "unknown_4" / Flag,
+            "unknown_0008" / Flag,
+            "unknown_0004" / Flag,
+            "unknown_0002" / Flag,
+            "unknown_0001" / Flag,
         ),
     ),
     "bt1_outdoor_temperature" / FixedPoint(Int16sl, 0.1, -0.5),
@@ -421,9 +432,10 @@ RmuData = Struct(
     "hw_time_hour" / Int8ub,
     "hw_time_min" / Int8ub,
     "fan_mode" / Int8ub,
-    "unknown2" / Bytes(2),
-    "_flags" / Bytes(1),
-    "unknown3" / Bytes(2),
+    "operational_mode" / Int8ub,
+    "_flags" / Bytes(2),
+    "clock_time_hour" / Int8ub,
+    "clock_time_min" / Int8ub,
     "alarm" / Int8ub,
     "unknown4" / Bytes(1),
     "fan_time_hour" / Int8ub,

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -53,6 +53,7 @@ from nibe.exceptions import (
     CoilWriteTimeoutException,
     NibeException,
     ProductInfoReadTimeoutException,
+    DecodeException,
 )
 from nibe.heatpump import HeatPump, ProductInfo
 
@@ -334,7 +335,13 @@ class NibeGW(asyncio.DatagramProtocol, Connection, EventServer):
             raise
 
         if coil.mappings and isinstance(value, int):
-            value = coil.get_mapping_for(value)
+            try:
+                value = coil.get_mapping_for(value)
+            except DecodeException:
+                logger.warning(
+                    f"Ignoring coil value {coil_address} due failure to decode: {value}"
+                )
+                return
 
         coil.value = value
         logger.info(f"{coil.name}: {coil.value}")

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -28,6 +28,9 @@ from construct import (
     Subconstruct,
     Switch,
     this,
+    BitStruct,
+    GreedyBytes,
+    Bitwise,
 )
 
 from nibe.coil import Coil
@@ -305,6 +308,37 @@ ProductInfoData = Struct(
     "_unknown" / Bytes(1), "version" / Int16ub, "model" / GreedyString("ASCII")
 )
 
+RmuData = Struct(
+    "bt1-outdoor-temperature" / Int16ul,
+    "bt7-hw-top" / Int16ul,
+    "room-sensor-setpoint-or-curve-offset-s1" / Int8ub,
+    "room-sensor-setpoint-or-curve-offset-s2" / Int8ub,
+    "room-sensor-setpoint-or-curve-offset-s3" / Int8ub,
+    "room-sensor-setpoint-or-curve-offset-s4" / Int8ub,
+    "bt50-room-temp-sX" / Int16ul,
+    "temporary-lux" / Int8ub,
+    "hw-time-hour" / Int8ub,
+    "hw-time-min" / Int8ub,
+    "fan-mode" / Int8ub,
+    "unknown2" / Bytes(2),
+    "flags"
+    / BitStruct(
+        "use-room-sensor-s4" / Flag,
+        "use-room-sensor-s3" / Flag,
+        "use-room-sensor-s2" / Flag,
+        "use-room-sensor-s1" / Flag,
+        "unknown_1" / Flag,
+        "unknown_2" / Flag,
+        "unknown_3" / Flag,
+        "unknown_4" / Flag,
+    ),
+    "unknown3" / Bytes(2),
+    "alarm" / Int8ub,
+    "unknown4" / Bytes(1),
+    "fan-time-hour" / Int8ub,
+    "fan-time-min" / Int8ub,
+    "unknown5" / GreedyBytes,
+)
 
 Data = Dedupe5C(
     Switch(
@@ -317,6 +351,7 @@ Data = Dedupe5C(
             ),
             "MODBUS_WRITE_RESP": Struct("result" / Flag),
             "PRODUCT_INFO_MSG": ProductInfoData,
+            "RMU_DATA_MSG": RmuData,
         },
         default=Bytes(this.length),
     )

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -192,6 +192,7 @@ class NibeGW(asyncio.DatagramProtocol, Connection, EventServer):
                 self._on_coil_value(48132, data.temporary_lux)
                 self._on_coil_value(45001, data.alarm)
                 self._on_coil_value(47137, data.operational_mode)
+                self._on_coil_value(47387, 1 if data.flags.hw_production else 0)
 
                 address_to_room_temp_coil = {
                     Address.RMU40_S1: 40033,
@@ -402,7 +403,7 @@ RmuData = Struct(
             "unknown_0008" / Flag,
             "unknown_0004" / Flag,
             "unknown_0002" / Flag,
-            "unknown_0001" / Flag,
+            "hw_production" / Flag,
         ),
     ),
     "bt1_outdoor_temperature" / FixedPoint(Int16sl, 0.1, -0.5),

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -330,7 +330,7 @@ class NibeGW(asyncio.DatagramProtocol, Connection, EventServer):
             raise
 
         if coil.mappings and isinstance(value, int):
-            value = coil.mappings[str(value)]
+            value = coil.get_mapping_for(value)
 
         coil.value = value
         logger.info(f"{coil.name}: {coil.value}")

--- a/nibe/exceptions.py
+++ b/nibe/exceptions.py
@@ -10,6 +10,10 @@ class DecodeException(NibeException):
     pass
 
 
+class NoMappingException(DecodeException):
+    pass
+
+
 class EncodeException(NibeException):
     pass
 

--- a/tests/connection/test_nibegw.py
+++ b/tests/connection/test_nibegw.py
@@ -69,8 +69,9 @@ class TestNibeGW(TestCase):
             binascii.unhexlify("c06902a0a9a2"), ("127.0.0.1", 9999)
         )
 
-    def test_read_coil_decode_exception(self):
+    def test_read_coil_decode_ignored(self):
         coil = self.heatpump.get_coil_by_address(43086)
+        coil.value = "HEAT"
 
         async def send_receive():
             task = self.loop.create_task(self.nibegw.read_coil(coil))
@@ -81,8 +82,8 @@ class TestNibeGW(TestCase):
 
             return await task
 
-        with self.assertRaises(CoilReadException):
-            self.loop.run_until_complete(send_receive())
+        self.loop.run_until_complete(send_receive())
+        assert coil.value == "HEAT"
 
     def test_read_coil_timeout_exception(self):
         coil = self.heatpump.get_coil_by_address(43086)

--- a/tests/connection/test_nibegw_message_parsing.py
+++ b/tests/connection/test_nibegw_message_parsing.py
@@ -133,6 +133,13 @@ class MessageResponseParsingTestCase(unittest.TestCase):
         self.assertEqual(data.data.model, "F1255-12 R")
         self.assertEqual(data.data.version, 9443)
 
+    def test_parse_rmu_data(self):
+        data = self._parse_hexlified_raw_message("5c001a62199b0029029ba00000e20000000000000239001f0003000001002e")
+        print(data)
+
+        data = self._parse_hexlified_raw_message("5c001962199b0028029ba00000e20000000000000239002100030000010012")
+        print(data)
+
     @staticmethod
     def _parse_hexlified_raw_message(txt_raw):
         raw = binascii.unhexlify(txt_raw)

--- a/tests/connection/test_nibegw_message_parsing.py
+++ b/tests/connection/test_nibegw_message_parsing.py
@@ -185,14 +185,14 @@ class MessageGenerigRequestParsingTestCase(unittest.TestCase):
         hex = bytes([192,238,3,238,3,1,193]).hex()
         data = self._parse_hexlified_raw_message(hex)
         self.assertEqual(data.cmd, "ACCESSORY_VERSION_REQ")
-        self.assertEqual(data.modbus.version, 1006)
-        self.assertEqual(data.modbus.unknown, 1)
+        self.assertEqual(data.data.modbus.version, 1006)
+        self.assertEqual(data.data.modbus.unknown, 1)
 
         hex = bytes([192,238,3,238,3,1,193]).hex()
         data = self._parse_hexlified_raw_message(hex)
         self.assertEqual(data.cmd, "ACCESSORY_VERSION_REQ")
-        self.assertEqual(data.rum.version, 259)
-        self.assertEqual(data.rmu.unknown, 238)
+        self.assertEqual(data.data.rmu.version, 259)
+        self.assertEqual(data.data.rmu.unknown, 238)
 
 
     def test_parse_write_request(self):

--- a/tests/connection/test_nibegw_message_parsing.py
+++ b/tests/connection/test_nibegw_message_parsing.py
@@ -166,7 +166,7 @@ class MessageWriteRequestParsingTestCase(unittest.TestCase):
         self.assertEqual(binascii.hexlify(raw), b"c06b06393006120f00bf")
 
 
-class MessageGenerigRequestParsingTestCase(unittest.TestCase):
+class MessageGenericRequestParsingTestCase(unittest.TestCase):
 
     @staticmethod
     def _parse_hexlified_raw_message(txt_raw):

--- a/tests/connection/test_nibegw_message_parsing.py
+++ b/tests/connection/test_nibegw_message_parsing.py
@@ -3,7 +3,7 @@ import unittest
 
 from construct import ChecksumError, Int16sl, Int32ul
 
-from nibe.connection.nibegw import ReadRequest, Response, WriteRequest
+from nibe.connection.nibegw import ReadRequest, Response, WriteRequest, GenericRequest
 
 
 class MessageResponseParsingTestCase(unittest.TestCase):
@@ -164,6 +164,49 @@ class MessageWriteRequestParsingTestCase(unittest.TestCase):
         )
 
         self.assertEqual(binascii.hexlify(raw), b"c06b06393006120f00bf")
+
+
+class MessageGenerigRequestParsingTestCase(unittest.TestCase):
+
+    @staticmethod
+    def _parse_hexlified_raw_message(txt_raw):
+        raw = binascii.unhexlify(txt_raw)
+        data = GenericRequest.parse(raw)
+        value = data.fields.value
+        print(value)
+        return value
+
+    def test_parse_write_request(self):
+        hex = bytes([192,107,6,115,176,1,0,0,0,111]).hex()
+        data = self._parse_hexlified_raw_message(hex)
+
+
+    def test_parse_version_request(self):
+        hex = bytes([192,238,3,238,3,1,193]).hex()
+        data = self._parse_hexlified_raw_message(hex)
+        self.assertEqual(data.cmd, "ACCESSORY_VERSION_REQ")
+        self.assertEqual(data.modbus.version, 1006)
+        self.assertEqual(data.modbus.unknown, 1)
+
+        hex = bytes([192,238,3,238,3,1,193]).hex()
+        data = self._parse_hexlified_raw_message(hex)
+        self.assertEqual(data.cmd, "ACCESSORY_VERSION_REQ")
+        self.assertEqual(data.rum.version, 259)
+        self.assertEqual(data.rmu.unknown, 238)
+
+
+    def test_parse_write_request(self):
+        hex = bytes([192,96,2,99,2,195]).hex()
+        data = self._parse_hexlified_raw_message(hex)
+        self.assertEqual(data.cmd, "RMU_WRITE_REQ")
+        self.assertEqual(data.data.index, 99)
+        self.assertEqual(data.data.value, b"\x02")
+
+        hex = bytes([192,96,3,6,217,0,124]).hex()
+        data = self._parse_hexlified_raw_message(hex)
+        self.assertEqual(data.cmd, "RMU_WRITE_REQ")
+        self.assertEqual(data.data.index, 6)
+        self.assertEqual(data.data.value, b'\xd9\x00')
 
 
 if __name__ == "__main__":

--- a/tests/connection/test_nibegw_message_parsing.py
+++ b/tests/connection/test_nibegw_message_parsing.py
@@ -1,7 +1,7 @@
 import binascii
 import unittest
 
-from construct import ChecksumError, Int16sl, Int32ul
+from construct import ChecksumError, Int16sl, Int32ul, Container
 
 from nibe.connection.nibegw import (
     Response,
@@ -137,15 +137,100 @@ class MessageResponseParsingTestCase(unittest.TestCase):
         self.assertEqual(data.data.version, 9443)
 
     def test_parse_rmu_data(self):
+        self.maxDiff = None
+
         data = self._parse_hexlified_raw_message(
             "5c001a62199b0029029ba00000e20000000000000239001f0003000001002e"
         )
-        print(data)
+        self.assertDictEqual(
+            data.data,
+            Container(
+                alarm=0,
+                bt1_outdoor_temperature=15.0,
+                bt50_room_temp_sX=22.1,
+                bt7_hw_top=54.8,
+                clock_time_hour=0,
+                clock_time_min=31,
+                fan_mode=0,
+                fan_time_hour=0,
+                fan_time_min=0,
+                flags=Container(
+                    unknown_8000=False,
+                    unknown_4000=False,
+                    unknown_2000=False,
+                    unknown_1000=False,
+                    unknown_0800=False,
+                    unknown_0400=False,
+                    unknown_0200=True,
+                    unknown_0100=False,
+                    use_room_sensor_s4=False,
+                    use_room_sensor_s3=False,
+                    use_room_sensor_s2=True,
+                    use_room_sensor_s1=True,
+                    unknown_0008=True,
+                    unknown_0004=False,
+                    unknown_0002=False,
+                    hw_production=True,
+                ),
+                hw_time_hour=0,
+                hw_time_min=0,
+                operational_mode=0,
+                setpoint_or_offset_s1=20.5,
+                setpoint_or_offset_s2=21.0,
+                setpoint_or_offset_s3=0.0,
+                setpoint_or_offset_s4=0.0,
+                temporary_lux=0,
+                unknown4=b"\x03",
+                unknown5=b"\x01\x00",
+            ),
+        )
 
         data = self._parse_hexlified_raw_message(
             "5c001962199b0028029ba00000e20000000000000239002100030000010012"
         )
-        print(data)
+
+        self.assertDictEqual(
+            data.data,
+            Container(
+                alarm=0,
+                bt1_outdoor_temperature=15.0,
+                bt50_room_temp_sX=22.1,
+                bt7_hw_top=54.7,
+                clock_time_hour=0,
+                clock_time_min=33,
+                fan_mode=0,
+                fan_time_hour=0,
+                fan_time_min=0,
+                flags=Container(
+                    unknown_8000=False,
+                    unknown_4000=False,
+                    unknown_2000=False,
+                    unknown_1000=False,
+                    unknown_0800=False,
+                    unknown_0400=False,
+                    unknown_0200=True,
+                    unknown_0100=False,
+                    use_room_sensor_s4=False,
+                    use_room_sensor_s3=False,
+                    use_room_sensor_s2=True,
+                    use_room_sensor_s1=True,
+                    unknown_0008=True,
+                    unknown_0004=False,
+                    unknown_0002=False,
+                    hw_production=True,
+                ),
+                hw_time_hour=0,
+                hw_time_min=0,
+                operational_mode=0,
+                setpoint_or_offset_s1=20.5,
+                setpoint_or_offset_s2=21.0,
+                setpoint_or_offset_s3=0.0,
+                setpoint_or_offset_s4=0.0,
+                temporary_lux=0,
+                unknown4=b"\x03",
+                unknown5=b"\x01\x00",
+            ),
+        )
 
     @staticmethod
     def _parse_hexlified_raw_message(txt_raw):
@@ -161,7 +246,6 @@ class MessageRequestParsingTestCase(unittest.TestCase):
         raw = binascii.unhexlify(txt_raw)
         data = Request.parse(raw)
         value = data.fields.value
-        print(value)
         return value
 
     def test_build_read_request(self):

--- a/tests/connection/test_nibegw_message_parsing.py
+++ b/tests/connection/test_nibegw_message_parsing.py
@@ -164,7 +164,7 @@ class MessageRequestParsingTestCase(unittest.TestCase):
         print(value)
         return value
 
-    def test_parse_read_request(self):
+    def test_build_read_request(self):
         raw = Request.build(
             dict(
                 fields=dict(
@@ -178,7 +178,7 @@ class MessageRequestParsingTestCase(unittest.TestCase):
 
         self.assertEqual(binascii.hexlify(raw), b"c069023930a2")
 
-    def test_parse_read_request(self):
+    def test_build_write_request(self):
         raw = Request.build(
             dict(
                 fields=dict(


### PR DESCRIPTION
Support parsing data that is sent when RMU subsystems are activated, to avoid the need to manually poll these sensors.

Adapted from: https://github.com/anerdins/nibepi/blob/c4d4adb3405ad10e338dfac965b6075ae1588cf5/index.js#L803