### PR TITLE
Move retry logic into library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage.xml
 /dist
 /nibe.egg-info
 /.tox
+/build

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -44,6 +44,7 @@ from construct import (
     Union as UnionConstruct,
     this,
 )
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
 
 from nibe.coil import Coil
 from nibe.connection import DEFAULT_TIMEOUT, READ_PRODUCT_INFO_TIMEOUT, Connection
@@ -87,6 +88,8 @@ class NibeGW(asyncio.DatagramProtocol, Connection, EventServer):
         remote_write_port: int = 10000,
         listening_ip: str = "0.0.0.0",
         listening_port: int = 9999,
+        read_retries: int = 3,
+        write_retries: int = 3,
     ) -> None:
         super().__init__()
 
@@ -103,6 +106,18 @@ class NibeGW(asyncio.DatagramProtocol, Connection, EventServer):
 
         self._send_lock = asyncio.Lock()
         self._futures = {}
+
+        self.read_coil = retry(
+            retry=retry_if_exception_type(CoilReadException),
+            stop=stop_after_attempt(read_retries),
+            reraise=True,
+        )(self.read_coil)
+
+        self.write_coil = retry(
+            retry=retry_if_exception_type(CoilWriteException),
+            stop=stop_after_attempt(write_retries),
+            reraise=True,
+        )(self.write_coil)
 
     async def start(self):
         logger.info(f"Starting UDP server on port {self._listening_port}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     construct >= 2.10.0, < 3.0.0
     async_modbus >= 0.2.0
     async_timeout >= 4.0.0
+    tenacity >= 8.0.0
 
 [options.package_data]
 * = *.json, *.md


### PR DESCRIPTION
Put the retry logic need for nibegw in library instead of client. This removes the need for:
- https://github.com/home-assistant/core/blob/cc13641f29385d58c425ca4afa10f5623c484dab/homeassistant/components/nibe_heatpump/__init__.py#L222
- https://github.com/yozik04/nibe-mqtt/blob/aa83e4760921e2603c340a8e312824ef358a2197/nibe_mqtt/service.py#L90
