### PR TITLE
Switch to py.test from unittest

### DIFF
--- a/tests/connection/test_nibegw.py
+++ b/tests/connection/test_nibegw.py
@@ -3,6 +3,8 @@ import binascii
 from unittest import TestCase
 from unittest.mock import Mock
 
+import pytest
+
 from nibe.connection.nibegw import ConnectionStatus, NibeGW
 from nibe.exceptions import CoilReadTimeoutException
 from nibe.heatpump import HeatPump, Model, ProductInfo
@@ -17,11 +19,11 @@ class TestNibeGW(TestCase):
         self.nibegw = NibeGW(self.heatpump, "127.0.0.1")
 
         self.transport = Mock()
-        self.assertEqual(None, self.nibegw.status)
+        assert "unknown" == self.nibegw.status
         self.nibegw.connection_made(self.transport)
 
     def test_status(self):
-        self.assertEqual("listening", self.nibegw.status)
+        assert "listening" == self.nibegw.status
 
         connection_status_handler_mock = Mock()
         self.nibegw.subscribe(
@@ -41,7 +43,7 @@ class TestNibeGW(TestCase):
 
         self.loop.run_until_complete(send_receive())
 
-        self.assertEqual("connected", self.nibegw.status)
+        assert "connected" == self.nibegw.status
         connection_status_handler_mock.assert_called_once_with(
             status=ConnectionStatus.CONNECTED
         )
@@ -63,7 +65,7 @@ class TestNibeGW(TestCase):
             return await task
 
         coil = self.loop.run_until_complete(send_receive())
-        self.assertEqual(4853, coil.value)
+        assert 4853 == coil.value
 
         self.transport.sendto.assert_called_with(
             binascii.unhexlify("c06902a0a9a2"), ("127.0.0.1", 9999)
@@ -88,7 +90,7 @@ class TestNibeGW(TestCase):
     def test_read_coil_timeout_exception(self):
         coil = self.heatpump.get_coil_by_address(43086)
 
-        with self.assertRaises(CoilReadTimeoutException):
+        with pytest.raises(CoilReadTimeoutException):
             self.loop.run_until_complete(self.nibegw.read_coil(coil, 0.1))
 
     def test_write_coil(self):

--- a/tests/connection/test_nibegw_message_parsing.py
+++ b/tests/connection/test_nibegw_message_parsing.py
@@ -2,6 +2,7 @@ import binascii
 import unittest
 
 from construct import ChecksumError, Container, Int16sl, Int32ul
+import pytest
 
 from nibe.connection.nibegw import Request, Response
 
@@ -10,128 +11,124 @@ class MessageResponseParsingTestCase(unittest.TestCase):
     def test_parse_read_response(self):
         data = self._parse_hexlified_raw_message("5c00206a060cb901000000f8")
 
-        self.assertEqual(data.address, "MODBUS40")
-        self.assertEqual(data.cmd, "MODBUS_READ_RESP")
-        self.assertEqual(data.data.coil_address, 47372)
-        self.assertEqual(data.data.value, b"\x01\x00\x00\x00")
+        assert data.address == "MODBUS40"
+        assert data.cmd == "MODBUS_READ_RESP"
+        assert data.data.coil_address == 47372
+        assert data.data.value == b"\x01\x00\x00\x00"
 
     def test_parse_escaped_read_response(self):
         data = self._parse_hexlified_raw_message("5c00206a074f9c5c5c002c00b2")
 
-        self.assertEqual(data.address, "MODBUS40")
-        self.assertEqual(data.cmd, "MODBUS_READ_RESP")
-        self.assertEqual(data.data.coil_address, 40015)
+        assert data.address == "MODBUS40"
+        assert data.cmd == "MODBUS_READ_RESP"
+        assert data.data.coil_address == 40015
 
-        self.assertEqual(Int16sl.parse(data.data.value) / 10, 9.2)
+        assert Int16sl.parse(data.data.value) / 10 == 9.2
 
     def test_parse_read_response_with_wrong_crc(self):
-        self.assertRaises(
-            ChecksumError, self._parse_hexlified_raw_message, "5c00206a060cb901000000f9"
-        )
+        with pytest.raises(ChecksumError):
+            self._parse_hexlified_raw_message("5c00206a060cb901000000f9")
 
     def test_parse_multiple_read_request(self):
         data = self._parse_hexlified_raw_message(
             "5c00206850449c9600489c49014c9c21014d9cb4014e9c8d014f9c2401509c0d01619ce400fda700004ea80"
             + "a0080a80000ada90000afa9000004bc000067be0000a3b7fd0063bef6006d9cec006e9c0101eeac4600fb"
         )
-        self.assertEqual(data.address, "MODBUS40")
-        self.assertEqual(data.cmd, "MODBUS_DATA_MSG")
-        self.assertIsInstance(data.data, list)
-        self.assertListEqual(
-            data.data,
-            [
-                dict(coil_address=40004, value=b"\x96\x00"),
-                dict(coil_address=40008, value=b"I\x01"),
-                dict(coil_address=40012, value=b"!\x01"),
-                dict(coil_address=40013, value=b"\xb4\x01"),
-                dict(coil_address=40014, value=b"\x8d\x01"),
-                dict(coil_address=40015, value=b"$\x01"),
-                dict(coil_address=40016, value=b"\r\x01"),
-                dict(coil_address=40033, value=b"\xe4\x00"),
-                dict(coil_address=43005, value=b"\x00\x00"),
-                dict(coil_address=43086, value=b"\n\x00"),
-                dict(coil_address=43136, value=b"\x00\x00"),
-                dict(coil_address=43437, value=b"\x00\x00"),
-                dict(coil_address=43439, value=b"\x00\x00"),
-                dict(coil_address=48132, value=b"\x00\x00"),
-                dict(coil_address=48743, value=b"\x00\x00"),
-                dict(coil_address=47011, value=b"\xfd\x00"),
-                dict(coil_address=48739, value=b"\xf6\x00"),
-                dict(coil_address=40045, value=b"\xec\x00"),
-                dict(coil_address=40046, value=b"\x01\x01"),
-                dict(coil_address=44270, value=b"F\x00"),
-            ],
-        )
+        assert data.address == "MODBUS40"
+        assert data.cmd == "MODBUS_DATA_MSG"
+        assert isinstance(data.data, list)
+        assert data.data == [
+            dict(coil_address=40004, value=b"\x96\x00"),
+            dict(coil_address=40008, value=b"I\x01"),
+            dict(coil_address=40012, value=b"!\x01"),
+            dict(coil_address=40013, value=b"\xb4\x01"),
+            dict(coil_address=40014, value=b"\x8d\x01"),
+            dict(coil_address=40015, value=b"$\x01"),
+            dict(coil_address=40016, value=b"\r\x01"),
+            dict(coil_address=40033, value=b"\xe4\x00"),
+            dict(coil_address=43005, value=b"\x00\x00"),
+            dict(coil_address=43086, value=b"\n\x00"),
+            dict(coil_address=43136, value=b"\x00\x00"),
+            dict(coil_address=43437, value=b"\x00\x00"),
+            dict(coil_address=43439, value=b"\x00\x00"),
+            dict(coil_address=48132, value=b"\x00\x00"),
+            dict(coil_address=48743, value=b"\x00\x00"),
+            dict(coil_address=47011, value=b"\xfd\x00"),
+            dict(coil_address=48739, value=b"\xf6\x00"),
+            dict(coil_address=40045, value=b"\xec\x00"),
+            dict(coil_address=40046, value=b"\x01\x01"),
+            dict(coil_address=44270, value=b"F\x00"),
+        ]
 
     def test_parse_multiple_with_5c_checksum(self):
         data = self._parse_hexlified_raw_message(
             "5c00206850449c2d00489cf4014c9c56014d9cf8014e9cc4014f9c4b00509c2800619cef00fda700004ea80a0080a80000ada90000afa9000004bc000067be0000a3b7010063befd006d9cf8006e9cff00eeacc800c5"
         )
-        self.assertEqual(data.address, "MODBUS40")
-        self.assertEqual(data.cmd, "MODBUS_DATA_MSG")
-        self.assertIsInstance(data.data, list)
+        assert data.address == "MODBUS40"
+        assert data.cmd == "MODBUS_DATA_MSG"
+        assert isinstance(data.data, list)
 
     def test_parse_multiple_escaped_value(self):
         data = self._parse_hexlified_raw_message(
             "5c00206851449c2c00489cf1014c9c59014d9cf8014e9cc4014f9c5c5c00509c2d00619cee00fda700004ea80a0080a80000ada90000afa9000004bc000067be0000a3b7010063befd006d9cf8006e9cff00eeacc80019"
         )
-        self.assertEqual(data.address, "MODBUS40")
-        self.assertEqual(data.cmd, "MODBUS_DATA_MSG")
-        self.assertIsInstance(data.data, list)
+        assert data.address == "MODBUS40"
+        assert data.cmd == "MODBUS_DATA_MSG"
+        assert isinstance(data.data, list)
 
-        self.assertEqual(b"\xc4\x01", data.data[4].value)
-        self.assertEqual(40015, data.data[5].coil_address)
-        self.assertEqual(b"\x5c\x00", data.data[5].value)
-        self.assertEqual(40016, data.data[6].coil_address)
+        assert b"\xc4\x01" == data.data[4].value
+        assert 40015 == data.data[5].coil_address
+        assert b"\x5c\x00" == data.data[5].value
+        assert 40016 == data.data[6].coil_address
 
-        self.assertEqual(44270, data.data[19].coil_address)
-        self.assertEqual(b"\xc8\x00", data.data[19].value)
+        assert 44270 == data.data[19].coil_address
+        assert b"\xc8\x00" == data.data[19].value
 
     def test_parse_multiple_heavily_escaped_value(self):
         data = self._parse_hexlified_raw_message(
             "5c0020685401a81f0100a86400fda7d003449c1e004f9ca000509c7800519c0301529c1b01879c14014e9cc601479c010115b9b0ff3ab94b00c9af0000489c0d014c9ce7004b9c0000ffff0000ffff00005c5c5c5c5c5c5c5c41"
         )
-        self.assertEqual(data.address, "MODBUS40")
-        self.assertEqual(data.cmd, "MODBUS_DATA_MSG")
-        self.assertIsInstance(data.data, list)
+        assert data.address == "MODBUS40"
+        assert data.cmd == "MODBUS_DATA_MSG"
+        assert isinstance(data.data, list)
 
     def test_special_len(self):
         data = self._parse_hexlified_raw_message(
             "5c00206851449c2500489cfc004c9cf1004e9cc7014d9c0b024f9c2500509c3300519c0b01529c5c5c01569c3100c9af000001a80c01fda716fafaa9070098a91b1bffff0000a0a9ca02ffff00009ca99212ffff0000be"
         )
-        self.assertEqual(data.address, "MODBUS40")
-        self.assertEqual(data.cmd, "MODBUS_DATA_MSG")
-        self.assertIsInstance(data.data, list)
+        assert data.address == "MODBUS40"
+        assert data.cmd == "MODBUS_DATA_MSG"
+        assert isinstance(data.data, list)
 
     def test_succesfull_write_response(self):
         data = self._parse_hexlified_raw_message("5c00206c01014c")
 
-        self.assertTrue(data.data.result)
+        assert data.data.result
 
     def test_failed_write_response(self):
         data = self._parse_hexlified_raw_message("5c00206c01004d")
 
-        self.assertFalse(data.data.result)
+        assert not data.data.result
 
     def test_parse_product_data(self):
         data = self._parse_hexlified_raw_message("5c00206d0b0124e346313135352d3136ec")
-        self.assertEqual(data.data._unknown, b"\x01")
-        self.assertEqual(data.data.model, "F1155-16")
-        self.assertEqual(data.data.version, 9443)
+        assert data.data._unknown == b"\x01"
+        assert data.data.model == "F1155-16"
+        assert data.data.version == 9443
 
         data = self._parse_hexlified_raw_message(
             "5c00206d100724575465686f7761747469204169721a"
         )
-        self.assertEqual(data.data._unknown, b"\x07")
-        self.assertEqual(data.data.model, "Tehowatti Air")
-        self.assertEqual(data.data.version, 9303)
+        assert data.data._unknown == b"\x07"
+        assert data.data.model == "Tehowatti Air"
+        assert data.data.version == 9303
 
         data = self._parse_hexlified_raw_message(
             "5c00206d0d0124e346313235352d313220529f"
         )
-        self.assertEqual(data.data._unknown, b"\x01")
-        self.assertEqual(data.data.model, "F1255-12 R")
-        self.assertEqual(data.data.version, 9443)
+        assert data.data._unknown == b"\x01"
+        assert data.data.model == "F1255-12 R"
+        assert data.data.version == 9443
 
     def test_parse_rmu_data(self):
         self.maxDiff = None
@@ -139,94 +136,88 @@ class MessageResponseParsingTestCase(unittest.TestCase):
         data = self._parse_hexlified_raw_message(
             "5c001a62199b0029029ba00000e20000000000000239001f0003000001002e"
         )
-        self.assertDictEqual(
-            data.data,
-            Container(
-                alarm=0,
-                bt1_outdoor_temperature=15.0,
-                bt50_room_temp_sX=22.1,
-                bt7_hw_top=54.8,
-                clock_time_hour=0,
-                clock_time_min=31,
-                fan_mode=0,
-                fan_time_hour=0,
-                fan_time_min=0,
-                flags=Container(
-                    unknown_8000=False,
-                    unknown_4000=False,
-                    unknown_2000=False,
-                    unknown_1000=False,
-                    unknown_0800=False,
-                    unknown_0400=False,
-                    unknown_0200=True,
-                    unknown_0100=False,
-                    use_room_sensor_s4=False,
-                    use_room_sensor_s3=False,
-                    use_room_sensor_s2=True,
-                    use_room_sensor_s1=True,
-                    unknown_0008=True,
-                    unknown_0004=False,
-                    unknown_0002=False,
-                    hw_production=True,
-                ),
-                hw_time_hour=0,
-                hw_time_min=0,
-                operational_mode=0,
-                setpoint_or_offset_s1=20.5,
-                setpoint_or_offset_s2=21.0,
-                setpoint_or_offset_s3=0.0,
-                setpoint_or_offset_s4=0.0,
-                temporary_lux=0,
-                unknown4=b"\x03",
-                unknown5=b"\x01\x00",
+        assert data.data == Container(
+            alarm=0,
+            bt1_outdoor_temperature=15.0,
+            bt50_room_temp_sX=22.1,
+            bt7_hw_top=54.8,
+            clock_time_hour=0,
+            clock_time_min=31,
+            fan_mode=0,
+            fan_time_hour=0,
+            fan_time_min=0,
+            flags=Container(
+                unknown_8000=False,
+                unknown_4000=False,
+                unknown_2000=False,
+                unknown_1000=False,
+                unknown_0800=False,
+                unknown_0400=False,
+                unknown_0200=True,
+                unknown_0100=False,
+                use_room_sensor_s4=False,
+                use_room_sensor_s3=False,
+                use_room_sensor_s2=True,
+                use_room_sensor_s1=True,
+                unknown_0008=True,
+                unknown_0004=False,
+                unknown_0002=False,
+                hw_production=True,
             ),
+            hw_time_hour=0,
+            hw_time_min=0,
+            operational_mode=0,
+            setpoint_or_offset_s1=20.5,
+            setpoint_or_offset_s2=21.0,
+            setpoint_or_offset_s3=0.0,
+            setpoint_or_offset_s4=0.0,
+            temporary_lux=0,
+            unknown4=b"\x03",
+            unknown5=b"\x01\x00",
         )
 
         data = self._parse_hexlified_raw_message(
             "5c001962199b0028029ba00000e20000000000000239002100030000010012"
         )
 
-        self.assertDictEqual(
-            data.data,
-            Container(
-                alarm=0,
-                bt1_outdoor_temperature=15.0,
-                bt50_room_temp_sX=22.1,
-                bt7_hw_top=54.7,
-                clock_time_hour=0,
-                clock_time_min=33,
-                fan_mode=0,
-                fan_time_hour=0,
-                fan_time_min=0,
-                flags=Container(
-                    unknown_8000=False,
-                    unknown_4000=False,
-                    unknown_2000=False,
-                    unknown_1000=False,
-                    unknown_0800=False,
-                    unknown_0400=False,
-                    unknown_0200=True,
-                    unknown_0100=False,
-                    use_room_sensor_s4=False,
-                    use_room_sensor_s3=False,
-                    use_room_sensor_s2=True,
-                    use_room_sensor_s1=True,
-                    unknown_0008=True,
-                    unknown_0004=False,
-                    unknown_0002=False,
-                    hw_production=True,
-                ),
-                hw_time_hour=0,
-                hw_time_min=0,
-                operational_mode=0,
-                setpoint_or_offset_s1=20.5,
-                setpoint_or_offset_s2=21.0,
-                setpoint_or_offset_s3=0.0,
-                setpoint_or_offset_s4=0.0,
-                temporary_lux=0,
-                unknown4=b"\x03",
-                unknown5=b"\x01\x00",
+        assert data.data == Container(
+            alarm=0,
+            bt1_outdoor_temperature=15.0,
+            bt50_room_temp_sX=22.1,
+            bt7_hw_top=54.7,
+            clock_time_hour=0,
+            clock_time_min=33,
+            fan_mode=0,
+            fan_time_hour=0,
+            fan_time_min=0,
+            flags=Container(
+                unknown_8000=False,
+                unknown_4000=False,
+                unknown_2000=False,
+                unknown_1000=False,
+                unknown_0800=False,
+                unknown_0400=False,
+                unknown_0200=True,
+                unknown_0100=False,
+                use_room_sensor_s4=False,
+                use_room_sensor_s3=False,
+                use_room_sensor_s2=True,
+                use_room_sensor_s1=True,
+                unknown_0008=True,
+                unknown_0004=False,
+                unknown_0002=False,
+                hw_production=True,
             ),
+            hw_time_hour=0,
+            hw_time_min=0,
+            operational_mode=0,
+            setpoint_or_offset_s1=20.5,
+            setpoint_or_offset_s2=21.0,
+            setpoint_or_offset_s3=0.0,
+            setpoint_or_offset_s4=0.0,
+            temporary_lux=0,
+            unknown4=b"\x03",
+            unknown5=b"\x01\x00",
         )
 
     @staticmethod
@@ -257,7 +248,7 @@ class MessageRequestParsingTestCase(unittest.TestCase):
             )
         )
 
-        self.assertEqual(binascii.hexlify(raw), b"c069023930a2")
+        assert binascii.hexlify(raw) == b"c069023930a2"
 
     def test_build_write_request(self):
         raw = Request.build(
@@ -271,7 +262,7 @@ class MessageRequestParsingTestCase(unittest.TestCase):
             )
         )
 
-        self.assertEqual(binascii.hexlify(raw), b"c06b06393006120f00bf")
+        assert binascii.hexlify(raw) == b"c06b06393006120f00bf"
 
     def test_parse_write_request(self):
         hex = bytes([192, 107, 6, 115, 176, 1, 0, 0, 0, 111]).hex()
@@ -280,28 +271,28 @@ class MessageRequestParsingTestCase(unittest.TestCase):
     def test_parse_version_request(self):
         hex = bytes([192, 238, 3, 238, 3, 1, 193]).hex()
         data = self._parse_hexlified_raw_message(hex)
-        self.assertEqual(data.cmd, "ACCESSORY_VERSION_REQ")
-        self.assertEqual(data.data.modbus.version, 1006)
-        self.assertEqual(data.data.modbus.unknown, 1)
+        assert data.cmd == "ACCESSORY_VERSION_REQ"
+        assert data.data.modbus.version == 1006
+        assert data.data.modbus.unknown == 1
 
         hex = bytes([192, 238, 3, 238, 3, 1, 193]).hex()
         data = self._parse_hexlified_raw_message(hex)
-        self.assertEqual(data.cmd, "ACCESSORY_VERSION_REQ")
-        self.assertEqual(data.data.rmu.version, 259)
-        self.assertEqual(data.data.rmu.unknown, 238)
+        assert data.cmd == "ACCESSORY_VERSION_REQ"
+        assert data.data.rmu.version == 259
+        assert data.data.rmu.unknown == 238
 
     def test_parse_rmu_write_request(self):
         hex = bytes([192, 96, 2, 99, 2, 195]).hex()
         data = self._parse_hexlified_raw_message(hex)
-        self.assertEqual(data.cmd, "RMU_WRITE_REQ")
-        self.assertEqual(data.data.index, 99)
-        self.assertEqual(data.data.value, b"\x02")
+        assert data.cmd == "RMU_WRITE_REQ"
+        assert data.data.index == 99
+        assert data.data.value == b"\x02"
 
         hex = bytes([192, 96, 3, 6, 217, 0, 124]).hex()
         data = self._parse_hexlified_raw_message(hex)
-        self.assertEqual(data.cmd, "RMU_WRITE_REQ")
-        self.assertEqual(data.data.index, 6)
-        self.assertEqual(data.data.value, b"\xd9\x00")
+        assert data.cmd == "RMU_WRITE_REQ"
+        assert data.data.index == 6
+        assert data.data.value == b"\xd9\x00"
 
 
 if __name__ == "__main__":

--- a/tests/connection/test_nibegw_message_parsing.py
+++ b/tests/connection/test_nibegw_message_parsing.py
@@ -76,13 +76,13 @@ class MessageResponseParsingTestCase(unittest.TestCase):
         assert data.cmd == "MODBUS_DATA_MSG"
         assert isinstance(data.data, list)
 
-        assert b"\xc4\x01" == data.data[4].value
-        assert 40015 == data.data[5].coil_address
-        assert b"\x5c\x00" == data.data[5].value
-        assert 40016 == data.data[6].coil_address
+        assert data.data[4].value == b"\xc4\x01"
+        assert data.data[5].coil_address == 40015
+        assert data.data[5].value == b"\x5c\x00"
+        assert data.data[6].coil_address == 40016
 
-        assert 44270 == data.data[19].coil_address
-        assert b"\xc8\x00" == data.data[19].value
+        assert data.data[19].coil_address == 44270
+        assert data.data[19].value == b"\xc8\x00"
 
     def test_parse_multiple_heavily_escaped_value(self):
         data = self._parse_hexlified_raw_message(

--- a/tests/test_coil.py
+++ b/tests/test_coil.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from construct import Int8ul
+import pytest
 
 from nibe.coil import Coil
 from nibe.exceptions import DecodeException, EncodeException
@@ -9,19 +10,19 @@ from nibe.parsers import swapwords
 
 class TestWordSwap(TestCase):
     def test_swapwords(self):
-        self.assertEqual(swapwords(b"abcd"), b"cdab")
-        self.assertEqual(swapwords(b"ab"), b"ab")
+        assert swapwords(b"abcd") == b"cdab"
+        assert swapwords(b"ab") == b"ab"
 
 
 class TestCoil(TestCase):
     def test_create(self):
         coil = Coil(123, "test_name", "test_title", "u8", unknown="some other")
 
-        self.assertEqual(coil.address, 123)
-        self.assertEqual(coil.name, "test_name")
-        self.assertEqual(coil.title, "test_title")
-        self.assertEqual(coil.parser, Int8ul)
-        self.assertEqual(coil.other["unknown"], "some other")
+        assert coil.address == 123
+        assert coil.name == "test_name"
+        assert coil.title == "test_title"
+        assert coil.parser == Int8ul
+        assert coil.other["unknown"] == "some other"
 
 
 class TestCoilSigned8(TestCase):
@@ -30,27 +31,27 @@ class TestCoilSigned8(TestCase):
 
     def test_decode(self):
         self.coil.raw_value = b"\xfc\x00\x00\x00"
-        self.assertEqual(-4, self.coil.value)
+        assert self.coil.value == -4
         self.coil.raw_value = b"\xfc\x00"
-        self.assertEqual(-4, self.coil.value)
+        assert self.coil.value == -4
         self.coil.raw_value = b"\xfc"
-        self.assertEqual(-4, self.coil.value)
+        assert self.coil.value == -4
 
     def test_decode_unavailable(self):
         self.coil.raw_value = b"\x80"
-        self.assertEqual(None, self.coil.value)
+        assert self.coil.value is None
 
     def test_encode(self):
         self.coil.value = -4
-        self.assertEqual(b"\xfc\x00\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"\xfc\x00\x00\x00"
 
-        with self.assertRaises(EncodeException):
+        with pytest.raises(EncodeException):
             self.coil.value = 256
             _ = self.coil.raw_value
 
     def test_encode_unavailable(self):
         self.coil.value = None
-        with self.assertRaises(EncodeException):
+        with pytest.raises(EncodeException):
             self.coil.raw_value
 
 
@@ -60,25 +61,25 @@ class TestCoilUnsigned8(TestCase):
 
     def test_decode(self):
         self.coil.raw_value = b"\x01\x00\x00\x00"
-        self.assertEqual(1, self.coil.value)
+        assert self.coil.value == 1
         self.coil.raw_value = b"\x01\x00"
-        self.assertEqual(1, self.coil.value)
+        assert self.coil.value == 1
         self.coil.raw_value = b"\x01"
-        self.assertEqual(1, self.coil.value)
+        assert self.coil.value == 1
 
     def test_decode_unavailable(self):
         self.coil.raw_value = b"\xff"
-        self.assertEqual(None, self.coil.value)
+        assert self.coil.value is None
         self.coil.raw_value = b"\xff\xff"
-        self.assertEqual(None, self.coil.value)
+        assert self.coil.value is None
 
     def test_encode(self):
         self.coil.value = 1
-        self.assertEqual(b"\x01\x00\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"\x01\x00\x00\x00"
         self.coil.value = 255
-        self.assertEqual(b"\xff\x00\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"\xff\x00\x00\x00"
 
-        with self.assertRaises(EncodeException):
+        with pytest.raises(EncodeException):
             self.coil.value = 256
             _ = self.coil.raw_value
 
@@ -89,25 +90,25 @@ class TestCoilUnsigned8WordSwap(TestCase):
 
     def test_decode(self):
         self.coil.raw_value = b"\x01\x00\x00\x00"
-        self.assertEqual(1, self.coil.value)
+        assert self.coil.value == 1
         self.coil.raw_value = b"\x01\x00"
-        self.assertEqual(1, self.coil.value)
+        assert self.coil.value == 1
         self.coil.raw_value = b"\x01"
-        self.assertEqual(1, self.coil.value)
+        assert self.coil.value == 1
 
     def test_decode_unavailable(self):
         self.coil.raw_value = b"\xff"
-        self.assertEqual(None, self.coil.value)
+        assert self.coil.value is None
         self.coil.raw_value = b"\xff\xff"
-        self.assertEqual(None, self.coil.value)
+        assert self.coil.value is None
 
     def test_encode(self):
         self.coil.value = 1
-        self.assertEqual(b"\x01\x00\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"\x01\x00\x00\x00"
         self.coil.value = 255
-        self.assertEqual(b"\xff\x00\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"\xff\x00\x00\x00"
 
-        with self.assertRaises(EncodeException):
+        with pytest.raises(EncodeException):
             self.coil.value = 256
             _ = self.coil.raw_value
 
@@ -117,48 +118,48 @@ class TestCoilSigned16(TestCase):
         self.coil = Coil(123, "test", "test", "s16", factor=10, min=50, max=300)
 
     def test_attributes(self):
-        self.assertEqual(5.0, self.coil.min)
-        self.assertEqual(30.0, self.coil.max)
+        assert self.coil.min == 5.0
+        assert self.coil.max == 30.0
 
-        self.assertEqual(50, self.coil.raw_min)
-        self.assertEqual(300, self.coil.raw_max)
+        assert self.coil.raw_min == 50
+        assert self.coil.raw_max == 300
 
-        self.assertFalse(self.coil.is_boolean)
-        self.assertFalse(self.coil.is_writable)
+        assert not self.coil.is_boolean
+        assert not self.coil.is_writable
 
     def test_set_value_bounds(self):
         self.coil.value = 5.0
         self.coil.value = 30
 
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.coil.value = 4.9
 
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.coil.value = 30.1
 
     def test_decode(self):
         self.coil.raw_value = b"\x97\x00"
 
     def test_decode_out_of_bounds(self):
-        with self.assertRaises(DecodeException):
+        with pytest.raises(DecodeException):
             self.coil.raw_value = b"\x31\x00"
 
-        with self.assertRaises(DecodeException):
+        with pytest.raises(DecodeException):
             self.coil.raw_value = b"\x2d\x10"
 
     def test_decode_unavailable(self):
         self.coil.raw_value = b"\x00\x80"
-        self.assertEqual(None, self.coil.value)
+        assert self.coil.value is None
 
     def test_encode(self):
         self.coil.value = 15.1
-        self.assertEqual(b"\x97\x00\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"\x97\x00\x00\x00"
 
     def test_encode_out_of_bounds(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.coil.value = 4
 
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.coil.value = 30.1
 
 
@@ -174,19 +175,19 @@ class TestCoilUnsigned16(TestCase):
 
     def test_decode(self):
         self.coil.raw_value = b"\x01\x00\x00\x00"
-        self.assertEqual(0.1, self.coil.value)
+        assert self.coil.value == 0.1
         self.coil.raw_value = b"\x01\x00"
-        self.assertEqual(0.1, self.coil.value)
+        assert self.coil.value == 0.1
 
     def test_decode_unavailable(self):
         self.coil.raw_value = b"\xff\xff"
-        self.assertEqual(None, self.coil.value)
+        assert self.coil.value is None
 
     def test_encode(self):
         self.coil.value = 0.1
-        self.assertEqual(b"\x01\x00\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"\x01\x00\x00\x00"
         self.coil.value = 25.5
-        self.assertEqual(b"\xff\x00\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"\xff\x00\x00\x00"
 
 
 class TestCoilUnsigned16WordSwap(TestCase):
@@ -202,19 +203,19 @@ class TestCoilUnsigned16WordSwap(TestCase):
 
     def test_decode(self):
         self.coil.raw_value = b"\x01\x00\x00\x00"
-        self.assertEqual(0.1, self.coil.value)
+        assert self.coil.value == 0.1
         self.coil.raw_value = b"\x01\x00"
-        self.assertEqual(0.1, self.coil.value)
+        assert self.coil.value == 0.1
 
     def test_decode_unavailable(self):
         self.coil.raw_value = b"\xff\xff"
-        self.assertEqual(None, self.coil.value)
+        assert self.coil.value is None
 
     def test_encode(self):
         self.coil.value = 0.1
-        self.assertEqual(b"\x01\x00\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"\x01\x00\x00\x00"
         self.coil.value = 25.5
-        self.assertEqual(b"\xff\x00\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"\xff\x00\x00\x00"
 
 
 class TestCoilSigned32(TestCase):
@@ -228,15 +229,15 @@ class TestCoilSigned32(TestCase):
 
     def test_decode(self):
         self.coil.raw_value = b"2T\x00\x00"
-        self.assertEqual(21554, self.coil.value)
+        assert self.coil.value == 21554
 
     def test_decode_unavailable(self):
         self.coil.raw_value = b"\x00\x00\x00\x80"
-        self.assertEqual(None, self.coil.value)
+        assert self.coil.value is None
 
     def test_encode(self):
         self.coil.value = 21554
-        self.assertEqual(b"2T\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"2T\x00\x00"
 
 
 class TestCoilSigned32WordSwap(TestCase):
@@ -251,15 +252,15 @@ class TestCoilSigned32WordSwap(TestCase):
 
     def test_decode(self):
         self.coil.raw_value = b"\x00\x00(\x06"
-        self.assertEqual(1576, self.coil.value)
+        assert self.coil.value == 1576
 
     def test_decode_unavailable(self):
         self.coil.raw_value = b"\x00\x80\x00\x00"
-        self.assertEqual(None, self.coil.value)
+        assert self.coil.value is None
 
     def test_encode(self):
         self.coil.value = 1576
-        self.assertEqual(b"\x00\x00(\x06", self.coil.raw_value)
+        assert self.coil.raw_value == b"\x00\x00(\x06"
 
 
 class TestCoilWithMapping(TestCase):
@@ -284,30 +285,30 @@ class TestCoilWithMapping(TestCase):
     def test_set_valid_value(self):
         self.coil.value = "off"
 
-        self.assertEqual("OFF", self.coil.value)
+        assert self.coil.value == "OFF"
 
     def test_set_invalid_value(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.coil.value = "Beer"
 
     def test_decode_mapping(self):
         self.coil.raw_value = b"\x0a"
-        self.assertEqual("OFF", self.coil.value)
+        assert self.coil.value == "OFF"
 
     def test_decode_unavailable(self):
         self.coil.raw_value = b"\xff\xff"
-        self.assertEqual(None, self.coil.value)
+        assert self.coil.value is None
 
     def test_encode_mapping(self):
         self.coil.value = "off"
-        self.assertEqual(b"\x0a\x00\x00\x00", self.coil.raw_value)
+        assert self.coil.raw_value == b"\x0a\x00\x00\x00"
 
     def test_decode_mapping_failure(self):
-        with self.assertRaises(DecodeException):
+        with pytest.raises(DecodeException):
             self.coil.raw_value = b"\x00"
 
     def test_encode_mapping_failure(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.coil.value = "Unknown"
 
 
@@ -323,14 +324,14 @@ class TestBooleanCoilWithMapping(TestCase):
         )
 
     def test_attributes(self):
-        self.assertTrue(self.coil.is_boolean)
+        assert self.coil.is_boolean
 
     def test_set_valid_value(self):
         self.coil.value = "On"
-        assert self.coil.value == "ON"
+        assert "ON" == self.coil.value
 
         self.coil.value = "ofF"
-        assert self.coil.value == "OFF"
+        assert "OFF" == self.coil.value
 
 
 class TestBooleanCoilWithBounds(TestCase):
@@ -347,7 +348,7 @@ class TestBooleanCoilWithBounds(TestCase):
         )
 
     def test_attributes(self):
-        self.assertTrue(self.coil.is_boolean)
+        assert self.coil.is_boolean
 
     def test_set_valid_value(self):
         self.coil.value = "ON"

--- a/tests/test_heatpump.py
+++ b/tests/test_heatpump.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import Mock
 
+import pytest
+
 from nibe.exceptions import CoilNotFoundException, ModelIdentificationFailed
 from nibe.heatpump import HeatPump, Model, ProductInfo
 
@@ -10,11 +12,11 @@ class HeatpumpTestCase(unittest.TestCase):
         self.heat_pump = HeatPump(Model.F1255)
         self.heat_pump.initialize()
 
-        self.assertGreater(len(self.heat_pump._address_to_coil), 100)
+        assert len(self.heat_pump._address_to_coil) > 100
 
     def test_get_coils(self):
         coils = self.heat_pump.get_coils()
-        self.assertIsInstance(coils, list)
+        assert isinstance(coils, list)
 
     def test_get_coil_by_returns_same(self):
         coil_address = 40004
@@ -22,19 +24,19 @@ class HeatpumpTestCase(unittest.TestCase):
         a = self.heat_pump.get_coil_by_address(coil_address)
         b = self.heat_pump.get_coil_by_address(str(coil_address))
 
-        self.assertEqual(coil_address, a.address)
+        assert coil_address == a.address
 
-        self.assertIs(a, b)
+        assert a is b
 
         c = self.heat_pump.get_coil_by_name("bt1-outdoor-temperature-40004")
 
-        self.assertIs(a, c)
+        assert a is c
 
     def test_get_missing_coil_raises_exception(self):
-        with self.assertRaises(CoilNotFoundException):
+        with pytest.raises(CoilNotFoundException):
             self.heat_pump.get_coil_by_address(0xFFFF)
 
-        with self.assertRaises(CoilNotFoundException):
+        with pytest.raises(CoilNotFoundException):
             self.heat_pump.get_coil_by_name("no-beer-today")
 
     def test_listener(self):
@@ -60,7 +62,7 @@ class HeatpumpTestCase(unittest.TestCase):
     def test_word_swap_is_true(self):
         coil = self.heat_pump.get_coil_by_address(43420)
         coil.raw_value = b"(\x06\x00\x00"
-        self.assertEqual(1576, coil.value)
+        assert 1576 == coil.value
 
 
 class HeatpumpWordSwapTestCase(unittest.TestCase):
@@ -72,7 +74,7 @@ class HeatpumpWordSwapTestCase(unittest.TestCase):
     def test_word_swap_is_false(self):
         coil = self.heat_pump.get_coil_by_address(43420)
         coil.raw_value = b"\x00\x00(\x06"
-        self.assertEqual(1576, coil.value)
+        assert 1576 == coil.value
 
 
 class HeatpumpIntialization(unittest.TestCase):
@@ -90,7 +92,7 @@ class HeatpumpIntialization(unittest.TestCase):
         self.heat_pump.get_coil_by_address(43420)
 
     def test_initalization_failed(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.heat_pump.initialize()
 
 
@@ -107,7 +109,7 @@ class ProductInfoTestCase(unittest.TestCase):
     def test_identify_model_error(self):
         product_info = ProductInfo("Tehowatti Air", 0)
 
-        with self.assertRaises(ModelIdentificationFailed):
+        with pytest.raises(ModelIdentificationFailed):
             product_info.identify_model()
 
 

--- a/tests/test_heatpump.py
+++ b/tests/test_heatpump.py
@@ -62,7 +62,7 @@ class HeatpumpTestCase(unittest.TestCase):
     def test_word_swap_is_true(self):
         coil = self.heat_pump.get_coil_by_address(43420)
         coil.raw_value = b"(\x06\x00\x00"
-        assert 1576 == coil.value
+        assert coil.value == 1576
 
 
 class HeatpumpWordSwapTestCase(unittest.TestCase):
@@ -74,7 +74,7 @@ class HeatpumpWordSwapTestCase(unittest.TestCase):
     def test_word_swap_is_false(self):
         coil = self.heat_pump.get_coil_by_address(43420)
         coil.raw_value = b"\x00\x00(\x06"
-        assert 1576 == coil.value
+        assert coil.value == 1576
 
 
 class HeatpumpIntialization(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,5 @@ skip_missing_interpreters = True
 
 [testenv]
 changedir = tests
-commands = python -m unittest
+deps = pytest
+commands = pytest --basetemp="{envtmpdir}"  {posargs}


### PR DESCRIPTION
Switch to using py.test instead of plain unittest. Old style class base tests remain, but execution allows individual test steps to be tested and stdout/logging to be captured.