### PR TITLE
RFC: Allow batching coils in api request

### DIFF
--- a/nibe/connection/__init__.py
+++ b/nibe/connection/__init__.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import AsyncGenerator, Iterable
 
 from nibe.coil import Coil
 from nibe.heatpump import ProductInfo
@@ -17,6 +18,12 @@ class Connection(ABC):
     @abstractmethod
     async def read_coil(self, coil: Coil, timeout: float = DEFAULT_TIMEOUT) -> Coil:
         pass
+
+    async def read_coils(
+        self, coils: Iterable[Coil], timeout: float = DEFAULT_TIMEOUT
+    ) -> AsyncGenerator[Coil]:
+        for coil in coils:
+            yield await self.read_coil(coil, timeout)
 
     @abstractmethod
     async def write_coil(self, coil: Coil, timeout: float = DEFAULT_TIMEOUT) -> Coil:

--- a/nibe/connection/__init__.py
+++ b/nibe/connection/__init__.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import AsyncGenerator, Iterable
+from collections.abc import AsyncIterator, Iterable
 
 from nibe.coil import Coil
 from nibe.heatpump import ProductInfo
@@ -21,7 +21,7 @@ class Connection(ABC):
 
     async def read_coils(
         self, coils: Iterable[Coil], timeout: float = DEFAULT_TIMEOUT
-    ) -> AsyncGenerator[Coil]:
+    ) -> AsyncIterator[Coil]:
         for coil in coils:
             yield await self.read_coil(coil, timeout)
 


### PR DESCRIPTION
I was pondering how at some point in the future we could handle uplink api allowing requests of multiple coils at a time. This might be a idea. Would allow us to use it like:

```python
async for coil in x.read_coils([coil1, coil2]):
   handle_coil(coil)
```

or even:

```python

def give_me_coils():
  if required(coil1):
    yield coil1
  yield coil2
  yield coil3

async for coil in x.read_coils(give_me_coils()):
   handle_coil(coil)
```


Then the backend can do something like batching up coils and request at the same time. One issue here is timeout/retry handling. I see that it's quite common to loose UDP packets, and thus either requests or responses so the nibegw backend do need retries on the read. At the moment we do this in HA, we might need to move that to backend lib instead if we want to do something like above.

Thoughts?
