### PR TITLE
Update smos40, add S320, adjust number offset

### DIFF
--- a/nibe/console_scripts/convert_csv.py
+++ b/nibe/console_scripts/convert_csv.py
@@ -193,15 +193,15 @@ class CSVConverter:
     def _update_index(self):
         def calculate_number(row):
             register_type: str = row["register type"]
-            register: str = row["register"]
+            location = 1 + int(row["register"])
             if register_type == "MODBUS_COIL":
-                return str(int(register))
+                return str(int(location))
             if register_type == "MODBUS_DISCRETE_INPUT":
-                return str(10000 + int(register))
+                return str(10000 + int(location))
             if register_type == "MODBUS_INPUT_REGISTER":
-                return str(30000 + int(register))
+                return str(30000 + int(location))
             if register_type == "MODBUS_HOLDING_REGISTER":
-                return str(40000 + int(register))
+                return str(40000 + int(location))
             return None
 
         if "register type" in self.data:

--- a/nibe/data/s1155_s1255.json
+++ b/nibe/data/s1155_s1255.json
@@ -1,503 +1,497 @@
 {
-  "30001": {
+  "30002": {
     "title": "Current outdoor temperature (BT1)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "current-outdoor-temperature-bt1-30001"
+    "name": "current-outdoor-temperature-bt1-30002"
   },
-  "30002": {
+  "30003": {
     "title": "Supply line (EP23-BT2)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "supply-line-ep23-bt2-30002"
+    "name": "supply-line-ep23-bt2-30003"
   },
-  "30003": {
+  "30004": {
     "title": "Supply line (EP22-BT2)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "supply-line-ep22-bt2-30003"
+    "name": "supply-line-ep22-bt2-30004"
   },
-  "30004": {
+  "30005": {
     "title": "Supply line (EP21-BT2)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "supply-line-ep21-bt2-30004"
+    "name": "supply-line-ep21-bt2-30005"
   },
-  "30005": {
+  "30006": {
     "title": "Supply line (BT2)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "supply-line-bt2-30005"
+    "name": "supply-line-bt2-30006"
   },
-  "30007": {
+  "30008": {
     "title": "Return line (BT3)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-bt3-30007"
+    "name": "return-line-bt3-30008"
   },
-  "30008": {
+  "30009": {
     "title": "Hot water top (BT7)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hot-water-top-bt7-30008"
+    "name": "hot-water-top-bt7-30009"
   },
-  "30009": {
+  "30010": {
     "title": "Hot water charging (BT6)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hot-water-charging-bt6-30009"
+    "name": "hot-water-charging-bt6-30010"
   },
-  "30010": {
+  "30011": {
     "title": "Brine in (BT10)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "brine-in-bt10-30010"
+    "name": "brine-in-bt10-30011"
   },
-  "30011": {
+  "30012": {
     "title": "Brine out (BT11)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "brine-out-bt11-30011"
+    "name": "brine-out-bt11-30012"
   },
-  "30012": {
+  "30013": {
     "title": "Condenser (BT12)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "condenser-bt12-30012"
+    "name": "condenser-bt12-30013"
   },
-  "30013": {
+  "30014": {
     "title": "Discharge (BT14)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "discharge-bt14-30013"
+    "name": "discharge-bt14-30014"
   },
-  "30014": {
+  "30015": {
     "title": "Liquid line (BT15)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "liquid-line-bt15-30014"
+    "name": "liquid-line-bt15-30015"
   },
-  "30016": {
+  "30017": {
     "title": "Suction gas (BT17)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "suction-gas-bt17-30016"
+    "name": "suction-gas-bt17-30017"
   },
-  "30021": {
+  "30022": {
     "title": "Collector in (AZ10-BT26)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "collector-in-az10-bt26-30021"
+    "name": "collector-in-az10-bt26-30022"
   },
-  "30022": {
+  "30023": {
     "title": "Collector out (AZ10-BT27)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "collector-out-az10-bt27-30022"
+    "name": "collector-out-az10-bt27-30023"
   },
-  "30026": {
+  "30027": {
     "title": "Roomsensor 1-1",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "roomsensor-1-1-30026"
+    "name": "roomsensor-1-1-30027"
   },
-  "30031": {
+  "30032": {
     "title": "Return line (EQ1-BT65)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-eq1-bt65-30031"
+    "name": "return-line-eq1-bt65-30032"
   },
-  "30036": {
+  "30037": {
     "title": "Temperature limiter (EB100-FD1)",
     "factor": 1,
     "size": "s16",
-    "name": "temperature-limiter-eb100-fd1-30036"
+    "name": "temperature-limiter-eb100-fd1-30037"
   },
-  "30037": {
+  "30038": {
     "title": "Average temperature (BT1)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "average-temperature-bt1-30037"
+    "name": "average-temperature-bt1-30038"
   },
-  "30038": {
+  "30039": {
     "title": "Boiler temperature (BT52)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "boiler-temperature-bt52-30038"
+    "name": "boiler-temperature-bt52-30039"
   },
-  "30040": {
+  "30041": {
     "title": "Flow sensor (BF1)",
     "factor": 10,
     "unit": "l/m",
     "size": "s16",
-    "name": "flow-sensor-bf1-30040"
+    "name": "flow-sensor-bf1-30041"
   },
-  "30041": {
+  "30042": {
     "title": "Electrical anode (EB100-FR1)",
     "factor": 1,
     "size": "s16",
-    "name": "electrical-anode-eb100-fr1-30041"
+    "name": "electrical-anode-eb100-fr1-30042"
   },
-  "30046": {
+  "30047": {
     "title": "Current (BE3)",
     "factor": 10,
     "unit": "A",
     "size": "u32",
-    "name": "current-be3-30046"
+    "name": "current-be3-30047"
   },
-  "30048": {
+  "30049": {
     "title": "Current (BE2)",
     "factor": 10,
     "unit": "A",
     "size": "u32",
-    "name": "current-be2-30048"
+    "name": "current-be2-30049"
   },
-  "30050": {
+  "30051": {
     "title": "Current (BE1)",
     "factor": 10,
     "unit": "A",
     "size": "u32",
-    "name": "current-be1-30050"
+    "name": "current-be1-30051"
   },
-  "30059": {
+  "30060": {
     "title": "Pool (CL12-BT51)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "pool-cl12-bt51-30059"
+    "name": "pool-cl12-bt51-30060"
   },
-  "30066": {
+  "30067": {
     "title": "Collector in (AZ13-BT26)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "collector-in-az13-bt26-30066"
+    "name": "collector-in-az13-bt26-30067"
   },
-  "30067": {
+  "30068": {
     "title": "Collector in (AZ12-BT26)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "collector-in-az12-bt26-30067"
+    "name": "collector-in-az12-bt26-30068"
   },
-  "30068": {
+  "30069": {
     "title": "Collector in (AZ11-BT26)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "collector-in-az11-bt26-30068"
+    "name": "collector-in-az11-bt26-30069"
   },
-  "30069": {
+  "30070": {
     "title": "Collector out (AZ13-BT27)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "collector-out-az13-bt27-30069"
+    "name": "collector-out-az13-bt27-30070"
   },
-  "30070": {
+  "30071": {
     "title": "Collector out (AZ12-BT27)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "collector-out-az12-bt27-30070"
+    "name": "collector-out-az12-bt27-30071"
   },
-  "30071": {
+  "30072": {
     "title": "Collector out (AZ11-BT27)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "collector-out-az11-bt27-30071"
+    "name": "collector-out-az11-bt27-30072"
   },
-  "30075": {
+  "30076": {
     "title": "Return line (EP23-BT3)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-ep23-bt3-30075"
+    "name": "return-line-ep23-bt3-30076"
   },
-  "30076": {
+  "30077": {
     "title": "Return line (EP22-BT3)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-ep22-bt3-30076"
+    "name": "return-line-ep22-bt3-30077"
   },
-  "30077": {
+  "30078": {
     "title": "Return line (EP21-BT3)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-ep21-bt3-30077"
+    "name": "return-line-ep21-bt3-30078"
   },
-  "30078": {
+  "30079": {
     "title": "Return line (EP15-BT3)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-ep15-bt3-30078"
+    "name": "return-line-ep15-bt3-30079"
   },
-  "30086": {
+  "30087": {
     "title": "Oil temperature (BT29)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "oil-temperature-bt29-30086"
+    "name": "oil-temperature-bt29-30087"
   },
-  "30087": {
+  "30088": {
     "title": "Outgoing hot water (BT70)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "outgoing-hot-water-bt70-30087"
+    "name": "outgoing-hot-water-bt70-30088"
   },
-  "30090": {
+  "30091": {
     "title": "Collector (EQ1-BT57)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "collector-eq1-bt57-30090"
+    "name": "collector-eq1-bt57-30091"
   },
-  "30091": {
+  "30092": {
     "title": "Heating dump (EQ1-BT75)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "heating-dump-eq1-bt75-30091"
+    "name": "heating-dump-eq1-bt75-30092"
   },
-  "30094": {
+  "30095": {
     "title": "Supply line (EP47-BT2)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "supply-line-ep47-bt2-30094"
+    "name": "supply-line-ep47-bt2-30095"
   },
-  "30095": {
+  "30096": {
     "title": "Supply line (EP46-BT2)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "supply-line-ep46-bt2-30095"
+    "name": "supply-line-ep46-bt2-30096"
   },
-  "30096": {
+  "30097": {
     "title": "Supply line (EP45-BT2)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "supply-line-ep45-bt2-30096"
+    "name": "supply-line-ep45-bt2-30097"
   },
-  "30097": {
+  "30098": {
     "title": "Supply line (EP44-BT2)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "supply-line-ep44-bt2-30097"
+    "name": "supply-line-ep44-bt2-30098"
   },
-  "30098": {
+  "30099": {
     "title": "Return line (EP47-BT3)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-ep47-bt3-30098"
+    "name": "return-line-ep47-bt3-30099"
   },
-  "30099": {
+  "30100": {
     "title": "Return line (EP46-BT3)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-ep46-bt3-30099"
+    "name": "return-line-ep46-bt3-30100"
   },
-  "30100": {
+  "30101": {
     "title": "Return line (EP45-BT3)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-ep45-bt3-30100"
+    "name": "return-line-ep45-bt3-30101"
   },
-  "30101": {
+  "30102": {
     "title": "Return line (EP44-BT3)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-ep44-bt3-30101"
+    "name": "return-line-ep44-bt3-30102"
   },
-  "30106": {
+  "30107": {
     "title": "Brine in (EP10-BT26)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "brine-in-ep10-bt26-30106"
+    "name": "brine-in-ep10-bt26-30107"
   },
-  "30109": {
+  "30110": {
     "title": "Room average temp. clim. system 8 (BT50)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "room-average-temp-clim-system-8-bt50-30109"
+    "name": "room-average-temp-clim-system-8-bt50-30110"
   },
-  "30110": {
+  "30111": {
     "title": "Room average temp. clim. system 7 (BT50)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "room-average-temp-clim-system-7-bt50-30110"
+    "name": "room-average-temp-clim-system-7-bt50-30111"
   },
-  "30111": {
+  "30112": {
     "title": "Room average temp. clim. system 6 (BT50)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "room-average-temp-clim-system-6-bt50-30111"
+    "name": "room-average-temp-clim-system-6-bt50-30112"
   },
-  "30112": {
+  "30113": {
     "title": "Room average temp. clim. system 5 (BT50)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "room-average-temp-clim-system-5-bt50-30112"
+    "name": "room-average-temp-clim-system-5-bt50-30113"
   },
-  "30113": {
+  "30114": {
     "title": "Room average temp. clim. system 4 (BT50)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "room-average-temp-clim-system-4-bt50-30113"
+    "name": "room-average-temp-clim-system-4-bt50-30114"
   },
-  "30114": {
+  "30115": {
     "title": "Room average temp. clim. system 3 (BT50)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "room-average-temp-clim-system-3-bt50-30114"
+    "name": "room-average-temp-clim-system-3-bt50-30115"
   },
-  "30115": {
+  "30116": {
     "title": "Room average temp. clim. system 2 (BT50)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "room-average-temp-clim-system-2-bt50-30115"
+    "name": "room-average-temp-clim-system-2-bt50-30116"
   },
-  "30116": {
+  "30117": {
     "title": "Room average temp. clim. system 1 (BT50)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "room-average-temp-clim-system-1-bt50-30116"
+    "name": "room-average-temp-clim-system-1-bt50-30117"
   },
-  "30119": {
+  "30120": {
     "title": "External cooling supply temperature (BT25)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "external-cooling-supply-temperature-bt25-30119"
+    "name": "external-cooling-supply-temperature-bt25-30120"
   },
-  "30129": {
+  "30130": {
     "title": "Oper. mode shunt climate system 8",
     "factor": 1,
     "size": "u8",
-    "name": "oper-mode-shunt-climate-system-8-30129"
+    "name": "oper-mode-shunt-climate-system-8-30130"
   },
-  "30130": {
+  "30131": {
     "title": "Oper. mode shunt climate system 7",
     "factor": 1,
     "size": "u8",
-    "name": "oper-mode-shunt-climate-system-7-30130"
+    "name": "oper-mode-shunt-climate-system-7-30131"
   },
-  "30131": {
+  "30132": {
     "title": "Oper. mode shunt climate system 6",
     "factor": 1,
     "size": "u8",
-    "name": "oper-mode-shunt-climate-system-6-30131"
+    "name": "oper-mode-shunt-climate-system-6-30132"
   },
-  "30132": {
+  "30133": {
     "title": "Oper. mode shunt climate system 5",
     "factor": 1,
     "size": "u8",
-    "name": "oper-mode-shunt-climate-system-5-30132"
+    "name": "oper-mode-shunt-climate-system-5-30133"
   },
-  "30134": {
+  "30135": {
     "title": "Relay status (ERS 1)",
     "factor": 1,
     "size": "u8",
-    "name": "relay-status-ers-1-30134"
+    "name": "relay-status-ers-1-30135"
   },
-  "30135": {
+  "30136": {
     "title": "Fan speed (AZ30-GQ2)",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "fan-speed-az30-gq2-30135"
+    "name": "fan-speed-az30-gq2-30136"
   },
-  "30136": {
+  "30137": {
     "title": "Fan speed (AZ30-GQ3)",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "fan-speed-az30-gq3-30136"
+    "name": "fan-speed-az30-gq3-30137"
   },
-  "30137": {
+  "30138": {
     "title": "Current hot water mode controlled by",
     "factor": 1,
     "size": "s8",
-    "name": "current-hot-water-mode-controlled-by-30137"
+    "name": "current-hot-water-mode-controlled-by-30138"
   },
-  "30138": {
+  "30139": {
     "title": "Inverter limit status",
     "factor": 1,
     "size": "u8",
-    "name": "inverter-limit-status-30138"
+    "name": "inverter-limit-status-30139"
   },
-  "30139": {
+  "30140": {
     "title": "Inverter drive status",
     "factor": 1,
     "size": "u16",
-    "name": "inverter-drive-status-30139"
+    "name": "inverter-drive-status-30140"
   },
-  "42755": {
+  "42756": {
     "title": "Inverter fault reset",
     "factor": 1,
     "size": "u16",
-    "name": "inverter-fault-reset-42755",
+    "name": "inverter-fault-reset-42756",
     "write": true
   },
-  "30140": {
+  "30141": {
     "title": "Requested compressor frequency",
     "factor": 1,
     "unit": "Hz",
     "size": "u16",
-    "name": "requested-compressor-frequency-30140"
+    "name": "requested-compressor-frequency-30141"
   },
-  "30141": {
+  "30142": {
     "title": "Max. compressor frequency, heating",
     "factor": 100,
     "unit": "Hz",
     "size": "u16",
-    "name": "max-compressor-frequency-heating-30141"
-  },
-  "30142": {
-    "title": "Inverter alarm code",
-    "factor": 1,
-    "size": "u16",
-    "name": "inverter-alarm-code-30142"
+    "name": "max-compressor-frequency-heating-30142"
   },
   "30143": {
     "title": "Inverter alarm code",
@@ -506,137 +500,143 @@
     "name": "inverter-alarm-code-30143"
   },
   "30144": {
+    "title": "Inverter alarm code",
+    "factor": 1,
+    "size": "u16",
+    "name": "inverter-alarm-code-30144"
+  },
+  "30145": {
     "title": "Inverter run command",
     "factor": 1,
     "size": "u16",
-    "name": "inverter-run-command-30144"
+    "name": "inverter-run-command-30145"
   },
-  "30145": {
+  "30146": {
     "title": "Inverter pic. version",
     "factor": 1,
     "size": "u16",
-    "name": "inverter-pic-version-30145"
+    "name": "inverter-pic-version-30146"
   },
-  "30146": {
+  "30147": {
     "title": "Inverter 8051 version",
     "factor": 1,
     "size": "u16",
-    "name": "inverter-8051-version-30146"
+    "name": "inverter-8051-version-30147"
   },
-  "30147": {
+  "30148": {
     "title": "Inverter wizard",
     "factor": 1,
     "size": "u16",
-    "name": "inverter-wizard-30147"
+    "name": "inverter-wizard-30148"
   },
-  "30148": {
+  "30149": {
     "title": "Inverter version (MCE)",
     "factor": 1,
     "size": "u16",
-    "name": "inverter-version-mce-30148"
+    "name": "inverter-version-mce-30149"
   },
-  "30149": {
+  "30150": {
     "title": "Inverter hw version",
     "factor": 1,
     "size": "u16",
-    "name": "inverter-hw-version-30149"
+    "name": "inverter-hw-version-30150"
   },
-  "30150": {
+  "30151": {
     "title": "Inverter hw type",
     "factor": 1,
     "size": "u16",
-    "name": "inverter-hw-type-30150"
+    "name": "inverter-hw-type-30151"
   },
-  "30151": {
+  "30152": {
     "title": "External adjustment climate system 8",
     "factor": 1,
     "size": "u8",
-    "name": "external-adjustment-climate-system-8-30151"
+    "name": "external-adjustment-climate-system-8-30152"
   },
-  "30152": {
+  "30153": {
     "title": "External adjustment climate system 7",
     "factor": 1,
     "size": "u8",
-    "name": "external-adjustment-climate-system-7-30152"
+    "name": "external-adjustment-climate-system-7-30153"
   },
-  "30153": {
+  "30154": {
     "title": "External adjustment climate system 6",
     "factor": 1,
     "size": "u8",
-    "name": "external-adjustment-climate-system-6-30153"
+    "name": "external-adjustment-climate-system-6-30154"
   },
-  "30154": {
+  "30155": {
     "title": "External adjustment climate system 5",
     "factor": 1,
     "size": "u8",
-    "name": "external-adjustment-climate-system-5-30154"
+    "name": "external-adjustment-climate-system-5-30155"
   },
-  "30156": {
+  "30157": {
     "title": "Climate system 8",
     "factor": 1,
     "size": "u8",
-    "name": "climate-system-8-30156"
+    "name": "climate-system-8-30157"
   },
-  "30157": {
+  "30158": {
     "title": "Climate system 7",
     "factor": 1,
     "size": "u8",
-    "name": "climate-system-7-30157"
+    "name": "climate-system-7-30158"
   },
-  "30158": {
+  "30159": {
     "title": "Climate system 6",
     "factor": 1,
     "size": "u8",
-    "name": "climate-system-6-30158"
+    "name": "climate-system-6-30159"
   },
-  "30159": {
+  "30160": {
     "title": "Climate system 5",
     "factor": 1,
     "size": "u8",
-    "name": "climate-system-5-30159"
+    "name": "climate-system-5-30160"
   },
-  "30160": {
+  "30161": {
     "title": "Extra cooling",
     "factor": 1,
     "size": "u8",
-    "name": "extra-cooling-30160"
+    "name": "extra-cooling-30161"
   },
-  "30174": {
+  "30175": {
     "title": "Hot water comfort return (BT82)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hot-water-comfort-return-bt82-30174"
+    "name": "hot-water-comfort-return-bt82-30175"
   },
-  "30175": {
+  "30176": {
     "title": "Hot water comfort heater (BT83)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hot-water-comfort-heater-bt83-30175"
+    "name": "hot-water-comfort-heater-bt83-30176"
   },
-  "30177": {
+  "30178": {
     "title": "Compressor, total time cooling, heat pump 8 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-8-ep15-30177"
+    "name": "compressor-total-time-cooling-heat-pump-8-ep15-30178"
   },
-  "30179": {
+  "30180": {
     "title": "Compressor, total time pool, heat pump 8 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-8-ep15-30179"
+    "name": "compressor-total-time-pool-heat-pump-8-ep15-30180"
   },
-  "30181": {
+  "30182": {
     "title": "Compressor, total time pool 2, heat pump 8 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-8-ep15-30181"
+    "name": "compressor-total-time-pool-2-heat-pump-8-ep15-30182"
   },
-  "30183": {
+  "30184": {
     "title": "Compressor, total time cooling, heat pump 8 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -644,9 +644,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-8-ep14-30183"
+    "name": "compressor-total-time-cooling-heat-pump-8-ep14-30184"
   },
-  "30185": {
+  "30186": {
     "title": "Compressor, total time pool, heat pump 8 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -654,9 +654,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-8-ep14-30185"
+    "name": "compressor-total-time-pool-heat-pump-8-ep14-30186"
   },
-  "30187": {
+  "30188": {
     "title": "Compressor, total time pool 2, heat pump 8 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -664,30 +664,30 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-8-ep14-30187"
+    "name": "compressor-total-time-pool-2-heat-pump-8-ep14-30188"
   },
-  "30189": {
+  "30190": {
     "title": "Compressor, total time cooling, heat pump 7 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-7-ep15-30189"
+    "name": "compressor-total-time-cooling-heat-pump-7-ep15-30190"
   },
-  "30191": {
+  "30192": {
     "title": "Compressor, total time pool, heat pump 7 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-7-ep15-30191"
+    "name": "compressor-total-time-pool-heat-pump-7-ep15-30192"
   },
-  "30193": {
+  "30194": {
     "title": "Compressor, total time pool 2, heat pump 7 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-7-ep15-30193"
+    "name": "compressor-total-time-pool-2-heat-pump-7-ep15-30194"
   },
-  "30195": {
+  "30196": {
     "title": "Compressor, total time cooling, heat pump 7 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -695,9 +695,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-7-ep14-30195"
+    "name": "compressor-total-time-cooling-heat-pump-7-ep14-30196"
   },
-  "30197": {
+  "30198": {
     "title": "Compressor, total time pool, heat pump 7 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -705,9 +705,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-7-ep14-30197"
+    "name": "compressor-total-time-pool-heat-pump-7-ep14-30198"
   },
-  "30199": {
+  "30200": {
     "title": "Compressor, total time pool 2, heat pump 7 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -715,30 +715,30 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-7-ep14-30199"
+    "name": "compressor-total-time-pool-2-heat-pump-7-ep14-30200"
   },
-  "30201": {
+  "30202": {
     "title": "Compressor, total time cooling, heat pump 6 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-6-ep15-30201"
+    "name": "compressor-total-time-cooling-heat-pump-6-ep15-30202"
   },
-  "30203": {
+  "30204": {
     "title": "Compressor, total time pool, heat pump 6 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-6-ep15-30203"
+    "name": "compressor-total-time-pool-heat-pump-6-ep15-30204"
   },
-  "30205": {
+  "30206": {
     "title": "Compressor, total time pool 2, heat pump 6 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-6-ep15-30205"
+    "name": "compressor-total-time-pool-2-heat-pump-6-ep15-30206"
   },
-  "30207": {
+  "30208": {
     "title": "Compressor, total time cooling, heat pump 6 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -746,9 +746,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-6-ep14-30207"
+    "name": "compressor-total-time-cooling-heat-pump-6-ep14-30208"
   },
-  "30209": {
+  "30210": {
     "title": "Compressor, total time pool, heat pump 6 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -756,9 +756,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-6-ep14-30209"
+    "name": "compressor-total-time-pool-heat-pump-6-ep14-30210"
   },
-  "30211": {
+  "30212": {
     "title": "Compressor, total time pool 2, heat pump 6 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -766,30 +766,30 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-6-ep14-30211"
+    "name": "compressor-total-time-pool-2-heat-pump-6-ep14-30212"
   },
-  "30213": {
+  "30214": {
     "title": "Compressor, total time cooling, heat pump 5 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-5-ep15-30213"
+    "name": "compressor-total-time-cooling-heat-pump-5-ep15-30214"
   },
-  "30215": {
+  "30216": {
     "title": "Compressor, total time pool, heat pump 5 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-5-ep15-30215"
+    "name": "compressor-total-time-pool-heat-pump-5-ep15-30216"
   },
-  "30217": {
+  "30218": {
     "title": "Compressor, total time pool 2, heat pump 5 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-5-ep15-30217"
+    "name": "compressor-total-time-pool-2-heat-pump-5-ep15-30218"
   },
-  "30219": {
+  "30220": {
     "title": "Compressor, total time cooling, heat pump 5 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -797,9 +797,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-5-ep14-30219"
+    "name": "compressor-total-time-cooling-heat-pump-5-ep14-30220"
   },
-  "30221": {
+  "30222": {
     "title": "Compressor, total time pool, heat pump 5 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -807,9 +807,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-5-ep14-30221"
+    "name": "compressor-total-time-pool-heat-pump-5-ep14-30222"
   },
-  "30223": {
+  "30224": {
     "title": "Compressor, total time pool 2, heat pump 5 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -817,30 +817,30 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-5-ep14-30223"
+    "name": "compressor-total-time-pool-2-heat-pump-5-ep14-30224"
   },
-  "30225": {
+  "30226": {
     "title": "Compressor, total time cooling, heat pump 4 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-4-ep15-30225"
+    "name": "compressor-total-time-cooling-heat-pump-4-ep15-30226"
   },
-  "30227": {
+  "30228": {
     "title": "Compressor, total time pool, heat pump 4 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-4-ep15-30227"
+    "name": "compressor-total-time-pool-heat-pump-4-ep15-30228"
   },
-  "30229": {
+  "30230": {
     "title": "Compressor, total time pool 2, heat pump 4 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-4-ep15-30229"
+    "name": "compressor-total-time-pool-2-heat-pump-4-ep15-30230"
   },
-  "30231": {
+  "30232": {
     "title": "Compressor, total time cooling, heat pump 4 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -848,9 +848,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-4-ep14-30231"
+    "name": "compressor-total-time-cooling-heat-pump-4-ep14-30232"
   },
-  "30233": {
+  "30234": {
     "title": "Compressor, total time pool, heat pump 4 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -858,9 +858,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-4-ep14-30233"
+    "name": "compressor-total-time-pool-heat-pump-4-ep14-30234"
   },
-  "30235": {
+  "30236": {
     "title": "Compressor, total time pool 2, heat pump 4 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -868,30 +868,30 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-4-ep14-30235"
+    "name": "compressor-total-time-pool-2-heat-pump-4-ep14-30236"
   },
-  "30237": {
+  "30238": {
     "title": "Compressor, total time cooling, heat pump 3 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-3-ep15-30237"
+    "name": "compressor-total-time-cooling-heat-pump-3-ep15-30238"
   },
-  "30239": {
+  "30240": {
     "title": "Compressor, total time pool, heat pump 3 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-3-ep15-30239"
+    "name": "compressor-total-time-pool-heat-pump-3-ep15-30240"
   },
-  "30241": {
+  "30242": {
     "title": "Compressor, total time pool 2, heat pump 3 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-3-ep15-30241"
+    "name": "compressor-total-time-pool-2-heat-pump-3-ep15-30242"
   },
-  "30243": {
+  "30244": {
     "title": "Compressor, total time cooling, heat pump 3 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -899,9 +899,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-3-ep14-30243"
+    "name": "compressor-total-time-cooling-heat-pump-3-ep14-30244"
   },
-  "30245": {
+  "30246": {
     "title": "Compressor, total time pool, heat pump 3 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -909,9 +909,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-3-ep14-30245"
+    "name": "compressor-total-time-pool-heat-pump-3-ep14-30246"
   },
-  "30247": {
+  "30248": {
     "title": "Compressor, total time pool 2, heat pump 3 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -919,30 +919,30 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-3-ep14-30247"
+    "name": "compressor-total-time-pool-2-heat-pump-3-ep14-30248"
   },
-  "30249": {
+  "30250": {
     "title": "Compressor, total time cooling, heat pump 2 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-2-ep15-30249"
+    "name": "compressor-total-time-cooling-heat-pump-2-ep15-30250"
   },
-  "30251": {
+  "30252": {
     "title": "Compressor, total time pool, heat pump 2 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-2-ep15-30251"
+    "name": "compressor-total-time-pool-heat-pump-2-ep15-30252"
   },
-  "30253": {
+  "30254": {
     "title": "Compressor, total time pool 2, heat pump 2 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-2-ep15-30253"
+    "name": "compressor-total-time-pool-2-heat-pump-2-ep15-30254"
   },
-  "30255": {
+  "30256": {
     "title": "Compressor, total time cooling, heat pump 2 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -950,9 +950,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-2-ep14-30255"
+    "name": "compressor-total-time-cooling-heat-pump-2-ep14-30256"
   },
-  "30257": {
+  "30258": {
     "title": "Compressor, total time pool, heat pump 2 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -960,9 +960,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-2-ep14-30257"
+    "name": "compressor-total-time-pool-heat-pump-2-ep14-30258"
   },
-  "30259": {
+  "30260": {
     "title": "Compressor, total time pool 2, heat pump 2 (EP14)",
     "factor": 1,
     "unit": "h",
@@ -970,30 +970,30 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-2-ep14-30259"
+    "name": "compressor-total-time-pool-2-heat-pump-2-ep14-30260"
   },
-  "30261": {
+  "30262": {
     "title": "Compressor, total time cooling, heat pump 1 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-1-ep15-30261"
+    "name": "compressor-total-time-cooling-heat-pump-1-ep15-30262"
   },
-  "30263": {
+  "30264": {
     "title": "Compressor, total time pool, heat pump 1 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-1-ep15-30263"
+    "name": "compressor-total-time-pool-heat-pump-1-ep15-30264"
   },
-  "30265": {
+  "30266": {
     "title": "Compressor, total time pool 2, heat pump 1 (EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-1-ep15-30265"
+    "name": "compressor-total-time-pool-2-heat-pump-1-ep15-30266"
   },
-  "30279": {
+  "30280": {
     "title": "Compressor, total time cooling, main unit (EP14)",
     "factor": 1,
     "unit": "h",
@@ -1001,9 +1001,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-cooling-main-unit-ep14-30279"
+    "name": "compressor-total-time-cooling-main-unit-ep14-30280"
   },
-  "30281": {
+  "30282": {
     "title": "Compressor, total time pool, main unit (EP14)",
     "factor": 1,
     "unit": "h",
@@ -1011,9 +1011,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-main-unit-ep14-30281"
+    "name": "compressor-total-time-pool-main-unit-ep14-30282"
   },
-  "30283": {
+  "30284": {
     "title": "Compressor, total time pool 2, main unit (EP14)",
     "factor": 1,
     "unit": "h",
@@ -1021,283 +1021,283 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-total-time-pool-2-main-unit-ep14-30283"
+    "name": "compressor-total-time-pool-2-main-unit-ep14-30284"
   },
-  "30294": {
+  "30295": {
     "title": "Heat pump 8 requested compressor frequency",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "heat-pump-8-requested-compressor-frequency-30294"
+    "name": "heat-pump-8-requested-compressor-frequency-30295"
   },
-  "30295": {
+  "30296": {
     "title": "Heat pump 7 requested compressor frequency",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "heat-pump-7-requested-compressor-frequency-30295"
+    "name": "heat-pump-7-requested-compressor-frequency-30296"
   },
-  "30296": {
+  "30297": {
     "title": "Heat pump 6 requested compressor frequency",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "heat-pump-6-requested-compressor-frequency-30296"
+    "name": "heat-pump-6-requested-compressor-frequency-30297"
   },
-  "30297": {
+  "30298": {
     "title": "Heat pump 5 requested compressor frequency",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "heat-pump-5-requested-compressor-frequency-30297"
+    "name": "heat-pump-5-requested-compressor-frequency-30298"
   },
-  "30298": {
+  "30299": {
     "title": "Heat pump 4 requested compressor frequency",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "heat-pump-4-requested-compressor-frequency-30298"
+    "name": "heat-pump-4-requested-compressor-frequency-30299"
   },
-  "30299": {
+  "30300": {
     "title": "Heat pump 3 requested compressor frequency",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "heat-pump-3-requested-compressor-frequency-30299"
+    "name": "heat-pump-3-requested-compressor-frequency-30300"
   },
-  "30300": {
+  "30301": {
     "title": "Heat pump 2 requested compressor frequency",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "heat-pump-2-requested-compressor-frequency-30300"
+    "name": "heat-pump-2-requested-compressor-frequency-30301"
   },
-  "30301": {
+  "30302": {
     "title": "Heat pump 1 requested compressor frequency",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "heat-pump-1-requested-compressor-frequency-30301"
+    "name": "heat-pump-1-requested-compressor-frequency-30302"
   },
-  "30303": {
+  "30304": {
     "title": "Frost protection heat exchanger heat pump 8",
     "factor": 1,
     "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-8-30303"
+    "name": "frost-protection-heat-exchanger-heat-pump-8-30304"
   },
-  "30304": {
+  "30305": {
     "title": "Frost protection heat exchanger heat pump 7",
     "factor": 1,
     "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-7-30304"
+    "name": "frost-protection-heat-exchanger-heat-pump-7-30305"
   },
-  "30305": {
+  "30306": {
     "title": "Frost protection heat exchanger heat pump 6",
     "factor": 1,
     "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-6-30305"
+    "name": "frost-protection-heat-exchanger-heat-pump-6-30306"
   },
-  "30306": {
+  "30307": {
     "title": "Frost protection heat exchanger heat pump 5",
     "factor": 1,
     "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-5-30306"
+    "name": "frost-protection-heat-exchanger-heat-pump-5-30307"
   },
-  "30307": {
+  "30308": {
     "title": "Frost protection heat exchanger heat pump 4",
     "factor": 1,
     "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-4-30307"
+    "name": "frost-protection-heat-exchanger-heat-pump-4-30308"
   },
-  "30308": {
+  "30309": {
     "title": "Frost protection heat exchanger heat pump 3",
     "factor": 1,
     "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-3-30308"
+    "name": "frost-protection-heat-exchanger-heat-pump-3-30309"
   },
-  "30309": {
+  "30310": {
     "title": "Frost protection heat exchanger heat pump 2",
     "factor": 1,
     "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-2-30309"
+    "name": "frost-protection-heat-exchanger-heat-pump-2-30310"
   },
-  "30311": {
+  "30312": {
     "title": "Status (OPT)",
     "factor": 1,
     "size": "u8",
-    "name": "status-opt-30311"
+    "name": "status-opt-30312"
   },
-  "30312": {
+  "30313": {
     "title": "Version (OPT)",
     "factor": 1,
     "size": "u16",
-    "name": "version-opt-30312"
+    "name": "version-opt-30313"
   },
-  "30313": {
+  "30314": {
     "title": "OPT relay, modulation level",
     "factor": 10,
     "unit": "%",
     "size": "s16",
-    "name": "opt-relay-modulation-level-30313"
+    "name": "opt-relay-modulation-level-30314"
   },
-  "30315": {
+  "30316": {
     "title": "OPT operating time",
     "factor": 1,
     "unit": "h",
     "size": "u16",
-    "name": "opt-operating-time-30315"
+    "name": "opt-operating-time-30316"
   },
-  "32021": {
+  "32022": {
     "title": "Compressor restrictions",
     "factor": 1,
     "size": "u32",
-    "name": "compressor-restrictions-32021"
+    "name": "compressor-restrictions-32022"
   },
-  "30317": {
+  "30318": {
     "title": "Available compressors heating",
     "factor": 1,
     "size": "u8",
-    "name": "available-compressors-heating-30317"
+    "name": "available-compressors-heating-30318"
   },
-  "30318": {
+  "30319": {
     "title": "Available compressors hot water",
     "factor": 1,
     "size": "u8",
-    "name": "available-compressors-hot-water-30318"
+    "name": "available-compressors-hot-water-30319"
   },
-  "30319": {
+  "30320": {
     "title": "Available compressors pool 1",
     "factor": 1,
     "size": "u8",
-    "name": "available-compressors-pool-1-30319"
+    "name": "available-compressors-pool-1-30320"
   },
-  "30320": {
+  "30321": {
     "title": "Available compressors pool 2",
     "factor": 1,
     "size": "u8",
-    "name": "available-compressors-pool-2-30320"
+    "name": "available-compressors-pool-2-30321"
   },
-  "30321": {
+  "30322": {
     "title": "Available compressors cooling",
     "factor": 1,
     "size": "u8",
-    "name": "available-compressors-cooling-30321"
+    "name": "available-compressors-cooling-30322"
   },
-  "30322": {
+  "30323": {
     "title": "Available compressors external control",
     "factor": 1,
     "size": "u8",
-    "name": "available-compressors-external-control-30322"
+    "name": "available-compressors-external-control-30323"
   },
-  "30327": {
+  "30328": {
     "title": "+Adjust, port",
     "factor": 1,
     "size": "u8",
-    "name": "adjust-port-30327"
+    "name": "adjust-port-30328"
   },
-  "30328": {
+  "30329": {
     "title": "+Adjust, operating mode",
     "factor": 1,
     "size": "u8",
-    "name": "adjust-operating-mode-30328"
+    "name": "adjust-operating-mode-30329"
   },
-  "30329": {
+  "30330": {
     "title": "+Adjust, comfort",
     "factor": 1,
     "size": "u8",
-    "name": "adjust-comfort-30329"
+    "name": "adjust-comfort-30330"
   },
-  "30330": {
+  "30331": {
     "title": "+Adjust, parallel adjustment",
     "factor": 1,
     "size": "s8",
-    "name": "adjust-parallel-adjustment-30330"
+    "name": "adjust-parallel-adjustment-30331"
   },
-  "30331": {
+  "30332": {
     "title": "+Adjust, humidity",
     "factor": 10,
     "unit": "%RH",
     "size": "s16",
-    "name": "adjust-humidity-30331"
+    "name": "adjust-humidity-30332"
   },
-  "30332": {
+  "30333": {
     "title": "+Adjust, indoor temperature",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "adjust-indoor-temperature-30332"
+    "name": "adjust-indoor-temperature-30333"
   },
-  "30333": {
+  "30334": {
     "title": "+Adjust, outdoor temperature",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "adjust-outdoor-temperature-30333"
+    "name": "adjust-outdoor-temperature-30334"
   },
-  "30334": {
+  "30335": {
     "title": "+Adjust, version",
     "factor": 1,
     "size": "u16",
-    "name": "adjust-version-30334"
+    "name": "adjust-version-30335"
   },
-  "30335": {
+  "30336": {
     "title": "+Adjust, active",
     "factor": 1,
     "size": "u8",
-    "name": "adjust-active-30335"
+    "name": "adjust-active-30336"
   },
-  "30336": {
+  "30337": {
     "title": "+Adjust, demand",
     "factor": 1,
     "size": "u8",
-    "name": "adjust-demand-30336"
+    "name": "adjust-demand-30337"
   },
-  "40001": {
+  "40002": {
     "title": "+Adjust, parallel factor",
     "factor": 1,
     "size": "s8",
     "min": 1.0,
     "max": 10.0,
     "default": 5.0,
-    "name": "adjust-parallel-factor-40001",
+    "name": "adjust-parallel-factor-40002",
     "write": true
   },
-  "40002": {
+  "40003": {
     "title": "+Adjust, Parallel (min-max)",
     "factor": 1,
     "size": "s8",
     "min": 1.0,
     "max": 100.0,
     "default": 100.0,
-    "name": "adjust-parallel-min-max-40002",
+    "name": "adjust-parallel-min-max-40003",
     "write": true
   },
-  "30337": {
+  "30338": {
     "title": "Supply temperature (BT64)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "supply-temperature-bt64-30337"
+    "name": "supply-temperature-bt64-30338"
   },
-  "30338": {
+  "30339": {
     "title": "Heat pump functionality 2",
     "factor": 1,
     "size": "u32",
-    "name": "heat-pump-functionality-2-30338"
+    "name": "heat-pump-functionality-2-30339"
   },
-  "30340": {
+  "30341": {
     "title": "Status (EQ1)",
     "factor": 1,
     "size": "u8",
-    "name": "status-eq1-30340"
+    "name": "status-eq1-30341"
   },
-  "30341": {
+  "30342": {
     "title": "Status, heating dump shunt (EQ1)",
     "factor": 1,
     "size": "u8",
-    "name": "status-heating-dump-shunt-eq1-30341"
+    "name": "status-heating-dump-shunt-eq1-30342"
   },
-  "40011": {
+  "40012": {
     "title": "Degree minutes",
     "factor": 10,
     "unit": "DM",
@@ -1305,665 +1305,659 @@
     "min": -30000.0,
     "max": 30000.0,
     "default": 0.0,
-    "name": "degree-minutes-40011",
+    "name": "degree-minutes-40012",
     "write": true
   },
-  "30358": {
+  "30359": {
     "title": "Blocking (ERS 1)",
     "factor": 1,
     "size": "u8",
-    "name": "blocking-ers-1-30358"
+    "name": "blocking-ers-1-30359"
   },
-  "30359": {
+  "30360": {
     "title": "AZ30-EB17",
     "factor": 1,
     "size": "u8",
-    "name": "az30-eb17-30359"
+    "name": "az30-eb17-30360"
   },
-  "30385": {
+  "30386": {
     "title": "Seconds of blank time left, charge pump 8",
     "factor": 1,
     "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-8-30385"
+    "name": "seconds-of-blank-time-left-charge-pump-8-30386"
   },
-  "30386": {
+  "30387": {
     "title": "Seconds of blank time left, charge pump 7",
     "factor": 1,
     "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-7-30386"
+    "name": "seconds-of-blank-time-left-charge-pump-7-30387"
   },
-  "30387": {
+  "30388": {
     "title": "Seconds of blank time left, charge pump 6",
     "factor": 1,
     "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-6-30387"
+    "name": "seconds-of-blank-time-left-charge-pump-6-30388"
   },
-  "30388": {
+  "30389": {
     "title": "Seconds of blank time left, charge pump 5",
     "factor": 1,
     "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-5-30388"
+    "name": "seconds-of-blank-time-left-charge-pump-5-30389"
   },
-  "30389": {
+  "30390": {
     "title": "Seconds of blank time left, charge pump 4",
     "factor": 1,
     "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-4-30389"
+    "name": "seconds-of-blank-time-left-charge-pump-4-30390"
   },
-  "30390": {
+  "30391": {
     "title": "Seconds of blank time left, charge pump 3",
     "factor": 1,
     "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-3-30390"
+    "name": "seconds-of-blank-time-left-charge-pump-3-30391"
   },
-  "30391": {
+  "30392": {
     "title": "Seconds of blank time left, charge pump 2",
     "factor": 1,
     "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-2-30391"
+    "name": "seconds-of-blank-time-left-charge-pump-2-30392"
   },
-  "30392": {
+  "30393": {
     "title": "Seconds of blank time left, charge pump 1",
     "factor": 1,
     "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-1-30392"
+    "name": "seconds-of-blank-time-left-charge-pump-1-30393"
   },
-  "30394": {
+  "30395": {
     "title": "Inverter min speed",
     "factor": 1,
     "size": "u16",
-    "name": "inverter-min-speed-30394"
+    "name": "inverter-min-speed-30395"
   },
-  "30395": {
+  "30396": {
     "title": "Inverter max speed",
     "factor": 1,
     "size": "u16",
-    "name": "inverter-max-speed-30395"
+    "name": "inverter-max-speed-30396"
   },
-  "30402": {
+  "30403": {
     "title": "Max fan speed (EB101)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "max-fan-speed-eb101-30402"
+    "name": "max-fan-speed-eb101-30403"
   },
-  "30403": {
+  "30404": {
     "title": "Min fan speed (EB101)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "min-fan-speed-eb101-30403"
+    "name": "min-fan-speed-eb101-30404"
   },
-  "30406": {
+  "30407": {
     "title": "Power (EB101)",
     "factor": 10,
     "unit": "kW",
     "size": "u16",
-    "name": "power-eb101-30406"
+    "name": "power-eb101-30407"
   },
-  "30407": {
+  "30408": {
     "title": "Time to defrosting (EB101)",
     "factor": 1,
     "unit": "min",
     "size": "u16",
-    "name": "time-to-defrosting-eb101-30407"
+    "name": "time-to-defrosting-eb101-30408"
   },
-  "30408": {
+  "30409": {
     "title": "Defrosting index (EB101)",
     "factor": 1,
     "size": "u16",
-    "name": "defrosting-index-eb101-30408"
+    "name": "defrosting-index-eb101-30409"
   },
-  "30409": {
+  "30410": {
     "title": "Superheat reference EEV (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-eev-eb101-30409"
+    "name": "superheat-reference-eev-eb101-30410"
   },
-  "30410": {
+  "30411": {
     "title": "Superheat EEV (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-eev-eb101-30410"
+    "name": "superheat-eev-eb101-30411"
   },
-  "30411": {
+  "30412": {
     "title": "EEV-ssh-error (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-eb101-30411"
+    "name": "eev-ssh-error-eb101-30412"
   },
-  "30412": {
+  "30413": {
     "title": "Superheat temp. reference EEV (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-eev-eb101-30412"
+    "name": "superheat-temp-reference-eev-eb101-30413"
   },
-  "30413": {
+  "30414": {
     "title": "Set point value EEV (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-eev-eb101-30413"
+    "name": "set-point-value-eev-eb101-30414"
   },
-  "30414": {
+  "30415": {
     "title": "EEV PV (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-pv-eb101-30414"
+    "name": "eev-pv-eb101-30415"
   },
-  "30415": {
+  "30416": {
     "title": "EEV-te-error average open (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-eb101-30415"
+    "name": "eev-te-error-average-open-eb101-30416"
   },
-  "30416": {
+  "30417": {
     "title": "Degree of opening EEV (EB101)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-eev-eb101-30416"
+    "name": "degree-of-opening-eev-eb101-30417"
   },
-  "30417": {
+  "30418": {
     "title": "Superheat reference EVI (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-evi-eb101-30417"
+    "name": "superheat-reference-evi-eb101-30418"
   },
-  "30418": {
+  "30419": {
     "title": "Superheat EVI (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-evi-eb101-30418"
+    "name": "superheat-evi-eb101-30419"
   },
-  "30419": {
+  "30420": {
     "title": "EEV-ssh-error (EVI)(EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-evi-eb101-30419"
+    "name": "eev-ssh-error-evi-eb101-30420"
   },
-  "30420": {
+  "30421": {
     "title": "Superheat temp. reference EVI (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-evi-eb101-30420"
+    "name": "superheat-temp-reference-evi-eb101-30421"
   },
-  "30421": {
+  "30422": {
     "title": "Set point value EVI (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-evi-eb101-30421"
+    "name": "set-point-value-evi-eb101-30422"
   },
-  "30422": {
+  "30423": {
     "title": "EVI PV (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pv-eb101-30422"
+    "name": "evi-pv-eb101-30423"
   },
-  "30423": {
+  "30424": {
     "title": "EEV-te-error average open in (EVI)(EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-in-evi-eb101-30423"
+    "name": "eev-te-error-average-open-in-evi-eb101-30424"
   },
-  "30424": {
+  "30425": {
     "title": "Degree of opening EVI (EB101)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-evi-eb101-30424"
+    "name": "degree-of-opening-evi-eb101-30425"
   },
-  "30438": {
+  "30439": {
     "title": "Low press (EB108 BP8 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "low-press-eb108-bp8-dew-30438"
+    "name": "low-press-eb108-bp8-dew-30439"
   },
-  "30439": {
+  "30440": {
     "title": "Hi press (EB108 BP9 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hi-press-eb108-bp9-dew-30439"
+    "name": "hi-press-eb108-bp9-dew-30440"
   },
-  "30440": {
+  "30441": {
     "title": "Injection (EB108-BT81)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "injection-eb108-bt81-30440"
+    "name": "injection-eb108-bt81-30441"
   },
-  "30441": {
+  "30442": {
     "title": "Pressure sensor, injection (EB108-BP11)",
     "factor": 10,
     "size": "s16",
-    "name": "pressure-sensor-injection-eb108-bp11-30441"
+    "name": "pressure-sensor-injection-eb108-bp11-30442"
   },
-  "30442": {
+  "30443": {
     "title": "EVI pressure (EB108-EP14-BP11 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pressure-eb108-ep14-bp11-dew-30442"
+    "name": "evi-pressure-eb108-ep14-bp11-dew-30443"
   },
-  "30444": {
+  "30445": {
     "title": "Fan status (EB108-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "fan-status-eb108-ep14-30444"
+    "name": "fan-status-eb108-ep14-30445"
   },
-  "30445": {
+  "30446": {
     "title": "Fan rpm (EB108-EP14)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "fan-rpm-eb108-ep14-30445"
+    "name": "fan-rpm-eb108-ep14-30446"
   },
-  "30454": {
+  "30455": {
     "title": "Low press (EB107 BP8 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "low-press-eb107-bp8-dew-30454"
+    "name": "low-press-eb107-bp8-dew-30455"
   },
-  "30455": {
+  "30456": {
     "title": "Hi press (EB107 BP9 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hi-press-eb107-bp9-dew-30455"
+    "name": "hi-press-eb107-bp9-dew-30456"
   },
-  "30456": {
+  "30457": {
     "title": "Injection (EB107-BT81)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "injection-eb107-bt81-30456"
+    "name": "injection-eb107-bt81-30457"
   },
-  "30457": {
+  "30458": {
     "title": "Pressure sensor, injection (EB107-BP11)",
     "factor": 10,
     "size": "s16",
-    "name": "pressure-sensor-injection-eb107-bp11-30457"
+    "name": "pressure-sensor-injection-eb107-bp11-30458"
   },
-  "30458": {
+  "30459": {
     "title": "EVI pressure (EB107-EP14-BP11 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pressure-eb107-ep14-bp11-dew-30458"
+    "name": "evi-pressure-eb107-ep14-bp11-dew-30459"
   },
-  "30460": {
+  "30461": {
     "title": "Fan status (EB107-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "fan-status-eb107-ep14-30460"
+    "name": "fan-status-eb107-ep14-30461"
   },
-  "30461": {
+  "30462": {
     "title": "Fan rpm (EB107-EP14)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "fan-rpm-eb107-ep14-30461"
+    "name": "fan-rpm-eb107-ep14-30462"
   },
-  "30470": {
+  "30471": {
     "title": "Low press (EB106 BP8 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "low-press-eb106-bp8-dew-30470"
+    "name": "low-press-eb106-bp8-dew-30471"
   },
-  "30471": {
+  "30472": {
     "title": "Hi press (EB106 BP9 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hi-press-eb106-bp9-dew-30471"
+    "name": "hi-press-eb106-bp9-dew-30472"
   },
-  "30472": {
+  "30473": {
     "title": "Injection (EB106-BT81)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "injection-eb106-bt81-30472"
+    "name": "injection-eb106-bt81-30473"
   },
-  "30473": {
+  "30474": {
     "title": "Pressure sensor, injection (EB106-BP11)",
     "factor": 10,
     "size": "s16",
-    "name": "pressure-sensor-injection-eb106-bp11-30473"
+    "name": "pressure-sensor-injection-eb106-bp11-30474"
   },
-  "30474": {
+  "30475": {
     "title": "EVI pressure (EB106-EP14-BP11 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pressure-eb106-ep14-bp11-dew-30474"
+    "name": "evi-pressure-eb106-ep14-bp11-dew-30475"
   },
-  "30476": {
+  "30477": {
     "title": "Fan status (EB106-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "fan-status-eb106-ep14-30476"
+    "name": "fan-status-eb106-ep14-30477"
   },
-  "30477": {
+  "30478": {
     "title": "Fan rpm (EB106-EP14)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "fan-rpm-eb106-ep14-30477"
+    "name": "fan-rpm-eb106-ep14-30478"
   },
-  "30486": {
+  "30487": {
     "title": "Low press (EB105 BP8 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "low-press-eb105-bp8-dew-30486"
+    "name": "low-press-eb105-bp8-dew-30487"
   },
-  "30487": {
+  "30488": {
     "title": "Hi press (EB105 BP9 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hi-press-eb105-bp9-dew-30487"
+    "name": "hi-press-eb105-bp9-dew-30488"
   },
-  "30488": {
+  "30489": {
     "title": "Injection (EB105-BT81)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "injection-eb105-bt81-30488"
+    "name": "injection-eb105-bt81-30489"
   },
-  "30489": {
+  "30490": {
     "title": "Pressure sensor, injection (EB105-BP11)",
     "factor": 10,
     "size": "s16",
-    "name": "pressure-sensor-injection-eb105-bp11-30489"
+    "name": "pressure-sensor-injection-eb105-bp11-30490"
   },
-  "30490": {
+  "30491": {
     "title": "EVI pressure (EB105-EP14-BP11 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pressure-eb105-ep14-bp11-dew-30490"
+    "name": "evi-pressure-eb105-ep14-bp11-dew-30491"
   },
-  "30492": {
+  "30493": {
     "title": "Fan status (EB105-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "fan-status-eb105-ep14-30492"
+    "name": "fan-status-eb105-ep14-30493"
   },
-  "30493": {
+  "30494": {
     "title": "Fan rpm (EB105-EP14)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "fan-rpm-eb105-ep14-30493"
+    "name": "fan-rpm-eb105-ep14-30494"
   },
-  "30502": {
+  "30503": {
     "title": "Low press (EB104 BP8 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "low-press-eb104-bp8-dew-30502"
+    "name": "low-press-eb104-bp8-dew-30503"
   },
-  "30503": {
+  "30504": {
     "title": "Hi press (EB104 BP9 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hi-press-eb104-bp9-dew-30503"
+    "name": "hi-press-eb104-bp9-dew-30504"
   },
-  "30504": {
+  "30505": {
     "title": "Injection (EB104-BT81)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "injection-eb104-bt81-30504"
+    "name": "injection-eb104-bt81-30505"
   },
-  "30505": {
+  "30506": {
     "title": "Pressure sensor, injection (EB104-BP11)",
     "factor": 10,
     "size": "s16",
-    "name": "pressure-sensor-injection-eb104-bp11-30505"
+    "name": "pressure-sensor-injection-eb104-bp11-30506"
   },
-  "30506": {
+  "30507": {
     "title": "EVI pressure (EB104-EP14-BP11 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pressure-eb104-ep14-bp11-dew-30506"
+    "name": "evi-pressure-eb104-ep14-bp11-dew-30507"
   },
-  "30508": {
+  "30509": {
     "title": "Fan status (EB104-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "fan-status-eb104-ep14-30508"
+    "name": "fan-status-eb104-ep14-30509"
   },
-  "30509": {
+  "30510": {
     "title": "Fan rpm (EB104-EP14)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "fan-rpm-eb104-ep14-30509"
+    "name": "fan-rpm-eb104-ep14-30510"
   },
-  "30518": {
+  "30519": {
     "title": "Low press (EB103 BP8 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "low-press-eb103-bp8-dew-30518"
+    "name": "low-press-eb103-bp8-dew-30519"
   },
-  "30519": {
+  "30520": {
     "title": "Hi press (EB103 BP9 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hi-press-eb103-bp9-dew-30519"
+    "name": "hi-press-eb103-bp9-dew-30520"
   },
-  "30520": {
+  "30521": {
     "title": "Injection (EB103-BT81)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "injection-eb103-bt81-30520"
+    "name": "injection-eb103-bt81-30521"
   },
-  "30521": {
+  "30522": {
     "title": "Pressure sensor, injection (EB103-BP11)",
     "factor": 10,
     "size": "s16",
-    "name": "pressure-sensor-injection-eb103-bp11-30521"
+    "name": "pressure-sensor-injection-eb103-bp11-30522"
   },
-  "30522": {
+  "30523": {
     "title": "EVI pressure (EB103-EP14-BP11 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pressure-eb103-ep14-bp11-dew-30522"
+    "name": "evi-pressure-eb103-ep14-bp11-dew-30523"
   },
-  "30524": {
+  "30525": {
     "title": "Fan status (EB103-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "fan-status-eb103-ep14-30524"
+    "name": "fan-status-eb103-ep14-30525"
   },
-  "30525": {
+  "30526": {
     "title": "Fan rpm (EB103-EP14)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "fan-rpm-eb103-ep14-30525"
+    "name": "fan-rpm-eb103-ep14-30526"
   },
-  "30534": {
+  "30535": {
     "title": "Low press (EB102 BP8 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "low-press-eb102-bp8-dew-30534"
+    "name": "low-press-eb102-bp8-dew-30535"
   },
-  "30535": {
+  "30536": {
     "title": "Hi press (EB102 BP9 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hi-press-eb102-bp9-dew-30535"
+    "name": "hi-press-eb102-bp9-dew-30536"
   },
-  "30536": {
+  "30537": {
     "title": "Injection (EB102-BT81)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "injection-eb102-bt81-30536"
+    "name": "injection-eb102-bt81-30537"
   },
-  "30537": {
+  "30538": {
     "title": "Pressure sensor, injection (EB102-EP14-BP11)",
     "factor": 10,
     "size": "s16",
-    "name": "pressure-sensor-injection-eb102-ep14-bp11-30537"
+    "name": "pressure-sensor-injection-eb102-ep14-bp11-30538"
   },
-  "30538": {
+  "30539": {
     "title": "EVI pressure (EB102-EP14-BP11 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pressure-eb102-ep14-bp11-dew-30538"
+    "name": "evi-pressure-eb102-ep14-bp11-dew-30539"
   },
-  "30540": {
+  "30541": {
     "title": "Fan status (EB102-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "fan-status-eb102-ep14-30540"
+    "name": "fan-status-eb102-ep14-30541"
   },
-  "30541": {
+  "30542": {
     "title": "Fan rpm (EB102-EP14)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "fan-rpm-eb102-ep14-30541"
+    "name": "fan-rpm-eb102-ep14-30542"
   },
-  "30550": {
+  "30551": {
     "title": "Low press (EB101 BP8 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "low-press-eb101-bp8-dew-30550"
+    "name": "low-press-eb101-bp8-dew-30551"
   },
-  "30551": {
+  "30552": {
     "title": "Hi press (EB101 BP9 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "hi-press-eb101-bp9-dew-30551"
+    "name": "hi-press-eb101-bp9-dew-30552"
   },
-  "30552": {
+  "30553": {
     "title": "Injection (EB101-BT81)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "injection-eb101-bt81-30552"
+    "name": "injection-eb101-bt81-30553"
   },
-  "30553": {
+  "30554": {
     "title": "Pressure sensor, injection (EB101-BP11)",
     "factor": 10,
     "size": "s16",
-    "name": "pressure-sensor-injection-eb101-bp11-30553"
+    "name": "pressure-sensor-injection-eb101-bp11-30554"
   },
-  "30554": {
+  "30555": {
     "title": "EVI pressure (EB101-EP14-BP11 dew)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pressure-eb101-ep14-bp11-dew-30554"
+    "name": "evi-pressure-eb101-ep14-bp11-dew-30555"
   },
-  "30556": {
+  "30557": {
     "title": "Fan status (EB101-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "fan-status-eb101-ep14-30556"
+    "name": "fan-status-eb101-ep14-30557"
   },
-  "30557": {
+  "30558": {
     "title": "Fan rpm (EB101-EP14)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "fan-rpm-eb101-ep14-30557"
+    "name": "fan-rpm-eb101-ep14-30558"
   },
-  "30578": {
+  "30579": {
     "title": "Average current (EME 10)",
     "factor": 10,
     "unit": "A",
     "size": "s16",
-    "name": "average-current-eme-10-30578"
+    "name": "average-current-eme-10-30579"
   },
-  "30579": {
+  "30580": {
     "title": "Operating mode PV panels",
     "factor": 1,
     "size": "u8",
-    "name": "operating-mode-pv-panels-30579"
+    "name": "operating-mode-pv-panels-30580"
   },
-  "30581": {
+  "30582": {
     "title": "EME lux mode without EME",
     "factor": 1,
     "size": "u8",
-    "name": "eme-lux-mode-without-eme-30581"
+    "name": "eme-lux-mode-without-eme-30582"
   },
-  "30582": {
+  "30583": {
     "title": "Timer (EME)",
     "factor": 60,
     "unit": "min",
     "size": "u16",
-    "name": "timer-eme-30582"
+    "name": "timer-eme-30583"
   },
-  "30590": {
+  "30591": {
     "title": "Fan mode 4",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "fan-mode-4-30590"
+    "name": "fan-mode-4-30591"
   },
-  "30591": {
+  "30592": {
     "title": "Fan mode 3",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "fan-mode-3-30591"
+    "name": "fan-mode-3-30592"
   },
-  "30592": {
+  "30593": {
     "title": "Fan mode 2",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "fan-mode-2-30592"
+    "name": "fan-mode-2-30593"
   },
-  "30593": {
+  "30594": {
     "title": "Is the compressor accessible",
     "factor": 1,
     "size": "u8",
-    "name": "is-the-compressor-accessible-30593"
+    "name": "is-the-compressor-accessible-30594"
   },
-  "30604": {
+  "30605": {
     "title": "Prio, hot water (OPT)",
     "factor": 1,
     "size": "u8",
-    "name": "prio-hot-water-opt-30604"
-  },
-  "30683": {
-    "title": "Permit (undefined)",
-    "factor": 1,
-    "size": "u8",
-    "name": "permit-undefined-30683"
+    "name": "prio-hot-water-opt-30605"
   },
   "30684": {
     "title": "Permit (undefined)",
@@ -1978,1265 +1972,1271 @@
     "name": "permit-undefined-30685"
   },
   "30686": {
+    "title": "Permit (undefined)",
+    "factor": 1,
+    "size": "u8",
+    "name": "permit-undefined-30686"
+  },
+  "30687": {
     "title": "Permit (OPT 10) additional heat",
     "factor": 1,
     "size": "u8",
-    "name": "permit-opt-10-additional-heat-30686"
+    "name": "permit-opt-10-additional-heat-30687"
   },
-  "30687": {
+  "30688": {
     "title": "Permit ext. imm. heater step",
     "factor": 1,
     "size": "u8",
-    "name": "permit-ext-imm-heater-step-30687"
+    "name": "permit-ext-imm-heater-step-30688"
   },
-  "30688": {
+  "30689": {
     "title": "Permit int. imm. heater step",
     "factor": 1,
     "size": "u8",
-    "name": "permit-int-imm-heater-step-30688"
+    "name": "permit-int-imm-heater-step-30689"
   },
-  "30689": {
+  "30690": {
     "title": "Permit shunted additional heat",
     "factor": 1,
     "size": "u8",
-    "name": "permit-shunted-additional-heat-30689"
+    "name": "permit-shunted-additional-heat-30690"
   },
-  "30690": {
+  "30691": {
     "title": "Permit prioritised additional heat",
     "factor": 1,
     "size": "u8",
-    "name": "permit-prioritised-additional-heat-30690"
+    "name": "permit-prioritised-additional-heat-30691"
   },
-  "30691": {
+  "30692": {
     "title": "Permit (EB108-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb108-ep15-30691"
+    "name": "permit-eb108-ep15-30692"
   },
-  "30692": {
+  "30693": {
     "title": "Permit (EB107-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb107-ep15-30692"
+    "name": "permit-eb107-ep15-30693"
   },
-  "30693": {
+  "30694": {
     "title": "Permit (EB106-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb106-ep15-30693"
+    "name": "permit-eb106-ep15-30694"
   },
-  "30694": {
+  "30695": {
     "title": "Permit (EB105-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb105-ep15-30694"
+    "name": "permit-eb105-ep15-30695"
   },
-  "30695": {
+  "30696": {
     "title": "Permit (EB104-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb104-ep15-30695"
+    "name": "permit-eb104-ep15-30696"
   },
-  "30696": {
+  "30697": {
     "title": "Permit (EB103-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb103-ep15-30696"
+    "name": "permit-eb103-ep15-30697"
   },
-  "30697": {
+  "30698": {
     "title": "Permit (EB102-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb102-ep15-30697"
+    "name": "permit-eb102-ep15-30698"
   },
-  "30698": {
+  "30699": {
     "title": "Permit (EB101-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb101-ep15-30698"
+    "name": "permit-eb101-ep15-30699"
   },
-  "30699": {
+  "30700": {
     "title": "Permit (EB100-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb100-ep15-30699"
+    "name": "permit-eb100-ep15-30700"
   },
-  "30700": {
+  "30701": {
     "title": "Permit (EB108-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb108-ep14-30700"
+    "name": "permit-eb108-ep14-30701"
   },
-  "30701": {
+  "30702": {
     "title": "Permit (EB107-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb107-ep14-30701"
+    "name": "permit-eb107-ep14-30702"
   },
-  "30702": {
+  "30703": {
     "title": "Permit (EB106-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb106-ep14-30702"
+    "name": "permit-eb106-ep14-30703"
   },
-  "30703": {
+  "30704": {
     "title": "Permit (EB105-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb105-ep14-30703"
+    "name": "permit-eb105-ep14-30704"
   },
-  "30704": {
+  "30705": {
     "title": "Permit (EB104-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb104-ep14-30704"
+    "name": "permit-eb104-ep14-30705"
   },
-  "30705": {
+  "30706": {
     "title": "Permit (EB103-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb103-ep14-30705"
+    "name": "permit-eb103-ep14-30706"
   },
-  "30706": {
+  "30707": {
     "title": "Permit (EB102-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb102-ep14-30706"
+    "name": "permit-eb102-ep14-30707"
   },
-  "30707": {
+  "30708": {
     "title": "Permit (EB101-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb101-ep14-30707"
+    "name": "permit-eb101-ep14-30708"
   },
-  "30708": {
+  "30709": {
     "title": "Permit (EB100-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "permit-eb100-ep14-30708"
+    "name": "permit-eb100-ep14-30709"
   },
-  "30709": {
+  "30710": {
     "title": "Smart energy source, priority 7, start DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-7-start-dm-30709"
+    "name": "smart-energy-source-priority-7-start-dm-30710"
   },
-  "30711": {
+  "30712": {
     "title": "Smart energy source, priority 6, start DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-6-start-dm-30711"
+    "name": "smart-energy-source-priority-6-start-dm-30712"
   },
-  "30713": {
+  "30714": {
     "title": "Smart energy source, priority 5, start DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-5-start-dm-30713"
+    "name": "smart-energy-source-priority-5-start-dm-30714"
   },
-  "30715": {
+  "30716": {
     "title": "Smart energy source, priority 4, start DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-4-start-dm-30715"
+    "name": "smart-energy-source-priority-4-start-dm-30716"
   },
-  "30717": {
+  "30718": {
     "title": "Smart energy source, priority 3, start DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-3-start-dm-30717"
+    "name": "smart-energy-source-priority-3-start-dm-30718"
   },
-  "30719": {
+  "30720": {
     "title": "Smart energy source, priority 2, start DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-2-start-dm-30719"
+    "name": "smart-energy-source-priority-2-start-dm-30720"
   },
-  "30721": {
+  "30722": {
     "title": "Smart energy source, priority 1, start DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-1-start-dm-30721"
+    "name": "smart-energy-source-priority-1-start-dm-30722"
   },
-  "30723": {
+  "30724": {
     "title": "Smart energy source, priority 7, stop DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-7-stop-dm-30723"
+    "name": "smart-energy-source-priority-7-stop-dm-30724"
   },
-  "30725": {
+  "30726": {
     "title": "Smart energy source, priority 6, stop DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-6-stop-dm-30725"
+    "name": "smart-energy-source-priority-6-stop-dm-30726"
   },
-  "30727": {
+  "30728": {
     "title": "Smart energy source, priority 5, stop DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-5-stop-dm-30727"
+    "name": "smart-energy-source-priority-5-stop-dm-30728"
   },
-  "30729": {
+  "30730": {
     "title": "Smart energy source, priority 4, stop DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-4-stop-dm-30729"
+    "name": "smart-energy-source-priority-4-stop-dm-30730"
   },
-  "30731": {
+  "30732": {
     "title": "Smart energy source, priority 3, stop DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-3-stop-dm-30731"
+    "name": "smart-energy-source-priority-3-stop-dm-30732"
   },
-  "30733": {
+  "30734": {
     "title": "Smart energy source, priority 2, stop DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-2-stop-dm-30733"
+    "name": "smart-energy-source-priority-2-stop-dm-30734"
   },
-  "30735": {
+  "30736": {
     "title": "Smart energy source, priority 1, stop DM",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-priority-1-stop-dm-30735"
+    "name": "smart-energy-source-priority-1-stop-dm-30736"
   },
-  "30737": {
+  "30738": {
     "title": "Smart energy source, DM minimum value",
     "factor": 1,
     "size": "s32",
-    "name": "smart-energy-source-dm-minimum-value-30737"
+    "name": "smart-energy-source-dm-minimum-value-30738"
   },
-  "30743": {
+  "30744": {
     "title": "Collector in (EP12-BT57)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "collector-in-ep12-bt57-30743"
+    "name": "collector-in-ep12-bt57-30744"
   },
-  "30744": {
+  "30745": {
     "title": "Collector out (EP12-BT58)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "collector-out-ep12-bt58-30744"
+    "name": "collector-out-ep12-bt58-30745"
   },
-  "30745": {
+  "30746": {
     "title": "External guide status",
     "factor": 1,
     "size": "u8",
-    "name": "external-guide-status-30745"
+    "name": "external-guide-status-30746"
   },
-  "30746": {
+  "30747": {
     "title": "Test guide value",
     "factor": 1,
     "size": "u16",
-    "name": "test-guide-value-30746"
+    "name": "test-guide-value-30747"
   },
-  "30747": {
+  "30748": {
     "title": "Temp. lux forces start of hot water demand",
     "factor": 1,
     "size": "u8",
-    "name": "temp-lux-forces-start-of-hot-water-demand-30747"
+    "name": "temp-lux-forces-start-of-hot-water-demand-30748"
   },
-  "30759": {
+  "30760": {
     "title": "Wood boiler activated",
     "factor": 1,
     "size": "u8",
-    "name": "wood-boiler-activated-30759"
+    "name": "wood-boiler-activated-30760"
   },
-  "30762": {
+  "30763": {
     "title": "Max fan speed (EB108-F21x0)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "max-fan-speed-eb108-f21x0-30762"
+    "name": "max-fan-speed-eb108-f21x0-30763"
   },
-  "30763": {
+  "30764": {
     "title": "Min fan speed (EB108)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "min-fan-speed-eb108-30763"
+    "name": "min-fan-speed-eb108-30764"
   },
-  "30766": {
+  "30767": {
     "title": "Power (EB108-F21x0)",
     "factor": 10,
     "unit": "kW",
     "size": "u16",
-    "name": "power-eb108-f21x0-30766"
+    "name": "power-eb108-f21x0-30767"
   },
-  "30767": {
+  "30768": {
     "title": "Time to defrosting (EB108)",
     "factor": 1,
     "unit": "min",
     "size": "u16",
-    "name": "time-to-defrosting-eb108-30767"
+    "name": "time-to-defrosting-eb108-30768"
   },
-  "30768": {
+  "30769": {
     "title": "Defrosting index (EB108)",
     "factor": 1,
     "size": "u16",
-    "name": "defrosting-index-eb108-30768"
+    "name": "defrosting-index-eb108-30769"
   },
-  "30769": {
+  "30770": {
     "title": "Superheat reference EEV (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-eev-eb108-30769"
+    "name": "superheat-reference-eev-eb108-30770"
   },
-  "30770": {
+  "30771": {
     "title": "Superheat EEV (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-eev-eb108-30770"
+    "name": "superheat-eev-eb108-30771"
   },
-  "30771": {
+  "30772": {
     "title": "EEV-ssh-error (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-eb108-30771"
+    "name": "eev-ssh-error-eb108-30772"
   },
-  "30772": {
+  "30773": {
     "title": "Superheat temp. reference EEV (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-eev-eb108-30772"
+    "name": "superheat-temp-reference-eev-eb108-30773"
   },
-  "30773": {
+  "30774": {
     "title": "Set point value EEV (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-eev-eb108-30773"
+    "name": "set-point-value-eev-eb108-30774"
   },
-  "30774": {
+  "30775": {
     "title": "EEV PV (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-pv-eb108-30774"
+    "name": "eev-pv-eb108-30775"
   },
-  "30775": {
+  "30776": {
     "title": "EEV-te-error average open (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-eb108-30775"
+    "name": "eev-te-error-average-open-eb108-30776"
   },
-  "30776": {
+  "30777": {
     "title": "Degree of opening EEV (EB108)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-eev-eb108-30776"
+    "name": "degree-of-opening-eev-eb108-30777"
   },
-  "30777": {
+  "30778": {
     "title": "Superheat reference EVI (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-evi-eb108-30777"
+    "name": "superheat-reference-evi-eb108-30778"
   },
-  "30778": {
+  "30779": {
     "title": "Superheat EVI (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-evi-eb108-30778"
+    "name": "superheat-evi-eb108-30779"
   },
-  "30779": {
+  "30780": {
     "title": "EEV-ssh-error (EVI)(EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-evi-eb108-30779"
+    "name": "eev-ssh-error-evi-eb108-30780"
   },
-  "30780": {
+  "30781": {
     "title": "Superheat temp. reference EVI (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-evi-eb108-30780"
+    "name": "superheat-temp-reference-evi-eb108-30781"
   },
-  "30781": {
+  "30782": {
     "title": "Set point value EVI (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-evi-eb108-30781"
+    "name": "set-point-value-evi-eb108-30782"
   },
-  "30782": {
+  "30783": {
     "title": "EVI PV (EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pv-eb108-30782"
+    "name": "evi-pv-eb108-30783"
   },
-  "30783": {
+  "30784": {
     "title": "EEV-te-error average open (EVI)(EB108)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb108-30783"
+    "name": "eev-te-error-average-open-evi-eb108-30784"
   },
-  "30784": {
+  "30785": {
     "title": "Degree of opening EVI (EB108)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-evi-eb108-30784"
+    "name": "degree-of-opening-evi-eb108-30785"
   },
-  "30787": {
+  "30788": {
     "title": "Max fan speed (EB107)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "max-fan-speed-eb107-30787"
+    "name": "max-fan-speed-eb107-30788"
   },
-  "30788": {
+  "30789": {
     "title": "Min fan speed (EB107)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "min-fan-speed-eb107-30788"
+    "name": "min-fan-speed-eb107-30789"
   },
-  "30791": {
+  "30792": {
     "title": "Power (EB107-F21x0)",
     "factor": 10,
     "unit": "kW",
     "size": "u16",
-    "name": "power-eb107-f21x0-30791"
+    "name": "power-eb107-f21x0-30792"
   },
-  "30793": {
+  "30794": {
     "title": "Defrosting index (EB107)",
     "factor": 1,
     "size": "u16",
-    "name": "defrosting-index-eb107-30793"
+    "name": "defrosting-index-eb107-30794"
   },
-  "30794": {
+  "30795": {
     "title": "Superheat reference EEV (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-eev-eb107-30794"
+    "name": "superheat-reference-eev-eb107-30795"
   },
-  "30795": {
+  "30796": {
     "title": "Superheat EEV (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-eev-eb107-30795"
+    "name": "superheat-eev-eb107-30796"
   },
-  "30796": {
+  "30797": {
     "title": "EEV-ssh-error (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-eb107-30796"
+    "name": "eev-ssh-error-eb107-30797"
   },
-  "30797": {
+  "30798": {
     "title": "Superheat temp. reference EEV (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-eev-eb107-30797"
+    "name": "superheat-temp-reference-eev-eb107-30798"
   },
-  "30798": {
+  "30799": {
     "title": "Set point value EEV (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-eev-eb107-30798"
+    "name": "set-point-value-eev-eb107-30799"
   },
-  "30799": {
+  "30800": {
     "title": "EEV PV (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-pv-eb107-30799"
+    "name": "eev-pv-eb107-30800"
   },
-  "30800": {
+  "30801": {
     "title": "EEV-te-error average open (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-eb107-30800"
+    "name": "eev-te-error-average-open-eb107-30801"
   },
-  "30801": {
+  "30802": {
     "title": "Degree of opening EEV (EB107)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-eev-eb107-30801"
+    "name": "degree-of-opening-eev-eb107-30802"
   },
-  "30802": {
+  "30803": {
     "title": "Superheat reference EVI (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-evi-eb107-30802"
+    "name": "superheat-reference-evi-eb107-30803"
   },
-  "30803": {
+  "30804": {
     "title": "Superheat EVI (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-evi-eb107-30803"
+    "name": "superheat-evi-eb107-30804"
   },
-  "30804": {
+  "30805": {
     "title": "EEV-ssh-error (EVI)(EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-evi-eb107-30804"
+    "name": "eev-ssh-error-evi-eb107-30805"
   },
-  "30805": {
+  "30806": {
     "title": "Superheat temp. reference EVI (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-evi-eb107-30805"
+    "name": "superheat-temp-reference-evi-eb107-30806"
   },
-  "30806": {
+  "30807": {
     "title": "Set point value EVI (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-evi-eb107-30806"
+    "name": "set-point-value-evi-eb107-30807"
   },
-  "30807": {
+  "30808": {
     "title": "EVI PV (EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pv-eb107-30807"
+    "name": "evi-pv-eb107-30808"
   },
-  "30808": {
+  "30809": {
     "title": "EEV-te-error average open (EVI)(EB107)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb107-30808"
+    "name": "eev-te-error-average-open-evi-eb107-30809"
   },
-  "30809": {
+  "30810": {
     "title": "Degree of opening EVI (EB107)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-evi-eb107-30809"
+    "name": "degree-of-opening-evi-eb107-30810"
   },
-  "30812": {
+  "30813": {
     "title": "Max fan speed (EB106)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "max-fan-speed-eb106-30812"
+    "name": "max-fan-speed-eb106-30813"
   },
-  "30816": {
+  "30817": {
     "title": "power (EB106)",
     "factor": 10,
     "unit": "kW",
     "size": "u16",
-    "name": "power-eb106-30816"
+    "name": "power-eb106-30817"
   },
-  "30818": {
+  "30819": {
     "title": "Defrosting index (EB106)",
     "factor": 1,
     "size": "u16",
-    "name": "defrosting-index-eb106-30818"
+    "name": "defrosting-index-eb106-30819"
   },
-  "30819": {
+  "30820": {
     "title": "Superheat reference EEV (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-eev-eb106-30819"
+    "name": "superheat-reference-eev-eb106-30820"
   },
-  "30820": {
+  "30821": {
     "title": "Superheat EEV (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-eev-eb106-30820"
+    "name": "superheat-eev-eb106-30821"
   },
-  "30821": {
+  "30822": {
     "title": "EEV-ssh-error (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-eb106-30821"
+    "name": "eev-ssh-error-eb106-30822"
   },
-  "30822": {
+  "30823": {
     "title": "Superheat temp. reference EEV (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-eev-eb106-30822"
+    "name": "superheat-temp-reference-eev-eb106-30823"
   },
-  "30823": {
+  "30824": {
     "title": "Set point value EEV (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-eev-eb106-30823"
+    "name": "set-point-value-eev-eb106-30824"
   },
-  "30824": {
+  "30825": {
     "title": "EEV PV (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-pv-eb106-30824"
+    "name": "eev-pv-eb106-30825"
   },
-  "30825": {
+  "30826": {
     "title": "EEV-te-error average open (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-eb106-30825"
+    "name": "eev-te-error-average-open-eb106-30826"
   },
-  "30826": {
+  "30827": {
     "title": "Degree of opening EEV (EB106)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-eev-eb106-30826"
+    "name": "degree-of-opening-eev-eb106-30827"
   },
-  "30827": {
+  "30828": {
     "title": "Superheat reference EVI (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-evi-eb106-30827"
+    "name": "superheat-reference-evi-eb106-30828"
   },
-  "30828": {
+  "30829": {
     "title": "Superheat EVI (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-evi-eb106-30828"
+    "name": "superheat-evi-eb106-30829"
   },
-  "30829": {
+  "30830": {
     "title": "EEV-ssh-error (EVI)(EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-evi-eb106-30829"
+    "name": "eev-ssh-error-evi-eb106-30830"
   },
-  "30830": {
+  "30831": {
     "title": "Superheat temp. reference EVI (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-evi-eb106-30830"
+    "name": "superheat-temp-reference-evi-eb106-30831"
   },
-  "30831": {
+  "30832": {
     "title": "Set point value EVI (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-evi-eb106-30831"
+    "name": "set-point-value-evi-eb106-30832"
   },
-  "30832": {
+  "30833": {
     "title": "EVI PV (EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pv-eb106-30832"
+    "name": "evi-pv-eb106-30833"
   },
-  "30833": {
+  "30834": {
     "title": "EEV-te-error average open (EVI)(EB106)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb106-30833"
+    "name": "eev-te-error-average-open-evi-eb106-30834"
   },
-  "30834": {
+  "30835": {
     "title": "Degree of opening EVI (EB106)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-evi-eb106-30834"
+    "name": "degree-of-opening-evi-eb106-30835"
   },
-  "30837": {
+  "30838": {
     "title": "Max fan speed (EB105)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "max-fan-speed-eb105-30837"
+    "name": "max-fan-speed-eb105-30838"
   },
-  "30838": {
+  "30839": {
     "title": "Min fan speed (EB105)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "min-fan-speed-eb105-30838"
+    "name": "min-fan-speed-eb105-30839"
   },
-  "30841": {
+  "30842": {
     "title": "Power (EB105)",
     "factor": 10,
     "unit": "kW",
     "size": "u16",
-    "name": "power-eb105-30841"
+    "name": "power-eb105-30842"
   },
-  "30843": {
+  "30844": {
     "title": "Defrosting index (EB105)",
     "factor": 1,
     "size": "u16",
-    "name": "defrosting-index-eb105-30843"
+    "name": "defrosting-index-eb105-30844"
   },
-  "30844": {
+  "30845": {
     "title": "Superheat reference EEV (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-eev-eb105-30844"
+    "name": "superheat-reference-eev-eb105-30845"
   },
-  "30845": {
+  "30846": {
     "title": "Superheat EEV (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-eev-eb105-30845"
+    "name": "superheat-eev-eb105-30846"
   },
-  "30846": {
+  "30847": {
     "title": "EEV-ssh-error (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-eb105-30846"
+    "name": "eev-ssh-error-eb105-30847"
   },
-  "30847": {
+  "30848": {
     "title": "Superheat temp. reference EEV (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-eev-eb105-30847"
+    "name": "superheat-temp-reference-eev-eb105-30848"
   },
-  "30848": {
+  "30849": {
     "title": "Set point value EEV (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-eev-eb105-30848"
+    "name": "set-point-value-eev-eb105-30849"
   },
-  "30849": {
+  "30850": {
     "title": "EEV PV (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-pv-eb105-30849"
+    "name": "eev-pv-eb105-30850"
   },
-  "30850": {
+  "30851": {
     "title": "EEV-te-error average open (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-eb105-30850"
+    "name": "eev-te-error-average-open-eb105-30851"
   },
-  "30851": {
+  "30852": {
     "title": "Degree of opening EEV (EB105)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-eev-eb105-30851"
+    "name": "degree-of-opening-eev-eb105-30852"
   },
-  "30852": {
+  "30853": {
     "title": "Superheat reference EVI (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-evi-eb105-30852"
+    "name": "superheat-reference-evi-eb105-30853"
   },
-  "30853": {
+  "30854": {
     "title": "Superheat EVI (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-evi-eb105-30853"
+    "name": "superheat-evi-eb105-30854"
   },
-  "30854": {
+  "30855": {
     "title": "EEV-ssh-error (EVI)(EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-evi-eb105-30854"
+    "name": "eev-ssh-error-evi-eb105-30855"
   },
-  "30855": {
+  "30856": {
     "title": "Superheat temp. reference EVI (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-evi-eb105-30855"
+    "name": "superheat-temp-reference-evi-eb105-30856"
   },
-  "30856": {
+  "30857": {
     "title": "Set point value EVI (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-evi-eb105-30856"
+    "name": "set-point-value-evi-eb105-30857"
   },
-  "30857": {
+  "30858": {
     "title": "EVI PV (EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pv-eb105-30857"
+    "name": "evi-pv-eb105-30858"
   },
-  "30858": {
+  "30859": {
     "title": "EEV-te-error average open (EVI)(EB105)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb105-30858"
+    "name": "eev-te-error-average-open-evi-eb105-30859"
   },
-  "30859": {
+  "30860": {
     "title": "Degree of opening EVI (EB105)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-evi-eb105-30859"
+    "name": "degree-of-opening-evi-eb105-30860"
   },
-  "30862": {
+  "30863": {
     "title": "Max fan speed (EB104)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "max-fan-speed-eb104-30862"
+    "name": "max-fan-speed-eb104-30863"
   },
-  "30863": {
+  "30864": {
     "title": "Min fan speed (EB104)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "min-fan-speed-eb104-30863"
+    "name": "min-fan-speed-eb104-30864"
   },
-  "30866": {
+  "30867": {
     "title": "Power (EB104)",
     "factor": 10,
     "unit": "kW",
     "size": "u16",
-    "name": "power-eb104-30866"
+    "name": "power-eb104-30867"
   },
-  "30868": {
+  "30869": {
     "title": "Defrosting index (EB104)",
     "factor": 1,
     "size": "u16",
-    "name": "defrosting-index-eb104-30868"
+    "name": "defrosting-index-eb104-30869"
   },
-  "30869": {
+  "30870": {
     "title": "Superheat reference EEV (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-eev-eb104-30869"
+    "name": "superheat-reference-eev-eb104-30870"
   },
-  "30870": {
+  "30871": {
     "title": "Superheat EEV (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-eev-eb104-30870"
+    "name": "superheat-eev-eb104-30871"
   },
-  "30871": {
+  "30872": {
     "title": "EEV-ssh-error (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-eb104-30871"
+    "name": "eev-ssh-error-eb104-30872"
   },
-  "30872": {
+  "30873": {
     "title": "Superheat temp. reference EEV (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-eev-eb104-30872"
+    "name": "superheat-temp-reference-eev-eb104-30873"
   },
-  "30873": {
+  "30874": {
     "title": "Set point value EEV (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-eev-eb104-30873"
+    "name": "set-point-value-eev-eb104-30874"
   },
-  "30874": {
+  "30875": {
     "title": "EEV PV (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-pv-eb104-30874"
+    "name": "eev-pv-eb104-30875"
   },
-  "30875": {
+  "30876": {
     "title": "EEV-te-error average open (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-eb104-30875"
+    "name": "eev-te-error-average-open-eb104-30876"
   },
-  "30876": {
+  "30877": {
     "title": "Degree of opening EEV (EB104)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-eev-eb104-30876"
+    "name": "degree-of-opening-eev-eb104-30877"
   },
-  "30877": {
+  "30878": {
     "title": "Superheat reference EVI (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-evi-eb104-30877"
+    "name": "superheat-reference-evi-eb104-30878"
   },
-  "30878": {
+  "30879": {
     "title": "Superheat EVI (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-evi-eb104-30878"
+    "name": "superheat-evi-eb104-30879"
   },
-  "30879": {
+  "30880": {
     "title": "EEV-ssh-error (EVI)(EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-evi-eb104-30879"
+    "name": "eev-ssh-error-evi-eb104-30880"
   },
-  "30880": {
+  "30881": {
     "title": "Superheat temp. reference EVI (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-evi-eb104-30880"
+    "name": "superheat-temp-reference-evi-eb104-30881"
   },
-  "30881": {
+  "30882": {
     "title": "Set point value EVI (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-evi-eb104-30881"
+    "name": "set-point-value-evi-eb104-30882"
   },
-  "30882": {
+  "30883": {
     "title": "EVI PV (EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pv-eb104-30882"
+    "name": "evi-pv-eb104-30883"
   },
-  "30883": {
+  "30884": {
     "title": "EEV-te-error average open (EVI)(EB104)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb104-30883"
+    "name": "eev-te-error-average-open-evi-eb104-30884"
   },
-  "30884": {
+  "30885": {
     "title": "Degree of opening EVI (EB104)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-evi-eb104-30884"
+    "name": "degree-of-opening-evi-eb104-30885"
   },
-  "30887": {
+  "30888": {
     "title": "Max fan speed (EB103)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "max-fan-speed-eb103-30887"
+    "name": "max-fan-speed-eb103-30888"
   },
-  "30888": {
+  "30889": {
     "title": "Min fan speed (EB103)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "min-fan-speed-eb103-30888"
+    "name": "min-fan-speed-eb103-30889"
   },
-  "30891": {
+  "30892": {
     "title": "Power (EB103)",
     "factor": 10,
     "unit": "kW",
     "size": "u16",
-    "name": "power-eb103-30891"
+    "name": "power-eb103-30892"
   },
-  "30893": {
+  "30894": {
     "title": "Defrosting index (EB103)",
     "factor": 1,
     "size": "u16",
-    "name": "defrosting-index-eb103-30893"
+    "name": "defrosting-index-eb103-30894"
   },
-  "30894": {
+  "30895": {
     "title": "Superheat reference EEV (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-eev-eb103-30894"
+    "name": "superheat-reference-eev-eb103-30895"
   },
-  "30895": {
+  "30896": {
     "title": "Superheat EEV (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-eev-eb103-30895"
+    "name": "superheat-eev-eb103-30896"
   },
-  "30896": {
+  "30897": {
     "title": "EEV-ssh-error (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-eb103-30896"
+    "name": "eev-ssh-error-eb103-30897"
   },
-  "30897": {
+  "30898": {
     "title": "Superheat temp. reference EEV (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-eev-eb103-30897"
+    "name": "superheat-temp-reference-eev-eb103-30898"
   },
-  "30898": {
+  "30899": {
     "title": "Set point value EEV (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-eev-eb103-30898"
+    "name": "set-point-value-eev-eb103-30899"
   },
-  "30899": {
+  "30900": {
     "title": "EEV PV (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-pv-eb103-30899"
+    "name": "eev-pv-eb103-30900"
   },
-  "30900": {
+  "30901": {
     "title": "EEV-te-error average open (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-eb103-30900"
+    "name": "eev-te-error-average-open-eb103-30901"
   },
-  "30901": {
+  "30902": {
     "title": "Degree of opening EEV (EB103)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-eev-eb103-30901"
+    "name": "degree-of-opening-eev-eb103-30902"
   },
-  "30902": {
+  "30903": {
     "title": "Superheat reference EVI (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-evi-eb103-30902"
+    "name": "superheat-reference-evi-eb103-30903"
   },
-  "30903": {
+  "30904": {
     "title": "Superheat EVI (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-evi-eb103-30903"
+    "name": "superheat-evi-eb103-30904"
   },
-  "30904": {
+  "30905": {
     "title": "EEV-ssh-error (EVI)(EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-evi-eb103-30904"
+    "name": "eev-ssh-error-evi-eb103-30905"
   },
-  "30905": {
+  "30906": {
     "title": "Superheat temp. reference EVI (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-evi-eb103-30905"
+    "name": "superheat-temp-reference-evi-eb103-30906"
   },
-  "30906": {
+  "30907": {
     "title": "Set point value EVI (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-evi-eb103-30906"
+    "name": "set-point-value-evi-eb103-30907"
   },
-  "30907": {
+  "30908": {
     "title": "EVI PV (EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pv-eb103-30907"
+    "name": "evi-pv-eb103-30908"
   },
-  "30908": {
+  "30909": {
     "title": "EEV-te-error average open (EVI)(EB103)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb103-30908"
+    "name": "eev-te-error-average-open-evi-eb103-30909"
   },
-  "30909": {
+  "30910": {
     "title": "Degree of opening EVI (EB103)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-evi-eb103-30909"
+    "name": "degree-of-opening-evi-eb103-30910"
   },
-  "30911": {
+  "30912": {
     "title": "Fan speed (EB102)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "fan-speed-eb102-30911"
+    "name": "fan-speed-eb102-30912"
   },
-  "30912": {
+  "30913": {
     "title": "Max fan speed (EB102)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "max-fan-speed-eb102-30912"
+    "name": "max-fan-speed-eb102-30913"
   },
-  "30913": {
+  "30914": {
     "title": "Min fan speed (EB102)",
     "factor": 1,
     "unit": "rpm",
     "size": "u16",
-    "name": "min-fan-speed-eb102-30913"
+    "name": "min-fan-speed-eb102-30914"
   },
-  "30916": {
+  "30917": {
     "title": "Power (EB102)",
     "factor": 10,
     "unit": "kW",
     "size": "u16",
-    "name": "power-eb102-30916"
+    "name": "power-eb102-30917"
   },
-  "30918": {
+  "30919": {
     "title": "Defrosting index (EB102)",
     "factor": 1,
     "size": "u16",
-    "name": "defrosting-index-eb102-30918"
+    "name": "defrosting-index-eb102-30919"
   },
-  "30919": {
+  "30920": {
     "title": "Superheat reference EEV (EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-eev-eb102-30919"
+    "name": "superheat-reference-eev-eb102-30920"
   },
-  "30920": {
+  "30921": {
     "title": "Superheat EEV (EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-eev-eb102-30920"
+    "name": "superheat-eev-eb102-30921"
   },
-  "30921": {
+  "30922": {
     "title": "EEV-ssh-error (EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-eb102-30921"
+    "name": "eev-ssh-error-eb102-30922"
   },
-  "30922": {
+  "30923": {
     "title": "Superheat temp. reference EEV (EB101)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-eev-eb101-30922"
+    "name": "superheat-temp-reference-eev-eb101-30923"
   },
-  "30923": {
+  "30924": {
     "title": "Set point value EEV (EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-eev-eb102-30923"
+    "name": "set-point-value-eev-eb102-30924"
   },
-  "30924": {
+  "30925": {
     "title": "EEV PV (EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-pv-eb102-30924"
+    "name": "eev-pv-eb102-30925"
   },
-  "30925": {
+  "30926": {
     "title": "EEV-te-error average open (EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-eb102-30925"
+    "name": "eev-te-error-average-open-eb102-30926"
   },
-  "30926": {
+  "30927": {
     "title": "Degree of opening EEV (EB102)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-eev-eb102-30926"
+    "name": "degree-of-opening-eev-eb102-30927"
   },
-  "30927": {
+  "30928": {
     "title": "Superheat reference EVI (EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-evi-eb102-30927"
+    "name": "superheat-reference-evi-eb102-30928"
   },
-  "30928": {
+  "30929": {
     "title": "Superheat EVI (EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-evi-eb102-30928"
+    "name": "superheat-evi-eb102-30929"
   },
-  "30929": {
+  "30930": {
     "title": "EEV-ssh-error (EVI)(EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-evi-eb102-30929"
+    "name": "eev-ssh-error-evi-eb102-30930"
   },
-  "30930": {
+  "30931": {
     "title": "Superheat temp. reference EVI (EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-evi-eb102-30930"
+    "name": "superheat-temp-reference-evi-eb102-30931"
   },
-  "30931": {
+  "30932": {
     "title": "Set point value EVI (EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-evi-eb102-30931"
+    "name": "set-point-value-evi-eb102-30932"
   },
-  "30932": {
+  "30933": {
     "title": "EVI PV (EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pv-eb102-30932"
+    "name": "evi-pv-eb102-30933"
   },
-  "30933": {
+  "30934": {
     "title": "EEV-te-error average open (EVI)(EB102)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb102-30933"
+    "name": "eev-te-error-average-open-evi-eb102-30934"
   },
-  "30934": {
+  "30935": {
     "title": "Degree of opening EVI (EB102)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-evi-eb102-30934"
+    "name": "degree-of-opening-evi-eb102-30935"
   },
-  "30960": {
+  "30961": {
     "title": "Wind speed, weather forecast",
     "factor": 10,
     "size": "u16",
-    "name": "wind-speed-weather-forecast-30960"
+    "name": "wind-speed-weather-forecast-30961"
   },
-  "30961": {
+  "30962": {
     "title": "Humidity, weather forecast",
     "factor": 10,
     "unit": "%",
     "size": "u16",
-    "name": "humidity-weather-forecast-30961"
+    "name": "humidity-weather-forecast-30962"
   },
-  "30962": {
+  "30963": {
     "title": "Temperature, weather forecast",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "temperature-weather-forecast-30962"
+    "name": "temperature-weather-forecast-30963"
   },
-  "30963": {
+  "30964": {
     "title": "Temperature, weather data (forecast)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "temperature-weather-data-forecast-30963"
+    "name": "temperature-weather-data-forecast-30964"
   },
-  "40018": {
+  "40019": {
     "title": "Limit DM",
     "factor": 10,
     "unit": "DM",
@@ -3244,35 +3244,35 @@
     "min": -30000.0,
     "max": 30000.0,
     "default": 0.0,
-    "name": "limit-dm-40018",
+    "name": "limit-dm-40019",
     "write": true
   },
-  "31017": {
+  "31018": {
     "title": "Calculated supply climate system 1",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "calculated-supply-climate-system-1-31017"
+    "name": "calculated-supply-climate-system-1-31018"
   },
-  "32195": {
+  "32196": {
     "title": "Class 1 alarm",
     "factor": 1,
     "size": "u8",
-    "name": "class-1-alarm-32195"
+    "name": "class-1-alarm-32196"
   },
-  "31018": {
+  "31019": {
     "title": "Frost protection status",
     "factor": 1,
     "size": "u16",
-    "name": "frost-protection-status-31018"
+    "name": "frost-protection-status-31019"
   },
-  "31019": {
+  "31020": {
     "title": "Cooling status",
     "factor": 1,
     "size": "u8",
-    "name": "cooling-status-31019"
+    "name": "cooling-status-31020"
   },
-  "31025": {
+  "31026": {
     "title": "Total run time additional heat",
     "factor": 10,
     "unit": "h",
@@ -3280,186 +3280,186 @@
     "min": 0.0,
     "max": 1000000.0,
     "default": 0.0,
-    "name": "total-run-time-additional-heat-31025"
+    "name": "total-run-time-additional-heat-31026"
   },
-  "31027": {
+  "31028": {
     "title": "Power internal additional heat",
     "factor": 100,
     "unit": "kW",
     "size": "s16",
-    "name": "power-internal-additional-heat-31027"
+    "name": "power-internal-additional-heat-31028"
   },
-  "31028": {
+  "31029": {
     "title": "Priority",
     "factor": 1,
     "size": "u8",
-    "name": "priority-31028"
+    "name": "priority-31029"
   },
-  "31029": {
+  "31030": {
     "title": "Operating mode internal add. heat",
     "factor": 1,
     "size": "u8",
-    "name": "operating-mode-internal-add-heat-31029"
+    "name": "operating-mode-internal-add-heat-31030"
   },
-  "31030": {
+  "31031": {
     "title": "Oper. mode shunt climate system 4",
     "factor": 1,
     "size": "u8",
-    "name": "oper-mode-shunt-climate-system-4-31030"
+    "name": "oper-mode-shunt-climate-system-4-31031"
   },
-  "31031": {
+  "31032": {
     "title": "Oper. mode shunt climate system 3",
     "factor": 1,
     "size": "u8",
-    "name": "oper-mode-shunt-climate-system-3-31031"
+    "name": "oper-mode-shunt-climate-system-3-31032"
   },
-  "31032": {
+  "31033": {
     "title": "Oper. mode shunt climate system 2",
     "factor": 1,
     "size": "u8",
-    "name": "oper-mode-shunt-climate-system-2-31032"
+    "name": "oper-mode-shunt-climate-system-2-31033"
   },
-  "31033": {
+  "31034": {
     "title": "Oper. mode shunt climate system 1",
     "factor": 1,
     "size": "u8",
-    "name": "oper-mode-shunt-climate-system-1-31033"
+    "name": "oper-mode-shunt-climate-system-1-31034"
   },
-  "31034": {
+  "31035": {
     "title": "Operating. mode shunt controlled additional heat",
     "factor": 1,
     "size": "u8",
-    "name": "operating-mode-shunt-controlled-additional-heat-31034"
+    "name": "operating-mode-shunt-controlled-additional-heat-31035"
   },
-  "31037": {
+  "31038": {
     "title": "Fan mode 1",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "fan-mode-1-31037"
+    "name": "fan-mode-1-31038"
   },
-  "31038": {
+  "31039": {
     "title": "Current hot water mode",
     "factor": 1,
     "size": "s8",
-    "name": "current-hot-water-mode-31038"
+    "name": "current-hot-water-mode-31039"
   },
-  "31041": {
+  "31042": {
     "title": "Min frequency compressor",
     "factor": 1,
     "unit": "Hz",
     "size": "s16",
-    "name": "min-frequency-compressor-31041"
+    "name": "min-frequency-compressor-31042"
   },
-  "31042": {
+  "31043": {
     "title": "Max frequency compressor",
     "factor": 1,
     "unit": "Hz",
     "size": "s16",
-    "name": "max-frequency-compressor-31042"
+    "name": "max-frequency-compressor-31043"
   },
-  "31046": {
+  "31047": {
     "title": "Compressor frequency, current",
     "factor": 10,
     "unit": "Hz",
     "size": "u16",
-    "name": "compressor-frequency-current-31046"
+    "name": "compressor-frequency-current-31047"
   },
-  "31047": {
+  "31048": {
     "title": "Inverter temperature",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "inverter-temperature-31047"
+    "name": "inverter-temperature-31048"
   },
-  "31048": {
+  "31049": {
     "title": "Compressor power input",
     "factor": 1,
     "unit": "W",
     "size": "u16",
-    "name": "compressor-power-input-31048"
+    "name": "compressor-power-input-31049"
   },
-  "31052": {
+  "31053": {
     "title": "Current compressor",
     "factor": 1,
     "unit": "mA",
     "size": "s16",
-    "name": "current-compressor-31052"
+    "name": "current-compressor-31053"
   },
-  "31053": {
+  "31054": {
     "title": "Blocking cooling",
     "factor": 1,
     "size": "u8",
-    "name": "blocking-cooling-31053"
+    "name": "blocking-cooling-31054"
   },
-  "31054": {
+  "31055": {
     "title": "External adjustment climate system 4",
     "factor": 1,
     "size": "u8",
-    "name": "external-adjustment-climate-system-4-31054"
+    "name": "external-adjustment-climate-system-4-31055"
   },
-  "31055": {
+  "31056": {
     "title": "External adjustment climate system 3",
     "factor": 1,
     "size": "u8",
-    "name": "external-adjustment-climate-system-3-31055"
+    "name": "external-adjustment-climate-system-3-31056"
   },
-  "31056": {
+  "31057": {
     "title": "External adjustment climate system 2",
     "factor": 1,
     "size": "u8",
-    "name": "external-adjustment-climate-system-2-31056"
+    "name": "external-adjustment-climate-system-2-31057"
   },
-  "31057": {
+  "31058": {
     "title": "External adjustment climate system 1",
     "factor": 1,
     "size": "u8",
-    "name": "external-adjustment-climate-system-1-31057"
+    "name": "external-adjustment-climate-system-1-31058"
   },
-  "31058": {
+  "31059": {
     "title": "External blocking",
     "factor": 1,
     "size": "u8",
-    "name": "external-blocking-31058"
+    "name": "external-blocking-31059"
   },
-  "31059": {
+  "31060": {
     "title": "Blocked",
     "factor": 1,
     "size": "u8",
-    "name": "blocked-31059"
+    "name": "blocked-31060"
   },
-  "31060": {
+  "31061": {
     "title": "External blocking, active cooling (HPAC)",
     "factor": 1,
     "size": "u8",
-    "name": "external-blocking-active-cooling-hpac-31060"
+    "name": "external-blocking-active-cooling-hpac-31061"
   },
-  "31061": {
+  "31062": {
     "title": "External blocking, passive cooling (HPAC)",
     "factor": 1,
     "size": "u8",
-    "name": "external-blocking-passive-cooling-hpac-31061"
+    "name": "external-blocking-passive-cooling-hpac-31062"
   },
-  "31062": {
+  "31063": {
     "title": "Step controlled add. heat blocking",
     "factor": 1,
     "size": "u8",
-    "name": "step-controlled-add-heat-blocking-31062"
+    "name": "step-controlled-add-heat-blocking-31063"
   },
-  "31063": {
+  "31064": {
     "title": "Hot water circulation (GP11)",
     "factor": 1,
     "size": "u8",
-    "name": "hot-water-circulation-gp11-31063"
+    "name": "hot-water-circulation-gp11-31064"
   },
-  "31065": {
+  "31066": {
     "title": "Compressor frequency",
     "factor": 1,
     "unit": "Hz",
     "size": "u16",
-    "name": "compressor-frequency-31065"
+    "name": "compressor-frequency-31066"
   },
-  "31069": {
+  "31070": {
     "title": "Total HW run time additional heat",
     "factor": 10,
     "unit": "h",
@@ -3467,37 +3467,37 @@
     "min": 0.0,
     "max": 9999999.0,
     "default": 0.0,
-    "name": "total-hw-run-time-additional-heat-31069"
+    "name": "total-hw-run-time-additional-heat-31070"
   },
-  "31078": {
+  "31079": {
     "title": "More hot water status",
     "factor": 1,
     "size": "u8",
-    "name": "more-hot-water-status-31078"
+    "name": "more-hot-water-status-31079"
   },
-  "31079": {
+  "31080": {
     "title": "Relay status (HPAC)",
     "factor": 1,
     "size": "u8",
-    "name": "relay-status-hpac-31079"
+    "name": "relay-status-hpac-31080"
   },
-  "40019": {
+  "40020": {
     "title": "Holiday function status",
     "factor": 1,
     "size": "s8",
-    "name": "holiday-function-status-40019",
+    "name": "holiday-function-status-40020",
     "write": true
   },
-  "31083": {
+  "31084": {
     "title": "Compressor starter",
     "factor": 1,
     "size": "s32",
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "compressor-starter-31083"
+    "name": "compressor-starter-31084"
   },
-  "31087": {
+  "31088": {
     "title": "Total run time compressor",
     "factor": 1,
     "unit": "h",
@@ -3505,9 +3505,9 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "total-run-time-compressor-31087"
+    "name": "total-run-time-compressor-31088"
   },
-  "31091": {
+  "31092": {
     "title": "Total run time compressor hot water",
     "factor": 1,
     "unit": "h",
@@ -3515,147 +3515,141 @@
     "min": -2147483648.0,
     "max": 2147483647.0,
     "default": 0.0,
-    "name": "total-run-time-compressor-hot-water-31091"
+    "name": "total-run-time-compressor-hot-water-31092"
   },
-  "31094": {
+  "31095": {
     "title": "Operating mode compressor",
     "factor": 1,
     "size": "u8",
-    "name": "operating-mode-compressor-31094"
+    "name": "operating-mode-compressor-31095"
   },
-  "31096": {
+  "31097": {
     "title": "Operating mode heating medium pump",
     "factor": 1,
     "size": "u8",
-    "name": "operating-mode-heating-medium-pump-31096"
+    "name": "operating-mode-heating-medium-pump-31097"
   },
-  "31098": {
+  "31099": {
     "title": "Operating mode brine pump",
     "factor": 1,
     "size": "u8",
-    "name": "operating-mode-brine-pump-31098"
+    "name": "operating-mode-brine-pump-31099"
   },
-  "31100": {
+  "31101": {
     "title": "Compressor status",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-status-31100"
+    "name": "compressor-status-31101"
   },
-  "31102": {
+  "31103": {
     "title": "Heating medium pump speed (GP1)",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "heating-medium-pump-speed-gp1-31102"
+    "name": "heating-medium-pump-speed-gp1-31103"
   },
-  "31104": {
+  "31105": {
     "title": "Brine pump speed (GP2)",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "brine-pump-speed-gp2-31104"
+    "name": "brine-pump-speed-gp2-31105"
   },
-  "31108": {
+  "31109": {
     "title": "Docked compressors heating",
     "factor": 1,
     "size": "u8",
-    "name": "docked-compressors-heating-31108"
+    "name": "docked-compressors-heating-31109"
   },
-  "31109": {
+  "31110": {
     "title": "Docked compressors hot water",
     "factor": 1,
     "size": "u8",
-    "name": "docked-compressors-hot-water-31109"
+    "name": "docked-compressors-hot-water-31110"
   },
-  "31110": {
+  "31111": {
     "title": "Docked compressors pool 1",
     "factor": 1,
     "size": "u8",
-    "name": "docked-compressors-pool-1-31110"
+    "name": "docked-compressors-pool-1-31111"
   },
-  "32196": {
+  "32197": {
     "title": "Reversing valve hot water (QN10)",
     "factor": 1,
     "size": "u8",
-    "name": "reversing-valve-hot-water-qn10-32196"
+    "name": "reversing-valve-hot-water-qn10-32197"
   },
-  "31111": {
+  "31112": {
     "title": "Cooling activated (FLM 4)",
     "factor": 1,
     "size": "u8",
-    "name": "cooling-activated-flm-4-31111"
+    "name": "cooling-activated-flm-4-31112"
   },
-  "31112": {
+  "31113": {
     "title": "Cooling activated (FLM 3)",
     "factor": 1,
     "size": "u8",
-    "name": "cooling-activated-flm-3-31112"
+    "name": "cooling-activated-flm-3-31113"
   },
-  "31113": {
+  "31114": {
     "title": "Cooling activated (FLM 2)",
     "factor": 1,
     "size": "u8",
-    "name": "cooling-activated-flm-2-31113"
+    "name": "cooling-activated-flm-2-31114"
   },
-  "31114": {
+  "31115": {
     "title": "Cooling activated (FLM 1)",
     "factor": 1,
     "size": "u8",
-    "name": "cooling-activated-flm-1-31114"
+    "name": "cooling-activated-flm-1-31115"
   },
-  "31117": {
+  "31118": {
     "title": "Relay status, base board (EB100-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "relay-status-base-board-eb100-ep14-31117"
+    "name": "relay-status-base-board-eb100-ep14-31118"
   },
-  "31119": {
+  "31120": {
     "title": "Relay status, imm. heat. board (EB100-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "relay-status-imm-heat-board-eb100-ep14-31119"
+    "name": "relay-status-imm-heat-board-eb100-ep14-31120"
   },
-  "31120": {
+  "31121": {
     "title": "Current status",
     "factor": 1,
     "size": "u32",
-    "name": "current-status-31120"
+    "name": "current-status-31121"
   },
-  "31122": {
+  "31123": {
     "title": "Functionality, heat pump (EP14)",
     "factor": 1,
     "size": "u32",
-    "name": "functionality-heat-pump-ep14-31122"
+    "name": "functionality-heat-pump-ep14-31123"
   },
-  "31124": {
+  "31125": {
     "title": "Active heat pumps",
     "factor": 1,
     "size": "u16",
-    "name": "active-heat-pumps-31124"
+    "name": "active-heat-pumps-31125"
   },
-  "31125": {
+  "31126": {
     "title": "Functionality, heat pump (EP15)",
     "factor": 1,
     "size": "u32",
-    "name": "functionality-heat-pump-ep15-31125"
+    "name": "functionality-heat-pump-ep15-31126"
   },
-  "31129": {
+  "31130": {
     "title": "Operating mode HW comfort",
     "factor": 1,
     "size": "u8",
-    "name": "operating-mode-hw-comfort-31129"
+    "name": "operating-mode-hw-comfort-31130"
   },
-  "31130": {
+  "31131": {
     "title": "Operating mode HW comfort additional heat",
     "factor": 1,
     "size": "u8",
-    "name": "operating-mode-hw-comfort-additional-heat-31130"
-  },
-  "31131": {
-    "title": "Blocked",
-    "factor": 1,
-    "size": "u8",
-    "name": "blocked-31131"
+    "name": "operating-mode-hw-comfort-additional-heat-31131"
   },
   "31132": {
     "title": "Blocked",
@@ -3664,280 +3658,286 @@
     "name": "blocked-31132"
   },
   "31133": {
+    "title": "Blocked",
+    "factor": 1,
+    "size": "u8",
+    "name": "blocked-31133"
+  },
+  "31134": {
     "title": "Pool 2 (QN19)",
     "factor": 1,
     "size": "u8",
-    "name": "pool-2-qn19-31133"
+    "name": "pool-2-qn19-31134"
   },
-  "31134": {
+  "31135": {
     "title": "Pool 1 (QN19)",
     "factor": 1,
     "size": "u8",
-    "name": "pool-1-qn19-31134"
+    "name": "pool-1-qn19-31135"
   },
-  "31135": {
+  "31136": {
     "title": "Docked compressors pool 2",
     "factor": 1,
     "size": "u8",
-    "name": "docked-compressors-pool-2-31135"
+    "name": "docked-compressors-pool-2-31136"
   },
-  "31496": {
+  "31497": {
     "title": "Version (EB100)",
     "factor": 1,
     "size": "u16",
-    "name": "version-eb100-31496"
+    "name": "version-eb100-31497"
   },
-  "31497": {
+  "31498": {
     "title": "Heat pump type (EB100)",
     "factor": 1,
     "size": "u8",
-    "name": "heat-pump-type-eb100-31497"
+    "name": "heat-pump-type-eb100-31498"
   },
-  "31498": {
+  "31499": {
     "title": "Compressor size (EB100)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-size-eb100-31498"
+    "name": "compressor-size-eb100-31499"
   },
-  "31515": {
+  "31516": {
     "title": "Compressor, oper. time, total (EB100-EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-oper-time-total-eb100-ep15-31515"
+    "name": "compressor-oper-time-total-eb100-ep15-31516"
   },
-  "31517": {
+  "31518": {
     "title": "Compressor, oper. time, hot water (EB100-EP15)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-oper-time-hot-water-eb100-ep15-31517"
+    "name": "compressor-oper-time-hot-water-eb100-ep15-31518"
   },
-  "31520": {
+  "31521": {
     "title": "Return line (EB100-BT3)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-eb100-bt3-31520"
+    "name": "return-line-eb100-bt3-31521"
   },
-  "31521": {
+  "31522": {
     "title": "Brine sensor in (EB100-BT10)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "brine-sensor-in-eb100-bt10-31521"
+    "name": "brine-sensor-in-eb100-bt10-31522"
   },
-  "31522": {
+  "31523": {
     "title": "Brine sensor out (EB100-BT11)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "brine-sensor-out-eb100-bt11-31522"
+    "name": "brine-sensor-out-eb100-bt11-31523"
   },
-  "31523": {
+  "31524": {
     "title": "Condenser (EB100-BT2)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "condenser-eb100-bt2-31523"
+    "name": "condenser-eb100-bt2-31524"
   },
-  "31524": {
+  "31525": {
     "title": "Discharge sensor (EB100-BT14)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "discharge-sensor-eb100-bt14-31524"
+    "name": "discharge-sensor-eb100-bt14-31525"
   },
-  "31525": {
+  "31526": {
     "title": "Liquid line sensor (EB100-BT15)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "liquid-line-sensor-eb100-bt15-31525"
+    "name": "liquid-line-sensor-eb100-bt15-31526"
   },
-  "31526": {
+  "31527": {
     "title": "Suction gas sensor (EB100-BT17)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "suction-gas-sensor-eb100-bt17-31526"
+    "name": "suction-gas-sensor-eb100-bt17-31527"
   },
-  "31527": {
+  "31528": {
     "title": "Compressor sensor (EB100-BT29)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "compressor-sensor-eb100-bt29-31527"
+    "name": "compressor-sensor-eb100-bt29-31528"
   },
-  "31528": {
+  "31529": {
     "title": "Low press (EB100-BP8)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "low-press-eb100-bp8-31528"
+    "name": "low-press-eb100-bp8-31529"
   },
-  "31529": {
+  "31530": {
     "title": "Compressor status (EB100)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-status-eb100-31529"
+    "name": "compressor-status-eb100-31530"
   },
-  "31530": {
+  "31531": {
     "title": "Compressor, time to start (EB100-EP14)",
     "factor": 1,
     "unit": "min",
     "size": "u8",
-    "name": "compressor-time-to-start-eb100-ep14-31530"
+    "name": "compressor-time-to-start-eb100-ep14-31531"
   },
-  "31531": {
+  "31532": {
     "title": "Relay status (EB100-EP14)",
     "factor": 1,
     "size": "u16",
-    "name": "relay-status-eb100-ep14-31531"
+    "name": "relay-status-eb100-ep14-31532"
   },
-  "31532": {
+  "31533": {
     "title": "Heating medium pump (EB100)",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "heating-medium-pump-eb100-31532"
+    "name": "heating-medium-pump-eb100-31533"
   },
-  "31533": {
+  "31534": {
     "title": "Brine pump (EB100)",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "brine-pump-eb100-31533"
+    "name": "brine-pump-eb100-31534"
   },
-  "31534": {
+  "31535": {
     "title": "Compressor, number of starts (EB100-EP14)",
     "factor": 1,
     "size": "u32",
-    "name": "compressor-number-of-starts-eb100-ep14-31534"
+    "name": "compressor-number-of-starts-eb100-ep14-31535"
   },
-  "31536": {
+  "31537": {
     "title": "Compressor, oper. time, total (EB100-EP14)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-oper-time-total-eb100-ep14-31536"
+    "name": "compressor-oper-time-total-eb100-ep14-31537"
   },
-  "31538": {
+  "31539": {
     "title": "Compressor, oper. time, hot water (EB100-EP14)",
     "factor": 1,
     "unit": "h",
     "size": "u32",
-    "name": "compressor-oper-time-hot-water-eb100-ep14-31538"
+    "name": "compressor-oper-time-hot-water-eb100-ep14-31539"
   },
-  "31541": {
+  "31542": {
     "title": "Compressor, requested (EB108-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb108-ep15-31541"
+    "name": "compressor-requested-eb108-ep15-31542"
   },
-  "31542": {
+  "31543": {
     "title": "Compressor, requested (EB108-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb108-ep14-31542"
+    "name": "compressor-requested-eb108-ep14-31543"
   },
-  "31543": {
+  "31544": {
     "title": "Compressor, requested (EB107-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb107-ep15-31543"
+    "name": "compressor-requested-eb107-ep15-31544"
   },
-  "31544": {
+  "31545": {
     "title": "Compressor, requested (EB107-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb107-ep14-31544"
+    "name": "compressor-requested-eb107-ep14-31545"
   },
-  "31545": {
+  "31546": {
     "title": "Compressor, requested (EB106-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb106-ep15-31545"
+    "name": "compressor-requested-eb106-ep15-31546"
   },
-  "31546": {
+  "31547": {
     "title": "Compressor, requested (EB106-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb106-ep14-31546"
+    "name": "compressor-requested-eb106-ep14-31547"
   },
-  "31547": {
+  "31548": {
     "title": "Compressor, requested (EB105-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb105-ep15-31547"
+    "name": "compressor-requested-eb105-ep15-31548"
   },
-  "31548": {
+  "31549": {
     "title": "Compressor, requested (EB105-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb105-ep14-31548"
+    "name": "compressor-requested-eb105-ep14-31549"
   },
-  "31549": {
+  "31550": {
     "title": "Compressor, requested (EB104-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb104-ep15-31549"
+    "name": "compressor-requested-eb104-ep15-31550"
   },
-  "31550": {
+  "31551": {
     "title": "Compressor, requested (EB104-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb104-ep14-31550"
+    "name": "compressor-requested-eb104-ep14-31551"
   },
-  "31551": {
+  "31552": {
     "title": "Compressor, requested (EB103-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb103-ep15-31551"
+    "name": "compressor-requested-eb103-ep15-31552"
   },
-  "31552": {
+  "31553": {
     "title": "Compressor, requested (EB103-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb103-ep14-31552"
+    "name": "compressor-requested-eb103-ep14-31553"
   },
-  "31553": {
+  "31554": {
     "title": "Compressor, requested (EB102-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb102-ep15-31553"
+    "name": "compressor-requested-eb102-ep15-31554"
   },
-  "31554": {
+  "31555": {
     "title": "Compressor, requested (EB102-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb102-ep14-31554"
+    "name": "compressor-requested-eb102-ep14-31555"
   },
-  "31555": {
+  "31556": {
     "title": "Compressor, requested (EB101-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb101-ep15-31555"
+    "name": "compressor-requested-eb101-ep15-31556"
   },
-  "31556": {
+  "31557": {
     "title": "Compressor, requested (EB101-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-requested-eb101-ep14-31556"
+    "name": "compressor-requested-eb101-ep14-31557"
   },
-  "31561": {
+  "31562": {
     "title": "Date, periodic hot water",
     "factor": 1,
     "size": "u16",
-    "name": "date-periodic-hot-water-31561"
+    "name": "date-periodic-hot-water-31562"
   },
-  "32174": {
+  "32175": {
     "title": "Blocked compressors",
     "factor": 1,
     "size": "u32",
-    "name": "blocked-compressors-32174"
+    "name": "blocked-compressors-32175"
   },
-  "40020": {
+  "40021": {
     "title": "Cooling degree minutes",
     "factor": 10,
     "unit": "DM",
@@ -3945,59 +3945,59 @@
     "min": -30000.0,
     "max": 30000.0,
     "default": 0.0,
-    "name": "cooling-degree-minutes-40020",
+    "name": "cooling-degree-minutes-40021",
     "write": true
   },
-  "31567": {
+  "31568": {
     "title": "Calculated cooling supply climate system 1",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "calculated-cooling-supply-climate-system-1-31567"
+    "name": "calculated-cooling-supply-climate-system-1-31568"
   },
-  "31568": {
+  "31569": {
     "title": "Status (ACS)",
     "factor": 1,
     "size": "u8",
-    "name": "status-acs-31568"
+    "name": "status-acs-31569"
   },
-  "31569": {
+  "31570": {
     "title": "Status, heating dumping (ACS)",
     "factor": 1,
     "size": "u8",
-    "name": "status-heating-dumping-acs-31569"
+    "name": "status-heating-dumping-acs-31570"
   },
-  "31570": {
+  "31571": {
     "title": "Status, cooling dumping (ACS)",
     "factor": 1,
     "size": "u8",
-    "name": "status-cooling-dumping-acs-31570"
+    "name": "status-cooling-dumping-acs-31571"
   },
-  "31571": {
+  "31572": {
     "title": "Used compressors hot water",
     "factor": 1,
     "size": "u8",
-    "name": "used-compressors-hot-water-31571"
+    "name": "used-compressors-hot-water-31572"
   },
-  "31572": {
+  "31573": {
     "title": "Used compressors heating",
     "factor": 1,
     "size": "u8",
-    "name": "used-compressors-heating-31572"
+    "name": "used-compressors-heating-31573"
   },
-  "31573": {
+  "31574": {
     "title": "Used compressors pool 1",
     "factor": 1,
     "size": "u8",
-    "name": "used-compressors-pool-1-31573"
+    "name": "used-compressors-pool-1-31574"
   },
-  "31574": {
+  "31575": {
     "title": "Used compressors pool 2",
     "factor": 1,
     "size": "u8",
-    "name": "used-compressors-pool-2-31574"
+    "name": "used-compressors-pool-2-31575"
   },
-  "31575": {
+  "31576": {
     "title": "Hot water, including int. add. heat",
     "factor": 10,
     "unit": "kWh",
@@ -4005,9 +4005,9 @@
     "min": 0.0,
     "max": 9999999.0,
     "default": 0.0,
-    "name": "hot-water-including-int-add-heat-31575"
+    "name": "hot-water-including-int-add-heat-31576"
   },
-  "31577": {
+  "31578": {
     "title": "Heating, including int. add. heat",
     "factor": 10,
     "unit": "kWh",
@@ -4015,9 +4015,9 @@
     "min": 0.0,
     "max": 9999999.0,
     "default": 0.0,
-    "name": "heating-including-int-add-heat-31577"
+    "name": "heating-including-int-add-heat-31578"
   },
-  "31583": {
+  "31584": {
     "title": "Hot water, compressor only",
     "factor": 10,
     "unit": "kWh",
@@ -4025,9 +4025,9 @@
     "min": 0.0,
     "max": 9999999.0,
     "default": 0.0,
-    "name": "hot-water-compressor-only-31583"
+    "name": "hot-water-compressor-only-31584"
   },
-  "31585": {
+  "31586": {
     "title": "Heating, compressor only",
     "factor": 10,
     "unit": "kWh",
@@ -4035,822 +4035,822 @@
     "min": 0.0,
     "max": 9999999.0,
     "default": 0.0,
-    "name": "heating-compressor-only-31585"
+    "name": "heating-compressor-only-31586"
   },
-  "31588": {
+  "31589": {
     "title": "Used compressors cooling",
     "factor": 1,
     "size": "u8",
-    "name": "used-compressors-cooling-31588"
+    "name": "used-compressors-cooling-31589"
   },
-  "31623": {
+  "31624": {
     "title": "(EB100-EP15-BT28)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eb100-ep15-bt28-31623"
+    "name": "eb100-ep15-bt28-31624"
   },
-  "31624": {
+  "31625": {
     "title": "(EB100-EP15-BT16)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eb100-ep15-bt16-31624"
+    "name": "eb100-ep15-bt16-31625"
   },
-  "31625": {
+  "31626": {
     "title": "(EB100-EP14-BT28)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eb100-ep14-bt28-31625"
+    "name": "eb100-ep14-bt28-31626"
   },
-  "31626": {
+  "31627": {
     "title": "(EB100-EP14-BT16)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eb100-ep14-bt16-31626"
+    "name": "eb100-ep14-bt16-31627"
   },
-  "31628": {
+  "31629": {
     "title": "Docked compressors external control",
     "factor": 1,
     "size": "u8",
-    "name": "docked-compressors-external-control-31628"
+    "name": "docked-compressors-external-control-31629"
   },
-  "31687": {
+  "31688": {
     "title": "Bit register (EB100)",
     "factor": 1,
     "size": "u8",
-    "name": "bit-register-eb100-31687"
+    "name": "bit-register-eb100-31688"
   },
-  "31688": {
+  "31689": {
     "title": "Controlling hot water sensor (EB100-BT6)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "controlling-hot-water-sensor-eb100-bt6-31688"
+    "name": "controlling-hot-water-sensor-eb100-bt6-31689"
   },
-  "31689": {
+  "31690": {
     "title": "Display hot water sensor (EB100-BT7)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "display-hot-water-sensor-eb100-bt7-31689"
+    "name": "display-hot-water-sensor-eb100-bt7-31690"
   },
-  "31690": {
+  "31691": {
     "title": "Supply temperature sensor (EB100-BT2)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "supply-temperature-sensor-eb100-bt2-31690"
+    "name": "supply-temperature-sensor-eb100-bt2-31691"
   },
-  "31691": {
+  "31692": {
     "title": "Compressor status (EB100-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-status-eb100-ep15-31691"
+    "name": "compressor-status-eb100-ep15-31692"
   },
-  "31692": {
+  "31693": {
     "title": "Compressor status (EB100-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-status-eb100-ep14-31692"
+    "name": "compressor-status-eb100-ep14-31693"
   },
-  "31694": {
+  "31695": {
     "title": "Docked compressors cooling",
     "factor": 1,
     "size": "u8",
-    "name": "docked-compressors-cooling-31694"
+    "name": "docked-compressors-cooling-31695"
   },
-  "31695": {
+  "31696": {
     "title": "BP4, unprocessed (EB108-EP15)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb108-ep15-31695"
+    "name": "bp4-unprocessed-eb108-ep15-31696"
   },
-  "31697": {
+  "31698": {
     "title": "Low pressure (EB108-EP15--BP8)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "low-pressure-eb108-ep15-bp8-31697"
+    "name": "low-pressure-eb108-ep15-bp8-31698"
   },
-  "31699": {
+  "31700": {
     "title": "Prot. status (EB108-EP15)",
     "factor": 1,
     "size": "u16",
-    "name": "prot-status-eb108-ep15-31699"
+    "name": "prot-status-eb108-ep15-31700"
   },
-  "31700": {
+  "31701": {
     "title": "Defrosting (EB108-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb108-ep15-31700"
+    "name": "defrosting-eb108-ep15-31701"
   },
-  "31702": {
+  "31703": {
     "title": "BP4, unprocessed (EB108-EP14)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb108-ep14-31702"
+    "name": "bp4-unprocessed-eb108-ep14-31703"
   },
-  "31707": {
+  "31708": {
     "title": "Defrosting (EB108)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb108-31707"
+    "name": "defrosting-eb108-31708"
   },
-  "31709": {
+  "31710": {
     "title": "BP4, unprocessed (EB107-EP15)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb107-ep15-31709"
+    "name": "bp4-unprocessed-eb107-ep15-31710"
   },
-  "31711": {
+  "31712": {
     "title": "Low pressure (EB107-EP15--BP8)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "low-pressure-eb107-ep15-bp8-31711"
+    "name": "low-pressure-eb107-ep15-bp8-31712"
   },
-  "31713": {
+  "31714": {
     "title": "Prot. status (EB107-EP15)",
     "factor": 1,
     "size": "u16",
-    "name": "prot-status-eb107-ep15-31713"
+    "name": "prot-status-eb107-ep15-31714"
   },
-  "31714": {
+  "31715": {
     "title": "Defrosting (EB107-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb107-ep15-31714"
+    "name": "defrosting-eb107-ep15-31715"
   },
-  "31715": {
+  "31716": {
     "title": "Power (EB107-EP15)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb107-ep15-31715"
+    "name": "power-eb107-ep15-31716"
   },
-  "31716": {
+  "31717": {
     "title": "BP4, unprocessed (EB107-EP14)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb107-ep14-31716"
+    "name": "bp4-unprocessed-eb107-ep14-31717"
   },
-  "31721": {
+  "31722": {
     "title": "Defrosting (EB107)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb107-31721"
+    "name": "defrosting-eb107-31722"
   },
-  "31722": {
+  "31723": {
     "title": "Power (EB107-EP14)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb107-ep14-31722"
+    "name": "power-eb107-ep14-31723"
   },
-  "31723": {
+  "31724": {
     "title": "BP4, unprocessed (EB106-EP15)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb106-ep15-31723"
+    "name": "bp4-unprocessed-eb106-ep15-31724"
   },
-  "31725": {
+  "31726": {
     "title": "Low pressure (EB106-EP15--BP8)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "low-pressure-eb106-ep15-bp8-31725"
+    "name": "low-pressure-eb106-ep15-bp8-31726"
   },
-  "31727": {
+  "31728": {
     "title": "Prot. status (EB106-EP15)",
     "factor": 1,
     "size": "u16",
-    "name": "prot-status-eb106-ep15-31727"
+    "name": "prot-status-eb106-ep15-31728"
   },
-  "31728": {
+  "31729": {
     "title": "Defrosting (EB106-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb106-ep15-31728"
+    "name": "defrosting-eb106-ep15-31729"
   },
-  "31729": {
+  "31730": {
     "title": "Power (EB106-EP15)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb106-ep15-31729"
+    "name": "power-eb106-ep15-31730"
   },
-  "31730": {
+  "31731": {
     "title": "BP4, unprocessed (EB106-EP14)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb106-ep14-31730"
+    "name": "bp4-unprocessed-eb106-ep14-31731"
   },
-  "31735": {
+  "31736": {
     "title": "Defrosting (EB106)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb106-31735"
+    "name": "defrosting-eb106-31736"
   },
-  "31736": {
+  "31737": {
     "title": "Power (EB106-EP14)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb106-ep14-31736"
+    "name": "power-eb106-ep14-31737"
   },
-  "31737": {
+  "31738": {
     "title": "BP4, unprocessed (EB105-EP15)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb105-ep15-31737"
+    "name": "bp4-unprocessed-eb105-ep15-31738"
   },
-  "31739": {
+  "31740": {
     "title": "Low pressure (EB105-EP15--BP8)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "low-pressure-eb105-ep15-bp8-31739"
+    "name": "low-pressure-eb105-ep15-bp8-31740"
   },
-  "31741": {
+  "31742": {
     "title": "Prot. status (EB105-EP15)",
     "factor": 1,
     "size": "u16",
-    "name": "prot-status-eb105-ep15-31741"
+    "name": "prot-status-eb105-ep15-31742"
   },
-  "31742": {
+  "31743": {
     "title": "Defrosting (EB105-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb105-ep15-31742"
+    "name": "defrosting-eb105-ep15-31743"
   },
-  "31743": {
+  "31744": {
     "title": "Power (EB105-EP15)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb105-ep15-31743"
+    "name": "power-eb105-ep15-31744"
   },
-  "31744": {
+  "31745": {
     "title": "BP4, unprocessed (EB105-EP14)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb105-ep14-31744"
+    "name": "bp4-unprocessed-eb105-ep14-31745"
   },
-  "31749": {
+  "31750": {
     "title": "Defrosting (EB105)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb105-31749"
+    "name": "defrosting-eb105-31750"
   },
-  "31750": {
+  "31751": {
     "title": "Power (EB105-EP15)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb105-ep15-31750"
+    "name": "power-eb105-ep15-31751"
   },
-  "31751": {
+  "31752": {
     "title": "BP4, unprocessed (EB104-EP15)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb104-ep15-31751"
+    "name": "bp4-unprocessed-eb104-ep15-31752"
   },
-  "31753": {
+  "31754": {
     "title": "Low pressure (EB104-EP15--BP8)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "low-pressure-eb104-ep15-bp8-31753"
+    "name": "low-pressure-eb104-ep15-bp8-31754"
   },
-  "31755": {
+  "31756": {
     "title": "Prot. status (EB104-EP15)",
     "factor": 1,
     "size": "u16",
-    "name": "prot-status-eb104-ep15-31755"
+    "name": "prot-status-eb104-ep15-31756"
   },
-  "31767": {
+  "31768": {
     "title": "Low pressure (EB103-EP15--BP8)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "low-pressure-eb103-ep15-bp8-31767"
+    "name": "low-pressure-eb103-ep15-bp8-31768"
   },
-  "31772": {
+  "31773": {
     "title": "BP4, unprocessed (EB103-EP14)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb103-ep14-31772"
+    "name": "bp4-unprocessed-eb103-ep14-31773"
   },
-  "31777": {
+  "31778": {
     "title": "Defrosting (EB103)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb103-31777"
+    "name": "defrosting-eb103-31778"
   },
-  "31778": {
+  "31779": {
     "title": "Power (EB103-EP14)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb103-ep14-31778"
+    "name": "power-eb103-ep14-31779"
   },
-  "31779": {
+  "31780": {
     "title": "BP4, unprocessed (EB102-EP15)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb102-ep15-31779"
+    "name": "bp4-unprocessed-eb102-ep15-31780"
   },
-  "31781": {
+  "31782": {
     "title": "Low pressure (EB102-EP15--BP8)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "low-pressure-eb102-ep15-bp8-31781"
+    "name": "low-pressure-eb102-ep15-bp8-31782"
   },
-  "31783": {
+  "31784": {
     "title": "Prot. status (EB102-EP15)",
     "factor": 1,
     "size": "u16",
-    "name": "prot-status-eb102-ep15-31783"
+    "name": "prot-status-eb102-ep15-31784"
   },
-  "31784": {
+  "31785": {
     "title": "Defrosting (EB102-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb102-ep15-31784"
+    "name": "defrosting-eb102-ep15-31785"
   },
-  "31785": {
+  "31786": {
     "title": "Power (EB102-EP15)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb102-ep15-31785"
+    "name": "power-eb102-ep15-31786"
   },
-  "31786": {
+  "31787": {
     "title": "BP4, unprocessed (EB102-EP14)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb102-ep14-31786"
+    "name": "bp4-unprocessed-eb102-ep14-31787"
   },
-  "31791": {
+  "31792": {
     "title": "Defrosting (EB102)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb102-31791"
+    "name": "defrosting-eb102-31792"
   },
-  "31792": {
+  "31793": {
     "title": "Power (EB102-EP14)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb102-ep14-31792"
+    "name": "power-eb102-ep14-31793"
   },
-  "31793": {
+  "31794": {
     "title": "BP4, unprocessed (EB101-EP15)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb101-ep15-31793"
+    "name": "bp4-unprocessed-eb101-ep15-31794"
   },
-  "31795": {
+  "31796": {
     "title": "Low pressure (EB101-EP15-BP8)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "low-pressure-eb101-ep15-bp8-31795"
+    "name": "low-pressure-eb101-ep15-bp8-31796"
   },
-  "31797": {
+  "31798": {
     "title": "Prot. status (EB101-EP15)",
     "factor": 1,
     "size": "u16",
-    "name": "prot-status-eb101-ep15-31797"
+    "name": "prot-status-eb101-ep15-31798"
   },
-  "31798": {
+  "31799": {
     "title": "Defrosting (EB101-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb101-ep15-31798"
+    "name": "defrosting-eb101-ep15-31799"
   },
-  "31799": {
+  "31800": {
     "title": "Power (EB101-EP15)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb101-ep15-31799"
+    "name": "power-eb101-ep15-31800"
   },
-  "31800": {
+  "31801": {
     "title": "BP4, unprocessed (EB101-EP14)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb101-ep14-31800"
+    "name": "bp4-unprocessed-eb101-ep14-31801"
   },
-  "31805": {
+  "31806": {
     "title": "Defrosting (EB101)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb101-31805"
+    "name": "defrosting-eb101-31806"
   },
-  "31806": {
+  "31807": {
     "title": "Power (EB101-EP14)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb101-ep14-31806"
+    "name": "power-eb101-ep14-31807"
   },
-  "31807": {
+  "31808": {
     "title": "BP4, unprocessed (EB100-EP15)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb100-ep15-31807"
+    "name": "bp4-unprocessed-eb100-ep15-31808"
   },
-  "31808": {
+  "31809": {
     "title": "Pressure sensor, condenser (EB100-EP15-BP4)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "pressure-sensor-condenser-eb100-ep15-bp4-31808"
+    "name": "pressure-sensor-condenser-eb100-ep15-bp4-31809"
   },
-  "31809": {
+  "31810": {
     "title": "Low pressure (EB100-EP15-BP8)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "low-pressure-eb100-ep15-bp8-31809"
+    "name": "low-pressure-eb100-ep15-bp8-31810"
   },
-  "31811": {
+  "31812": {
     "title": "Prot. status (EB100-EP15)",
     "factor": 1,
     "size": "u16",
-    "name": "prot-status-eb100-ep15-31811"
+    "name": "prot-status-eb100-ep15-31812"
   },
-  "31812": {
+  "31813": {
     "title": "Defrosting (EB100-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb100-ep15-31812"
+    "name": "defrosting-eb100-ep15-31813"
   },
-  "31813": {
+  "31814": {
     "title": "Power (EB100-EP15)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb100-ep15-31813"
+    "name": "power-eb100-ep15-31814"
   },
-  "31814": {
+  "31815": {
     "title": "BP4, unprocessed (EB100-EP14)",
     "factor": 1,
     "size": "s16",
-    "name": "bp4-unprocessed-eb100-ep14-31814"
+    "name": "bp4-unprocessed-eb100-ep14-31815"
   },
-  "31815": {
+  "31816": {
     "title": "Pressure sensor, condenser (EB100-EP14-BP4)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "pressure-sensor-condenser-eb100-ep14-bp4-31815"
+    "name": "pressure-sensor-condenser-eb100-ep14-bp4-31816"
   },
-  "31816": {
+  "31817": {
     "title": "Low pressure (EB100-EP14-BP8)",
     "factor": 10,
     "unit": "bar",
     "size": "s16",
-    "name": "low-pressure-eb100-ep14-bp8-31816"
+    "name": "low-pressure-eb100-ep14-bp8-31817"
   },
-  "31818": {
+  "31819": {
     "title": "Prot. status (EB100-EP14)",
     "factor": 1,
     "size": "u16",
-    "name": "prot-status-eb100-ep14-31818"
+    "name": "prot-status-eb100-ep14-31819"
   },
-  "31819": {
+  "31820": {
     "title": "Defrosting (EB100-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb100-ep14-31819"
+    "name": "defrosting-eb100-ep14-31820"
   },
-  "31820": {
+  "31821": {
     "title": "Power (EB100-EP14)",
     "factor": 1,
     "unit": "kW",
     "size": "u8",
-    "name": "power-eb100-ep14-31820"
+    "name": "power-eb100-ep14-31821"
   },
-  "31823": {
+  "31824": {
     "title": "Climate system 4",
     "factor": 1,
     "size": "u8",
-    "name": "climate-system-4-31823"
+    "name": "climate-system-4-31824"
   },
-  "31824": {
+  "31825": {
     "title": "Climate system 3",
     "factor": 1,
     "size": "u8",
-    "name": "climate-system-3-31824"
+    "name": "climate-system-3-31825"
   },
-  "31825": {
+  "31826": {
     "title": "Climate system 2",
     "factor": 1,
     "size": "u8",
-    "name": "climate-system-2-31825"
+    "name": "climate-system-2-31826"
   },
-  "31826": {
+  "31827": {
     "title": "Climate system 1 (HMP)",
     "factor": 1,
     "size": "u8",
-    "name": "climate-system-1-hmp-31826"
+    "name": "climate-system-1-hmp-31827"
   },
-  "31827": {
+  "31828": {
     "title": "Pool 2 pump status",
     "factor": 1,
     "size": "u8",
-    "name": "pool-2-pump-status-31827"
+    "name": "pool-2-pump-status-31828"
   },
-  "31828": {
+  "31829": {
     "title": "Pool 1 pump status",
     "factor": 1,
     "size": "u8",
-    "name": "pool-1-pump-status-31828"
+    "name": "pool-1-pump-status-31829"
   },
-  "31830": {
+  "31831": {
     "title": "ACS EQ1-QN12",
     "factor": 1,
     "size": "u8",
-    "name": "acs-eq1-qn12-31830"
+    "name": "acs-eq1-qn12-31831"
   },
-  "31831": {
+  "31832": {
     "title": "ACS EQ1-GP20",
     "factor": 1,
     "size": "u8",
-    "name": "acs-eq1-gp20-31831"
+    "name": "acs-eq1-gp20-31832"
   },
-  "31832": {
+  "31833": {
     "title": "Passive cooling shunt",
     "factor": 1,
     "size": "u8",
-    "name": "passive-cooling-shunt-31832"
+    "name": "passive-cooling-shunt-31833"
   },
-  "31833": {
+  "31834": {
     "title": "Passive cooling pump (GP13)",
     "factor": 1,
     "size": "u8",
-    "name": "passive-cooling-pump-gp13-31833"
+    "name": "passive-cooling-pump-gp13-31834"
   },
-  "31835": {
+  "31836": {
     "title": "Oper. mode groundwater pump",
     "factor": 1,
     "size": "u8",
-    "name": "oper-mode-groundwater-pump-31835"
+    "name": "oper-mode-groundwater-pump-31836"
   },
-  "31837": {
+  "31838": {
     "title": "Alarm number (EB100-EP15)",
     "factor": 1,
     "size": "u16",
-    "name": "alarm-number-eb100-ep15-31837"
+    "name": "alarm-number-eb100-ep15-31838"
   },
-  "31838": {
+  "31839": {
     "title": "Alarm number (EB100-EP14)",
     "factor": 1,
     "size": "u16",
-    "name": "alarm-number-eb100-ep14-31838"
+    "name": "alarm-number-eb100-ep14-31839"
   },
-  "31839": {
+  "31840": {
     "title": "Requested compressor frequency (EB108-EP15)",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "requested-compressor-frequency-eb108-ep15-31839"
+    "name": "requested-compressor-frequency-eb108-ep15-31840"
   },
-  "31841": {
+  "31842": {
     "title": "Requested compressor frequency (EB107-EP15)",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "requested-compressor-frequency-eb107-ep15-31841"
+    "name": "requested-compressor-frequency-eb107-ep15-31842"
   },
-  "31843": {
+  "31844": {
     "title": "Requested compressor frequency (EB106-EP15)",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "requested-compressor-frequency-eb106-ep15-31843"
+    "name": "requested-compressor-frequency-eb106-ep15-31844"
   },
-  "31845": {
+  "31846": {
     "title": "Requested compressor frequency (EB105-EP15)",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "requested-compressor-frequency-eb105-ep15-31845"
+    "name": "requested-compressor-frequency-eb105-ep15-31846"
   },
-  "31847": {
+  "31848": {
     "title": "Requested compressor frequency (EB104-EP15)",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "requested-compressor-frequency-eb104-ep15-31847"
+    "name": "requested-compressor-frequency-eb104-ep15-31848"
   },
-  "31849": {
+  "31850": {
     "title": "Requested compressor frequency (EB103-EP15)",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "requested-compressor-frequency-eb103-ep15-31849"
+    "name": "requested-compressor-frequency-eb103-ep15-31850"
   },
-  "31851": {
+  "31852": {
     "title": "Requested compressor frequency (EB102-EP15)",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "requested-compressor-frequency-eb102-ep15-31851"
+    "name": "requested-compressor-frequency-eb102-ep15-31852"
   },
-  "31853": {
+  "31854": {
     "title": "Requested compressor frequency (EB101-EP15)",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "requested-compressor-frequency-eb101-ep15-31853"
+    "name": "requested-compressor-frequency-eb101-ep15-31854"
   },
-  "31855": {
+  "31856": {
     "title": "Requested compressor frequency (EP15)",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "requested-compressor-frequency-ep15-31855"
+    "name": "requested-compressor-frequency-ep15-31856"
   },
-  "31856": {
+  "31857": {
     "title": "Requested compressor frequency",
     "factor": 1,
     "unit": "Hz",
     "size": "u8",
-    "name": "requested-compressor-frequency-31856"
+    "name": "requested-compressor-frequency-31857"
   },
-  "31905": {
+  "31906": {
     "title": "Low press. sensor, unprocessed (EB100-EP15)",
     "factor": 1,
     "size": "s16",
-    "name": "low-press-sensor-unprocessed-eb100-ep15-31905"
+    "name": "low-press-sensor-unprocessed-eb100-ep15-31906"
   },
-  "31906": {
+  "31907": {
     "title": "Current sensor (EB100-EP15)",
     "factor": 10,
     "unit": "A",
     "size": "s16",
-    "name": "current-sensor-eb100-ep15-31906"
+    "name": "current-sensor-eb100-ep15-31907"
   },
-  "31908": {
+  "31909": {
     "title": "Low press. sensor, unprocessed (EB100-EP14)",
     "factor": 1,
     "size": "s16",
-    "name": "low-press-sensor-unprocessed-eb100-ep14-31908"
+    "name": "low-press-sensor-unprocessed-eb100-ep14-31909"
   },
-  "31909": {
+  "31910": {
     "title": "Current sensor (EB100-EP14)",
     "factor": 10,
     "unit": "A",
     "size": "s16",
-    "name": "current-sensor-eb100-ep14-31909"
+    "name": "current-sensor-eb100-ep14-31910"
   },
-  "31911": {
+  "31912": {
     "title": "Operating mode (SG Ready)",
     "factor": 1,
     "size": "u8",
-    "name": "operating-mode-sg-ready-31911"
+    "name": "operating-mode-sg-ready-31912"
   },
-  "31912": {
+  "31913": {
     "title": "SG ready, input A",
     "factor": 1,
     "size": "u8",
-    "name": "sg-ready-input-a-31912"
+    "name": "sg-ready-input-a-31913"
   },
-  "31913": {
+  "31914": {
     "title": "SG ready, input B",
     "factor": 1,
     "size": "u8",
-    "name": "sg-ready-input-b-31913"
+    "name": "sg-ready-input-b-31914"
   },
-  "31914": {
+  "31915": {
     "title": "Heating offset (SPA)",
     "factor": 10,
     "size": "s8",
-    "name": "heating-offset-spa-31914"
+    "name": "heating-offset-spa-31915"
   },
-  "31915": {
+  "31916": {
     "title": "Hot water comfort mode (SPA)",
     "factor": 1,
     "size": "s8",
-    "name": "hot-water-comfort-mode-spa-31915"
+    "name": "hot-water-comfort-mode-spa-31916"
   },
-  "31916": {
+  "31917": {
     "title": "Pool offset (SPA)",
     "factor": 1,
     "size": "s8",
-    "name": "pool-offset-spa-31916"
+    "name": "pool-offset-spa-31917"
   },
-  "31917": {
+  "31918": {
     "title": "Cooling offset (SPA)",
     "factor": 1,
     "size": "s8",
-    "name": "cooling-offset-spa-31917"
+    "name": "cooling-offset-spa-31918"
   },
-  "31918": {
+  "31919": {
     "title": "Operating mode (Smart Price Adaption)",
     "factor": 1,
     "size": "u8",
-    "name": "operating-mode-smart-price-adaption-31918"
+    "name": "operating-mode-smart-price-adaption-31919"
   },
-  "31919": {
+  "31920": {
     "title": "Brine pump dT current",
     "factor": 10,
     "size": "s16",
-    "name": "brine-pump-dt-current-31919"
+    "name": "brine-pump-dt-current-31920"
   },
-  "31920": {
+  "31921": {
     "title": "Brine pump dT set point value",
     "factor": 10,
     "size": "s16",
-    "name": "brine-pump-dt-set-point-value-31920"
+    "name": "brine-pump-dt-set-point-value-31921"
   },
-  "31969": {
+  "31970": {
     "title": "Evaporator 2 (EB100-EP15-BT16)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evaporator-2-eb100-ep15-bt16-31969"
+    "name": "evaporator-2-eb100-ep15-bt16-31970"
   },
-  "31970": {
+  "31971": {
     "title": "Temperature, inverter (EB100-EP15)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "temperature-inverter-eb100-ep15-31970"
+    "name": "temperature-inverter-eb100-ep15-31971"
   },
-  "31971": {
+  "31972": {
     "title": "fan speed (EB100-EP15)",
     "factor": 1,
     "size": "u8",
-    "name": "fan-speed-eb100-ep15-31971"
+    "name": "fan-speed-eb100-ep15-31972"
   },
-  "31972": {
+  "31973": {
     "title": "Evaporator 2 (EB100-EP14-BT16)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evaporator-2-eb100-ep14-bt16-31972"
+    "name": "evaporator-2-eb100-ep14-bt16-31973"
   },
-  "31973": {
+  "31974": {
     "title": "Temperature, inverter (EB100-EP14)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "temperature-inverter-eb100-ep14-31973"
+    "name": "temperature-inverter-eb100-ep14-31974"
   },
-  "31974": {
+  "31975": {
     "title": "fan speed (EB100-EP14)",
     "factor": 1,
     "size": "u8",
-    "name": "fan-speed-eb100-ep14-31974"
+    "name": "fan-speed-eb100-ep14-31975"
   },
-  "31975": {
+  "31976": {
     "title": "Alarm number",
     "factor": 1,
     "size": "s16",
-    "name": "alarm-number-31975"
+    "name": "alarm-number-31976"
   },
-  "40022": {
+  "40023": {
     "title": "Reset alarm",
     "factor": 1,
     "size": "u8",
-    "name": "reset-alarm-40022",
+    "name": "reset-alarm-40023",
     "write": true
   },
-  "31976": {
+  "31977": {
     "title": "Non module-specific alarm numbers",
     "factor": 1,
     "size": "s16",
-    "name": "non-module-specific-alarm-numbers-31976"
+    "name": "non-module-specific-alarm-numbers-31977"
   },
-  "40026": {
+  "40027": {
     "title": "Heating curve climate system 1",
     "factor": 1,
     "size": "s8",
     "min": 0.0,
     "max": 15.0,
     "default": 9.0,
-    "name": "heating-curve-climate-system-1-40026",
+    "name": "heating-curve-climate-system-1-40027",
     "write": true
   },
-  "40030": {
+  "40031": {
     "title": "Heating offset climate system 1",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "heating-offset-climate-system-1-40030",
+    "name": "heating-offset-climate-system-1-40031",
     "write": true
   },
-  "40034": {
+  "40035": {
     "title": "Min supply climate system 1",
     "factor": 10,
     "unit": "\u00b0C",
@@ -4858,10 +4858,10 @@
     "min": 50.0,
     "max": 800.0,
     "default": 200.0,
-    "name": "min-supply-climate-system-1-40034",
+    "name": "min-supply-climate-system-1-40035",
     "write": true
   },
-  "40038": {
+  "40039": {
     "title": "Max supply climate system 1",
     "factor": 10,
     "unit": "\u00b0C",
@@ -4869,10 +4869,10 @@
     "min": 50.0,
     "max": 800.0,
     "default": 600.0,
-    "name": "max-supply-climate-system-1-40038",
+    "name": "max-supply-climate-system-1-40039",
     "write": true
   },
-  "40039": {
+  "40040": {
     "title": "Own curve, heating P7",
     "factor": 1,
     "unit": "\u00b0C",
@@ -4880,10 +4880,10 @@
     "min": 5.0,
     "max": 80.0,
     "default": 15.0,
-    "name": "own-curve-heating-p7-40039",
+    "name": "own-curve-heating-p7-40040",
     "write": true
   },
-  "40040": {
+  "40041": {
     "title": "Own curve, heating P6",
     "factor": 1,
     "unit": "\u00b0C",
@@ -4891,10 +4891,10 @@
     "min": 5.0,
     "max": 80.0,
     "default": 15.0,
-    "name": "own-curve-heating-p6-40040",
+    "name": "own-curve-heating-p6-40041",
     "write": true
   },
-  "40041": {
+  "40042": {
     "title": "Own curve, heating P5",
     "factor": 1,
     "unit": "\u00b0C",
@@ -4902,10 +4902,10 @@
     "min": 5.0,
     "max": 80.0,
     "default": 26.0,
-    "name": "own-curve-heating-p5-40041",
+    "name": "own-curve-heating-p5-40042",
     "write": true
   },
-  "40042": {
+  "40043": {
     "title": "Own curve, heating P4",
     "factor": 1,
     "unit": "\u00b0C",
@@ -4913,10 +4913,10 @@
     "min": 5.0,
     "max": 80.0,
     "default": 32.0,
-    "name": "own-curve-heating-p4-40042",
+    "name": "own-curve-heating-p4-40043",
     "write": true
   },
-  "40043": {
+  "40044": {
     "title": "Own curve, heating P3",
     "factor": 1,
     "unit": "\u00b0C",
@@ -4924,10 +4924,10 @@
     "min": 5.0,
     "max": 80.0,
     "default": 35.0,
-    "name": "own-curve-heating-p3-40043",
+    "name": "own-curve-heating-p3-40044",
     "write": true
   },
-  "40044": {
+  "40045": {
     "title": "Own curve, heating P2",
     "factor": 1,
     "unit": "\u00b0C",
@@ -4935,10 +4935,10 @@
     "min": 5.0,
     "max": 80.0,
     "default": 40.0,
-    "name": "own-curve-heating-p2-40044",
+    "name": "own-curve-heating-p2-40045",
     "write": true
   },
-  "40045": {
+  "40046": {
     "title": "Own curve, heating P1",
     "factor": 1,
     "unit": "\u00b0C",
@@ -4946,10 +4946,10 @@
     "min": 5.0,
     "max": 80.0,
     "default": 45.0,
-    "name": "own-curve-heating-p1-40045",
+    "name": "own-curve-heating-p1-40046",
     "write": true
   },
-  "40046": {
+  "40047": {
     "title": "Point offset outdoor temperature",
     "factor": 1,
     "unit": "\u00b0C",
@@ -4957,10 +4957,10 @@
     "min": -40.0,
     "max": 30.0,
     "default": 0.0,
-    "name": "point-offset-outdoor-temperature-40046",
+    "name": "point-offset-outdoor-temperature-40047",
     "write": true
   },
-  "40047": {
+  "40048": {
     "title": "Point offset",
     "factor": 1,
     "unit": "\u00b0C",
@@ -4968,20 +4968,20 @@
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "point-offset-40047",
+    "name": "point-offset-40048",
     "write": true
   },
-  "40051": {
+  "40052": {
     "title": "External adjustment climate system 1",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-climate-system-1-40051",
+    "name": "external-adjustment-climate-system-1-40052",
     "write": true
   },
-  "40055": {
+  "40056": {
     "title": "External adjustment with room sensor climate system 1",
     "factor": 10,
     "unit": "\u00b0C",
@@ -4989,20 +4989,20 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-climate-system-1-40055",
+    "name": "external-adjustment-with-room-sensor-climate-system-1-40056",
     "write": true
   },
-  "40056": {
+  "40057": {
     "title": "Hot water demand mode",
     "factor": 1,
     "size": "s8",
     "min": 0.0,
     "max": 4.0,
     "default": 1.0,
-    "name": "hot-water-demand-mode-40056",
+    "name": "hot-water-demand-mode-40057",
     "write": true
   },
-  "40058": {
+  "40059": {
     "title": "Start temperature HW high temperature",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5010,10 +5010,10 @@
     "min": 50.0,
     "max": 700.0,
     "default": 500.0,
-    "name": "start-temperature-hw-high-temperature-40058",
+    "name": "start-temperature-hw-high-temperature-40059",
     "write": true
   },
-  "40059": {
+  "40060": {
     "title": "Start temperature HW normal temperature",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5021,10 +5021,10 @@
     "min": 50.0,
     "max": 600.0,
     "default": 470.0,
-    "name": "start-temperature-hw-normal-temperature-40059",
+    "name": "start-temperature-hw-normal-temperature-40060",
     "write": true
   },
-  "40060": {
+  "40061": {
     "title": "Start temperature HW low temperature",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5032,10 +5032,10 @@
     "min": 50.0,
     "max": 550.0,
     "default": 430.0,
-    "name": "start-temperature-hw-low-temperature-40060",
+    "name": "start-temperature-hw-low-temperature-40061",
     "write": true
   },
-  "40061": {
+  "40062": {
     "title": "Stop temperature HW periodic increase",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5043,10 +5043,10 @@
     "min": 550.0,
     "max": 700.0,
     "default": 550.0,
-    "name": "stop-temperature-hw-periodic-increase-40061",
+    "name": "stop-temperature-hw-periodic-increase-40062",
     "write": true
   },
-  "40062": {
+  "40063": {
     "title": "Stop temperature HW high temperature",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5054,10 +5054,10 @@
     "min": 50.0,
     "max": 700.0,
     "default": 540.0,
-    "name": "stop-temperature-hw-high-temperature-40062",
+    "name": "stop-temperature-hw-high-temperature-40063",
     "write": true
   },
-  "40063": {
+  "40064": {
     "title": "Stop temperature HW normal temperature",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5065,10 +5065,10 @@
     "min": 50.0,
     "max": 650.0,
     "default": 510.0,
-    "name": "stop-temperature-hw-normal-temperature-40063",
+    "name": "stop-temperature-hw-normal-temperature-40064",
     "write": true
   },
-  "40064": {
+  "40065": {
     "title": "Stop temperature HW low temperature",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5076,20 +5076,20 @@
     "min": 50.0,
     "max": 600.0,
     "default": 470.0,
-    "name": "stop-temperature-hw-low-temperature-40064",
+    "name": "stop-temperature-hw-low-temperature-40065",
     "write": true
   },
-  "40065": {
+  "40066": {
     "title": "Periodic hot water",
     "factor": 1,
     "size": "s8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "periodic-hot-water-40065",
+    "name": "periodic-hot-water-40066",
     "write": true
   },
-  "40066": {
+  "40067": {
     "title": "Periodic hot water interval",
     "factor": 1,
     "unit": "days",
@@ -5097,37 +5097,37 @@
     "min": 1.0,
     "max": 90.0,
     "default": 7.0,
-    "name": "periodic-hot-water-interval-40066",
+    "name": "periodic-hot-water-interval-40067",
     "write": true
   },
-  "40067": {
+  "40068": {
     "title": "Start time periodic hot water",
     "factor": 1,
     "size": "u16",
-    "name": "start-time-periodic-hot-water-40067",
+    "name": "start-time-periodic-hot-water-40068",
     "write": true
   },
-  "42754": {
+  "42755": {
     "title": "Hot water circulation",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "hot-water-circulation-42754",
+    "name": "hot-water-circulation-42755",
     "write": true
   },
-  "40091": {
+  "40092": {
     "title": "Language",
     "factor": 1,
     "size": "s8",
     "min": 0.0,
     "max": 22.0,
     "default": 0.0,
-    "name": "language-40091",
+    "name": "language-40092",
     "write": true
   },
-  "40092": {
+  "40093": {
     "title": "Period time hot water",
     "factor": 1,
     "unit": "min",
@@ -5135,10 +5135,10 @@
     "min": 0.0,
     "max": 180.0,
     "default": 30.0,
-    "name": "period-time-hot-water-40092",
+    "name": "period-time-hot-water-40093",
     "write": true
   },
-  "40093": {
+  "40094": {
     "title": "Period time heating",
     "factor": 1,
     "unit": "min",
@@ -5146,47 +5146,47 @@
     "min": 0.0,
     "max": 180.0,
     "default": 30.0,
-    "name": "period-time-heating-40093",
+    "name": "period-time-heating-40094",
     "write": true
   },
-  "42743": {
+  "42744": {
     "title": "Operating mode",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 2.0,
     "default": 0.0,
-    "name": "operating-mode-42743",
+    "name": "operating-mode-42744",
     "write": true
   },
-  "40095": {
+  "40096": {
     "title": "Operating mode heating medium pump",
     "factor": 1,
     "size": "u8",
     "min": 10.0,
     "max": 40.0,
     "default": 40.0,
-    "name": "operating-mode-heating-medium-pump-40095",
+    "name": "operating-mode-heating-medium-pump-40096",
     "write": true
   },
-  "40096": {
+  "40097": {
     "title": "Operating mode brine pump",
     "factor": 1,
     "size": "u8",
     "min": 10.0,
     "max": 30.0,
     "default": 10.0,
-    "name": "operating-mode-brine-pump-40096",
+    "name": "operating-mode-brine-pump-40097",
     "write": true
   },
-  "45000": {
+  "45001": {
     "title": "Activate force control",
     "factor": 1,
     "size": "u8",
-    "name": "activate-force-control-45000",
+    "name": "activate-force-control-45001",
     "write": true
   },
-  "40097": {
+  "40098": {
     "title": "DM start heating",
     "factor": 1,
     "unit": "DM",
@@ -5194,10 +5194,10 @@
     "min": -1000.0,
     "max": -30.0,
     "default": -60.0,
-    "name": "dm-start-heating-40097",
+    "name": "dm-start-heating-40098",
     "write": true
   },
-  "40100": {
+  "40101": {
     "title": "DM between additional heat step",
     "factor": 1,
     "unit": "DM",
@@ -5205,10 +5205,10 @@
     "min": 10.0,
     "max": 1000.0,
     "default": 100.0,
-    "name": "dm-between-additional-heat-step-40100",
+    "name": "dm-between-additional-heat-step-40101",
     "write": true
   },
-  "40102": {
+  "40103": {
     "title": "Max. internal additional heat",
     "factor": 100,
     "unit": "kW",
@@ -5216,10 +5216,10 @@
     "min": 0.0,
     "max": 4500.0,
     "default": 700.0,
-    "name": "max-internal-additional-heat-40102",
+    "name": "max-internal-additional-heat-40103",
     "write": true
   },
-  "40103": {
+  "40104": {
     "title": "Fuse",
     "factor": 1,
     "unit": "A",
@@ -5227,20 +5227,20 @@
     "min": 1.0,
     "max": 400.0,
     "default": 16.0,
-    "name": "fuse-40103",
+    "name": "fuse-40104",
     "write": true
   },
-  "40120": {
+  "40121": {
     "title": "Floor drying",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "floor-drying-40120",
+    "name": "floor-drying-40121",
     "write": true
   },
-  "40121": {
+  "40122": {
     "title": "Floor drying period 7",
     "factor": 1,
     "unit": "days",
@@ -5248,10 +5248,10 @@
     "min": 0.0,
     "max": 30.0,
     "default": 2.0,
-    "name": "floor-drying-period-7-40121",
+    "name": "floor-drying-period-7-40122",
     "write": true
   },
-  "40122": {
+  "40123": {
     "title": "Floor drying period 6",
     "factor": 1,
     "unit": "days",
@@ -5259,10 +5259,10 @@
     "min": 0.0,
     "max": 30.0,
     "default": 2.0,
-    "name": "floor-drying-period-6-40122",
+    "name": "floor-drying-period-6-40123",
     "write": true
   },
-  "40123": {
+  "40124": {
     "title": "Floor drying period 5",
     "factor": 1,
     "unit": "days",
@@ -5270,10 +5270,10 @@
     "min": 0.0,
     "max": 30.0,
     "default": 2.0,
-    "name": "floor-drying-period-5-40123",
+    "name": "floor-drying-period-5-40124",
     "write": true
   },
-  "40124": {
+  "40125": {
     "title": "Floor drying period 4",
     "factor": 1,
     "unit": "days",
@@ -5281,10 +5281,10 @@
     "min": 0.0,
     "max": 30.0,
     "default": 3.0,
-    "name": "floor-drying-period-4-40124",
+    "name": "floor-drying-period-4-40125",
     "write": true
   },
-  "40125": {
+  "40126": {
     "title": "Floor drying period 3",
     "factor": 1,
     "unit": "days",
@@ -5292,10 +5292,10 @@
     "min": 0.0,
     "max": 30.0,
     "default": 2.0,
-    "name": "floor-drying-period-3-40125",
+    "name": "floor-drying-period-3-40126",
     "write": true
   },
-  "40126": {
+  "40127": {
     "title": "Floor drying period 2",
     "factor": 1,
     "unit": "days",
@@ -5303,10 +5303,10 @@
     "min": 0.0,
     "max": 30.0,
     "default": 2.0,
-    "name": "floor-drying-period-2-40126",
+    "name": "floor-drying-period-2-40127",
     "write": true
   },
-  "40127": {
+  "40128": {
     "title": "Floor drying period 1",
     "factor": 1,
     "unit": "days",
@@ -5314,10 +5314,10 @@
     "min": 0.0,
     "max": 30.0,
     "default": 2.0,
-    "name": "floor-drying-period-1-40127",
+    "name": "floor-drying-period-1-40128",
     "write": true
   },
-  "40128": {
+  "40129": {
     "title": "Floor drying temp. 7",
     "factor": 1,
     "unit": "\u00b0C",
@@ -5325,10 +5325,10 @@
     "min": 15.0,
     "max": 70.0,
     "default": 20.0,
-    "name": "floor-drying-temp-7-40128",
+    "name": "floor-drying-temp-7-40129",
     "write": true
   },
-  "40129": {
+  "40130": {
     "title": "Floor drying temp. 6",
     "factor": 1,
     "unit": "\u00b0C",
@@ -5336,10 +5336,10 @@
     "min": 15.0,
     "max": 70.0,
     "default": 30.0,
-    "name": "floor-drying-temp-6-40129",
+    "name": "floor-drying-temp-6-40130",
     "write": true
   },
-  "40130": {
+  "40131": {
     "title": "Floor drying temp. 5",
     "factor": 1,
     "unit": "\u00b0C",
@@ -5347,10 +5347,10 @@
     "min": 15.0,
     "max": 70.0,
     "default": 40.0,
-    "name": "floor-drying-temp-5-40130",
+    "name": "floor-drying-temp-5-40131",
     "write": true
   },
-  "40131": {
+  "40132": {
     "title": "Floor drying temp. 4",
     "factor": 1,
     "unit": "\u00b0C",
@@ -5358,10 +5358,10 @@
     "min": 15.0,
     "max": 70.0,
     "default": 45.0,
-    "name": "floor-drying-temp-4-40131",
+    "name": "floor-drying-temp-4-40132",
     "write": true
   },
-  "40132": {
+  "40133": {
     "title": "Floor drying temp. 3",
     "factor": 1,
     "unit": "\u00b0C",
@@ -5369,10 +5369,10 @@
     "min": 15.0,
     "max": 70.0,
     "default": 40.0,
-    "name": "floor-drying-temp-3-40132",
+    "name": "floor-drying-temp-3-40133",
     "write": true
   },
-  "40133": {
+  "40134": {
     "title": "Floor drying temp. 2",
     "factor": 1,
     "unit": "\u00b0C",
@@ -5380,10 +5380,10 @@
     "min": 15.0,
     "max": 70.0,
     "default": 30.0,
-    "name": "floor-drying-temp-2-40133",
+    "name": "floor-drying-temp-2-40134",
     "write": true
   },
-  "40134": {
+  "40135": {
     "title": "Floor drying temp. 1",
     "factor": 1,
     "unit": "\u00b0C",
@@ -5391,19 +5391,19 @@
     "min": 15.0,
     "max": 70.0,
     "default": 20.0,
-    "name": "floor-drying-temp-1-40134",
+    "name": "floor-drying-temp-1-40135",
     "write": true
   },
-  "31977": {
+  "31978": {
     "title": "Floor drying ongoing time.",
     "factor": 1,
     "size": "u16",
     "min": 0.0,
     "max": 10000.0,
     "default": 0.0,
-    "name": "floor-drying-ongoing-time-31977"
+    "name": "floor-drying-ongoing-time-31978"
   },
-  "40140": {
+  "40141": {
     "title": "Dimensioned outdoor temperature",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5411,10 +5411,10 @@
     "min": -400.0,
     "max": 200.0,
     "default": -180.0,
-    "name": "dimensioned-outdoor-temperature-40140",
+    "name": "dimensioned-outdoor-temperature-40141",
     "write": true
   },
-  "40141": {
+  "40142": {
     "title": "Delta T for DOT",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5422,50 +5422,50 @@
     "min": 10.0,
     "max": 250.0,
     "default": 100.0,
-    "name": "delta-t-for-dot-40141",
+    "name": "delta-t-for-dot-40142",
     "write": true
   },
-  "40142": {
+  "40143": {
     "title": "Climate system 2",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "climate-system-2-40142",
+    "name": "climate-system-2-40143",
     "write": true
   },
-  "40143": {
+  "40144": {
     "title": "Climate system 3",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "climate-system-3-40143",
+    "name": "climate-system-3-40144",
     "write": true
   },
-  "40144": {
+  "40145": {
     "title": "Climate system 4",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "climate-system-4-40144",
+    "name": "climate-system-4-40145",
     "write": true
   },
-  "40153": {
+  "40154": {
     "title": "Shunt controlled additional heat",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "shunt-controlled-additional-heat-40153",
+    "name": "shunt-controlled-additional-heat-40154",
     "write": true
   },
-  "40157": {
+  "40158": {
     "title": "Wait time shunt, shunt controlled additional heat",
     "factor": 1,
     "unit": "s",
@@ -5473,20 +5473,20 @@
     "min": 10.0,
     "max": 300.0,
     "default": 30.0,
-    "name": "wait-time-shunt-shunt-controlled-additional-heat-40157",
+    "name": "wait-time-shunt-shunt-controlled-additional-heat-40158",
     "write": true
   },
-  "40158": {
+  "40159": {
     "title": "Step controlled additional heat accessory",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "step-controlled-additional-heat-accessory-40158",
+    "name": "step-controlled-additional-heat-accessory-40159",
     "write": true
   },
-  "40159": {
+  "40160": {
     "title": "DM start step controlled additional heat",
     "factor": 1,
     "unit": "DM",
@@ -5494,50 +5494,50 @@
     "min": -2000.0,
     "max": -30.0,
     "default": -400.0,
-    "name": "dm-start-step-controlled-additional-heat-40159",
+    "name": "dm-start-step-controlled-additional-heat-40160",
     "write": true
   },
-  "40162": {
+  "40163": {
     "title": "Ground water pump accessory",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "ground-water-pump-accessory-40162",
+    "name": "ground-water-pump-accessory-40163",
     "write": true
   },
-  "41980": {
+  "41981": {
     "title": "PCI accessories",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "pci-accessories-41980",
+    "name": "pci-accessories-41981",
     "write": true
   },
-  "40163": {
+  "40164": {
     "title": "Cooling 2-pipe",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "cooling-2-pipe-40163",
+    "name": "cooling-2-pipe-40164",
     "write": true
   },
-  "40164": {
+  "40165": {
     "title": "Cooling 4-pipe",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "cooling-4-pipe-40164",
+    "name": "cooling-4-pipe-40165",
     "write": true
   },
-  "40165": {
+  "40166": {
     "title": "Waiting time cooling/heating",
     "factor": 1,
     "unit": "h",
@@ -5545,10 +5545,10 @@
     "min": 0.0,
     "max": 48.0,
     "default": 2.0,
-    "name": "waiting-time-cooling-heating-40165",
+    "name": "waiting-time-cooling-heating-40166",
     "write": true
   },
-  "40166": {
+  "40167": {
     "title": "Heating start at under temp.",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5556,10 +5556,10 @@
     "min": 5.0,
     "max": 100.0,
     "default": 10.0,
-    "name": "heating-start-at-under-temp-40166",
+    "name": "heating-start-at-under-temp-40167",
     "write": true
   },
-  "40167": {
+  "40168": {
     "title": "Cooling start at over temp.",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5567,20 +5567,20 @@
     "min": 5.0,
     "max": 100.0,
     "default": 30.0,
-    "name": "cooling-start-at-over-temp-40167",
+    "name": "cooling-start-at-over-temp-40168",
     "write": true
   },
-  "40168": {
+  "40169": {
     "title": "Cooling shunt amplification",
     "factor": 10,
     "size": "s8",
     "min": 1.0,
     "max": 100.0,
     "default": 10.0,
-    "name": "cooling-shunt-amplification-40168",
+    "name": "cooling-shunt-amplification-40169",
     "write": true
   },
-  "40169": {
+  "40170": {
     "title": "Cooling shunt waiting time",
     "factor": 1,
     "unit": "s",
@@ -5588,30 +5588,30 @@
     "min": 10.0,
     "max": 300.0,
     "default": 30.0,
-    "name": "cooling-shunt-waiting-time-40169",
+    "name": "cooling-shunt-waiting-time-40170",
     "write": true
   },
-  "40170": {
+  "40171": {
     "title": "Cooling with room sensors",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 41.0,
     "default": 0.0,
-    "name": "cooling-with-room-sensors-40170",
+    "name": "cooling-with-room-sensors-40171",
     "write": true
   },
-  "40171": {
+  "40172": {
     "title": "HPAC",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "hpac-40171",
+    "name": "hpac-40172",
     "write": true
   },
-  "40172": {
+  "40173": {
     "title": "Start passive cooling DM",
     "factor": 1,
     "unit": "DM",
@@ -5619,10 +5619,10 @@
     "min": 10.0,
     "max": 500.0,
     "default": 30.0,
-    "name": "start-passive-cooling-dm-40172",
+    "name": "start-passive-cooling-dm-40173",
     "write": true
   },
-  "40173": {
+  "40174": {
     "title": "Start active cooling DM",
     "factor": 1,
     "unit": "DM",
@@ -5630,50 +5630,50 @@
     "min": 10.0,
     "max": 300.0,
     "default": 90.0,
-    "name": "start-active-cooling-dm-40173",
+    "name": "start-active-cooling-dm-40174",
     "write": true
   },
-  "42744": {
+  "42745": {
     "title": "Changes have been made",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "changes-have-been-made-42744",
+    "name": "changes-have-been-made-42745",
     "write": true
   },
-  "40180": {
+  "40181": {
     "title": "Permit additional heat, heating",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "permit-additional-heat-heating-40180",
+    "name": "permit-additional-heat-heating-40181",
     "write": true
   },
-  "40181": {
+  "40182": {
     "title": "Permit heating",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "permit-heating-40181",
+    "name": "permit-heating-40182",
     "write": true
   },
-  "40182": {
+  "40183": {
     "title": "Permit cooling",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "permit-cooling-40182",
+    "name": "permit-cooling-40183",
     "write": true
   },
-  "40183": {
+  "40184": {
     "title": "Auto mode, start temperature for cooling",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5681,10 +5681,10 @@
     "min": -200.0,
     "max": 400.0,
     "default": 250.0,
-    "name": "auto-mode-start-temperature-for-cooling-40183",
+    "name": "auto-mode-start-temperature-for-cooling-40184",
     "write": true
   },
-  "40184": {
+  "40185": {
     "title": "Auto mode, stop temperature for heating",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5692,10 +5692,10 @@
     "min": -200.0,
     "max": 400.0,
     "default": 170.0,
-    "name": "auto-mode-stop-temperature-for-heating-40184",
+    "name": "auto-mode-stop-temperature-for-heating-40185",
     "write": true
   },
-  "40185": {
+  "40186": {
     "title": "Auto mode, additional heat stop temperature",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5703,10 +5703,10 @@
     "min": -250.0,
     "max": 400.0,
     "default": 50.0,
-    "name": "auto-mode-additional-heat-stop-temperature-40185",
+    "name": "auto-mode-additional-heat-stop-temperature-40186",
     "write": true
   },
-  "40186": {
+  "40187": {
     "title": "Auto mode filter time",
     "factor": 1,
     "unit": "h",
@@ -5714,10 +5714,10 @@
     "min": 0.0,
     "max": 48.0,
     "default": 24.0,
-    "name": "auto-mode-filter-time-40186",
+    "name": "auto-mode-filter-time-40187",
     "write": true
   },
-  "40187": {
+  "40188": {
     "title": "Max difference supply, compressor",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5725,10 +5725,10 @@
     "min": 10.0,
     "max": 250.0,
     "default": 100.0,
-    "name": "max-difference-supply-compressor-40187",
+    "name": "max-difference-supply-compressor-40188",
     "write": true
   },
-  "40188": {
+  "40189": {
     "title": "Max difference supply, additional heat",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5736,20 +5736,20 @@
     "min": 10.0,
     "max": 240.0,
     "default": 30.0,
-    "name": "max-difference-supply-additional-heat-40188",
+    "name": "max-difference-supply-additional-heat-40189",
     "write": true
   },
-  "40189": {
+  "40190": {
     "title": "Low brine alarm auto reset",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "low-brine-alarm-auto-reset-40189",
+    "name": "low-brine-alarm-auto-reset-40190",
     "write": true
   },
-  "40190": {
+  "40191": {
     "title": "Low brine out alarm temperature (EP14)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5757,17 +5757,17 @@
     "min": -120.0,
     "max": 150.0,
     "default": -80.0,
-    "name": "low-brine-out-alarm-temperature-ep14-40190",
-    "write": true
-  },
-  "40191": {
-    "title": "High brine in alarm active",
-    "factor": 1,
-    "size": "u8",
-    "name": "high-brine-in-alarm-active-40191",
+    "name": "low-brine-out-alarm-temperature-ep14-40191",
     "write": true
   },
   "40192": {
+    "title": "High brine in alarm active",
+    "factor": 1,
+    "size": "u8",
+    "name": "high-brine-in-alarm-active-40192",
+    "write": true
+  },
+  "40193": {
     "title": "High brine in alarm temperature",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5775,87 +5775,87 @@
     "min": 100.0,
     "max": 300.0,
     "default": 300.0,
-    "name": "high-brine-in-alarm-temperature-40192",
+    "name": "high-brine-in-alarm-temperature-40193",
     "write": true
   },
-  "40194": {
+  "40195": {
     "title": "Time format",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "time-format-40194",
+    "name": "time-format-40195",
     "write": true
   },
-  "40196": {
+  "40197": {
     "title": "Alarm action, lower room temperature",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "alarm-action-lower-room-temperature-40196",
+    "name": "alarm-action-lower-room-temperature-40197",
     "write": true
   },
-  "40197": {
+  "40198": {
     "title": "Alarm action lower HW temperature",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "alarm-action-lower-hw-temperature-40197",
-    "write": true
-  },
-  "40198": {
-    "title": "Auxiliary operation on alarm",
-    "factor": 1,
-    "size": "u8",
-    "name": "auxiliary-operation-on-alarm-40198",
+    "name": "alarm-action-lower-hw-temperature-40198",
     "write": true
   },
   "40199": {
+    "title": "Auxiliary operation on alarm",
+    "factor": 1,
+    "size": "u8",
+    "name": "auxiliary-operation-on-alarm-40199",
+    "write": true
+  },
+  "40200": {
     "title": "Use room sensor climate system 4",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "use-room-sensor-climate-system-4-40199",
+    "name": "use-room-sensor-climate-system-4-40200",
     "write": true
   },
-  "40200": {
+  "40201": {
     "title": "Use room sensor climate system 3",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "use-room-sensor-climate-system-3-40200",
+    "name": "use-room-sensor-climate-system-3-40201",
     "write": true
   },
-  "40201": {
+  "40202": {
     "title": "Use room sensor climate system 2",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "use-room-sensor-climate-system-2-40201",
+    "name": "use-room-sensor-climate-system-2-40202",
     "write": true
   },
-  "40202": {
+  "40203": {
     "title": "Use room sensor climate system 1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "use-room-sensor-climate-system-1-40202",
+    "name": "use-room-sensor-climate-system-1-40203",
     "write": true
   },
-  "40203": {
+  "40204": {
     "title": "Room sensor set point value climate system 4",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5863,10 +5863,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "room-sensor-set-point-value-climate-system-4-40203",
+    "name": "room-sensor-set-point-value-climate-system-4-40204",
     "write": true
   },
-  "40204": {
+  "40205": {
     "title": "Room sensor set point value climate system 3",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5874,10 +5874,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "room-sensor-set-point-value-climate-system-3-40204",
+    "name": "room-sensor-set-point-value-climate-system-3-40205",
     "write": true
   },
-  "40205": {
+  "40206": {
     "title": "Room sensor set point value climate system 2",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5885,10 +5885,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "room-sensor-set-point-value-climate-system-2-40205",
+    "name": "room-sensor-set-point-value-climate-system-2-40206",
     "write": true
   },
-  "40206": {
+  "40207": {
     "title": "Room sensor set point value climate system 1",
     "factor": 10,
     "unit": "\u00b0C",
@@ -5896,110 +5896,110 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "room-sensor-set-point-value-climate-system-1-40206",
+    "name": "room-sensor-set-point-value-climate-system-1-40207",
     "write": true
   },
-  "40207": {
+  "40208": {
     "title": "Room sensor factor climate system 4",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 20.0,
-    "name": "room-sensor-factor-climate-system-4-40207",
+    "name": "room-sensor-factor-climate-system-4-40208",
     "write": true
   },
-  "40208": {
+  "40209": {
     "title": "Room sensor factor climate system 3",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 20.0,
-    "name": "room-sensor-factor-climate-system-3-40208",
+    "name": "room-sensor-factor-climate-system-3-40209",
     "write": true
   },
-  "40209": {
+  "40210": {
     "title": "Room sensor factor climate system 2",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 20.0,
-    "name": "room-sensor-factor-climate-system-2-40209",
+    "name": "room-sensor-factor-climate-system-2-40210",
     "write": true
   },
-  "40210": {
+  "40211": {
     "title": "Room sensor factor climate system 1",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 20.0,
-    "name": "room-sensor-factor-climate-system-1-40210",
+    "name": "room-sensor-factor-climate-system-1-40211",
     "write": true
   },
-  "40211": {
+  "40212": {
     "title": "Input AUX5",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 59.0,
     "default": 0.0,
-    "name": "input-aux5-40211",
+    "name": "input-aux5-40212",
     "write": true
   },
-  "40212": {
+  "40213": {
     "title": "Input AUX4",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 59.0,
     "default": 0.0,
-    "name": "input-aux4-40212",
+    "name": "input-aux4-40213",
     "write": true
   },
-  "40213": {
+  "40214": {
     "title": "Input AUX3",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 59.0,
     "default": 0.0,
-    "name": "input-aux3-40213",
+    "name": "input-aux3-40214",
     "write": true
   },
-  "40214": {
+  "40215": {
     "title": "Input AUX2",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 59.0,
     "default": 0.0,
-    "name": "input-aux2-40214",
+    "name": "input-aux2-40215",
     "write": true
   },
-  "40215": {
+  "40216": {
     "title": "Input AUX1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 59.0,
     "default": 0.0,
-    "name": "input-aux1-40215",
+    "name": "input-aux1-40216",
     "write": true
   },
-  "40216": {
+  "40217": {
     "title": "Output AUX1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 25.0,
     "default": 0.0,
-    "name": "output-aux1-40216",
+    "name": "output-aux1-40217",
     "write": true
   },
-  "40217": {
+  "40218": {
     "title": "Speed of circulation pump for hot water",
     "factor": 1,
     "unit": "%",
@@ -6007,10 +6007,10 @@
     "min": 1.0,
     "max": 100.0,
     "default": 70.0,
-    "name": "speed-of-circulation-pump-for-hot-water-40217",
+    "name": "speed-of-circulation-pump-for-hot-water-40218",
     "write": true
   },
-  "40218": {
+  "40219": {
     "title": "Speed of circulation pump for heating",
     "factor": 1,
     "unit": "%",
@@ -6018,10 +6018,10 @@
     "min": 1.0,
     "max": 100.0,
     "default": 70.0,
-    "name": "speed-of-circulation-pump-for-heating-40218",
+    "name": "speed-of-circulation-pump-for-heating-40219",
     "write": true
   },
-  "40219": {
+  "40220": {
     "title": "Speed, heating medium pump for pool",
     "factor": 1,
     "unit": "%",
@@ -6029,10 +6029,10 @@
     "min": 1.0,
     "max": 100.0,
     "default": 70.0,
-    "name": "speed-heating-medium-pump-for-pool-40219",
+    "name": "speed-heating-medium-pump-for-pool-40220",
     "write": true
   },
-  "40220": {
+  "40221": {
     "title": "Speed heating medium pump waiting mode",
     "factor": 1,
     "unit": "%",
@@ -6040,10 +6040,10 @@
     "min": 1.0,
     "max": 100.0,
     "default": 30.0,
-    "name": "speed-heating-medium-pump-waiting-mode-40220",
+    "name": "speed-heating-medium-pump-waiting-mode-40221",
     "write": true
   },
-  "40221": {
+  "40222": {
     "title": "Speed of circulation pump passive cooling (EP14)",
     "factor": 1,
     "unit": "%",
@@ -6051,10 +6051,10 @@
     "min": 1.0,
     "max": 100.0,
     "default": 70.0,
-    "name": "speed-of-circulation-pump-passive-cooling-ep14-40221",
+    "name": "speed-of-circulation-pump-passive-cooling-ep14-40222",
     "write": true
   },
-  "40222": {
+  "40223": {
     "title": "Speed, brine pump",
     "factor": 1,
     "unit": "%",
@@ -6062,74 +6062,74 @@
     "min": 1.0,
     "max": 100.0,
     "default": 100.0,
-    "name": "speed-brine-pump-40222",
+    "name": "speed-brine-pump-40223",
     "write": true
   },
-  "40223": {
+  "40224": {
     "title": "Preset flow setting for climate system",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 3.0,
     "default": 1.0,
-    "name": "preset-flow-setting-for-climate-system-40223",
+    "name": "preset-flow-setting-for-climate-system-40224",
     "write": true
   },
-  "40225": {
+  "40226": {
     "title": "More hot water",
     "factor": 10,
     "size": "u16",
-    "name": "more-hot-water-40225",
+    "name": "more-hot-water-40226",
     "write": true
   },
-  "40237": {
+  "40238": {
     "title": "Oper. mode",
     "factor": 1,
     "size": "u8",
-    "name": "oper-mode-40237",
+    "name": "oper-mode-40238",
     "write": true
   },
-  "40675": {
+  "40676": {
     "title": "FLM 4",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "flm-4-40675",
+    "name": "flm-4-40676",
     "write": true
   },
-  "40676": {
+  "40677": {
     "title": "FLM 3",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "flm-3-40676",
+    "name": "flm-3-40677",
     "write": true
   },
-  "40677": {
+  "40678": {
     "title": "FLM 2",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "flm-2-40677",
+    "name": "flm-2-40678",
     "write": true
   },
-  "40678": {
+  "40679": {
     "title": "FLM 1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "flm-1-40678",
+    "name": "flm-1-40679",
     "write": true
   },
-  "40679": {
+  "40680": {
     "title": "DM diff. start additional heat",
     "factor": 1,
     "unit": "DM",
@@ -6137,50 +6137,50 @@
     "min": 100.0,
     "max": 2000.0,
     "default": 400.0,
-    "name": "dm-diff-start-additional-heat-40679",
+    "name": "dm-diff-start-additional-heat-40680",
     "write": true
   },
-  "40681": {
+  "40682": {
     "title": "Cooling heat sensor set point value",
     "factor": 10,
     "size": "s16",
     "min": 50.0,
     "max": 400.0,
     "default": 210.0,
-    "name": "cooling-heat-sensor-set-point-value-40681",
+    "name": "cooling-heat-sensor-set-point-value-40682",
     "write": true
   },
-  "40684": {
+  "40685": {
     "title": "Pool 2 accessory",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "pool-2-accessory-40684",
+    "name": "pool-2-accessory-40685",
     "write": true
   },
-  "40685": {
+  "40686": {
     "title": "Pool 1 accessory",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "pool-1-accessory-40685",
+    "name": "pool-1-accessory-40686",
     "write": true
   },
-  "40694": {
+  "40695": {
     "title": "Hot water comfort",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "hot-water-comfort-40694",
+    "name": "hot-water-comfort-40695",
     "write": true
   },
-  "40695": {
+  "40696": {
     "title": "Manual heating medium pump speed",
     "factor": 1,
     "unit": "%",
@@ -6188,17 +6188,17 @@
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "manual-heating-medium-pump-speed-40695",
+    "name": "manual-heating-medium-pump-speed-40696",
     "write": true
   },
-  "40697": {
+  "40698": {
     "title": "More hot water",
     "factor": 1,
     "size": "s8",
-    "name": "more-hot-water-40697",
+    "name": "more-hot-water-40698",
     "write": true
   },
-  "40703": {
+  "40704": {
     "title": "Start diff. DM, step-controlled add. heat",
     "factor": 1,
     "unit": "DM",
@@ -6206,20 +6206,20 @@
     "min": 0.0,
     "max": 2000.0,
     "default": 400.0,
-    "name": "start-diff-dm-step-controlled-add-heat-40703",
+    "name": "start-diff-dm-step-controlled-add-heat-40704",
     "write": true
   },
-  "40705": {
+  "40706": {
     "title": "HW comfort shunt on/off",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "hw-comfort-shunt-on-off-40705",
+    "name": "hw-comfort-shunt-on-off-40706",
     "write": true
   },
-  "40711": {
+  "40712": {
     "title": "Supp. air curve SAM, outd. temp. (T3)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6227,10 +6227,10 @@
     "min": -400.0,
     "max": 200.0,
     "default": 150.0,
-    "name": "supp-air-curve-sam-outd-temp-t3-40711",
+    "name": "supp-air-curve-sam-outd-temp-t3-40712",
     "write": true
   },
-  "40712": {
+  "40713": {
     "title": "Supp. air curve SAM, outd. temp. (T2)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6238,10 +6238,10 @@
     "min": -390.0,
     "max": 190.0,
     "default": 0.0,
-    "name": "supp-air-curve-sam-outd-temp-t2-40712",
+    "name": "supp-air-curve-sam-outd-temp-t2-40713",
     "write": true
   },
-  "40713": {
+  "40714": {
     "title": "Supp. air curve SAM, outd. temp. (T1)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6249,10 +6249,10 @@
     "min": -400.0,
     "max": 200.0,
     "default": -150.0,
-    "name": "supp-air-curve-sam-outd-temp-t1-40713",
+    "name": "supp-air-curve-sam-outd-temp-t1-40714",
     "write": true
   },
-  "40714": {
+  "40715": {
     "title": "Supp. air curve SAM, desired supp. air temp. at given outd. temp. (T3)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6260,10 +6260,10 @@
     "min": 160.0,
     "max": 220.0,
     "default": 180.0,
-    "name": "supp-air-curve-sam-desired-supp-air-temp-at-given-outd-temp-t3-40714",
+    "name": "supp-air-curve-sam-desired-supp-air-temp-at-given-outd-temp-t3-40715",
     "write": true
   },
-  "40715": {
+  "40716": {
     "title": "Supp. air curve SAM, desired supp. air temp. at given outd. temp. (T2)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6271,10 +6271,10 @@
     "min": 160.0,
     "max": 220.0,
     "default": 180.0,
-    "name": "supp-air-curve-sam-desired-supp-air-temp-at-given-outd-temp-t2-40715",
+    "name": "supp-air-curve-sam-desired-supp-air-temp-at-given-outd-temp-t2-40716",
     "write": true
   },
-  "40716": {
+  "40717": {
     "title": "Supp. air curve SAM, desired supp. air temp. at given outd. temp. (T1)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6282,10 +6282,10 @@
     "min": 160.0,
     "max": 220.0,
     "default": 180.0,
-    "name": "supp-air-curve-sam-desired-supp-air-temp-at-given-outd-temp-t1-40716",
+    "name": "supp-air-curve-sam-desired-supp-air-temp-at-given-outd-temp-t1-40717",
     "write": true
   },
-  "40720": {
+  "40721": {
     "title": "Min. supply temp. cooling climate system 1",
     "factor": 1,
     "unit": "\u00b0C",
@@ -6293,10 +6293,10 @@
     "min": -5.0,
     "max": 30.0,
     "default": 18.0,
-    "name": "min-supply-temp-cooling-climate-system-1-40720",
+    "name": "min-supply-temp-cooling-climate-system-1-40721",
     "write": true
   },
-  "40721": {
+  "40722": {
     "title": "Own curve, cooling P3",
     "factor": 1,
     "unit": "\u00b0C",
@@ -6304,10 +6304,10 @@
     "min": -5.0,
     "max": 40.0,
     "default": 20.0,
-    "name": "own-curve-cooling-p3-40721",
+    "name": "own-curve-cooling-p3-40722",
     "write": true
   },
-  "40722": {
+  "40723": {
     "title": "Own curve, cooling P5",
     "factor": 1,
     "unit": "\u00b0C",
@@ -6315,27 +6315,27 @@
     "min": -5.0,
     "max": 40.0,
     "default": 20.0,
-    "name": "own-curve-cooling-p5-40722",
+    "name": "own-curve-cooling-p5-40723",
     "write": true
   },
-  "40726": {
+  "40727": {
     "title": "Cooling connected, climate system 1",
     "factor": 1,
     "size": "u8",
-    "name": "cooling-connected-climate-system-1-40726",
+    "name": "cooling-connected-climate-system-1-40727",
     "write": true
   },
-  "40731": {
+  "40732": {
     "title": "ACS",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "acs-40731",
+    "name": "acs-40732",
     "write": true
   },
-  "40740": {
+  "40741": {
     "title": "Max speed, regulator, charge/heating medium pump (EB100)",
     "factor": 1,
     "unit": "%",
@@ -6343,17 +6343,17 @@
     "min": 50.0,
     "max": 100.0,
     "default": 100.0,
-    "name": "max-speed-regulator-charge-heating-medium-pump-eb100-40740",
+    "name": "max-speed-regulator-charge-heating-medium-pump-eb100-40741",
     "write": true
   },
-  "44064": {
+  "44065": {
     "title": "Shunted brine, accessory",
     "factor": 1,
     "size": "u8",
-    "name": "shunted-brine-accessory-44064",
+    "name": "shunted-brine-accessory-44065",
     "write": true
   },
-  "44067": {
+  "44068": {
     "title": "Shunted brine max. temp.",
     "factor": 1,
     "unit": "\u00b0C",
@@ -6361,20 +6361,20 @@
     "min": 0.0,
     "max": 30.0,
     "default": 20.0,
-    "name": "shunted-brine-max-temp-44067",
+    "name": "shunted-brine-max-temp-44068",
     "write": true
   },
-  "40760": {
+  "40761": {
     "title": "Heating (SG Ready)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "heating-sg-ready-40760",
+    "name": "heating-sg-ready-40761",
     "write": true
   },
-  "40766": {
+  "40767": {
     "title": "Set compressor frequency, cooling",
     "factor": 1,
     "unit": "%",
@@ -6382,88 +6382,88 @@
     "min": 1.0,
     "max": 100.0,
     "default": 1.0,
-    "name": "set-compressor-frequency-cooling-40766",
+    "name": "set-compressor-frequency-cooling-40767",
     "write": true
   },
-  "40767": {
+  "40768": {
     "title": "Input AUX5",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 59.0,
     "default": 0.0,
-    "name": "input-aux5-40767",
+    "name": "input-aux5-40768",
     "write": true
   },
-  "40842": {
+  "40843": {
     "title": "Speed, circulation pump, standby mode (EB100)",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "speed-circulation-pump-standby-mode-eb100-40842",
+    "name": "speed-circulation-pump-standby-mode-eb100-40843",
     "write": true
   },
-  "40843": {
+  "40844": {
     "title": "Activated (Smart Price Adaption)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "activated-smart-price-adaption-40843",
+    "name": "activated-smart-price-adaption-40844",
     "write": true
   },
-  "40844": {
+  "40845": {
     "title": "(SPA), heating activated (SPA)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "spa-heating-activated-spa-40844",
+    "name": "spa-heating-activated-spa-40845",
     "write": true
   },
-  "40845": {
+  "40846": {
     "title": "(SPA), heating influence",
     "factor": 1,
     "size": "s8",
     "min": 1.0,
     "max": 10.0,
     "default": 5.0,
-    "name": "spa-heating-influence-40845",
+    "name": "spa-heating-influence-40846",
     "write": true
   },
-  "40846": {
+  "40847": {
     "title": "(SPA), hot water activated",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "spa-hot-water-activated-40846",
+    "name": "spa-hot-water-activated-40847",
     "write": true
   },
-  "40849": {
+  "40850": {
     "title": "(SPA), cooling activated",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "spa-cooling-activated-40849",
+    "name": "spa-cooling-activated-40850",
     "write": true
   },
-  "40851": {
+  "40852": {
     "title": "(SPA), area",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 254.0,
     "default": 23.0,
-    "name": "spa-area-40851",
+    "name": "spa-area-40852",
     "write": true
   },
-  "40852": {
+  "40853": {
     "title": "Automatic speed heating medium pump, hot water",
     "factor": 1,
     "unit": "%",
@@ -6471,10 +6471,10 @@
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "automatic-speed-heating-medium-pump-hot-water-40852",
+    "name": "automatic-speed-heating-medium-pump-hot-water-40853",
     "write": true
   },
-  "40853": {
+  "40854": {
     "title": "Automatic speed heating medium pump, heating",
     "factor": 1,
     "unit": "%",
@@ -6482,10 +6482,10 @@
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "automatic-speed-heating-medium-pump-heating-40853",
+    "name": "automatic-speed-heating-medium-pump-heating-40854",
     "write": true
   },
-  "40858": {
+  "40859": {
     "title": "Maximum speed of circulation pump for heating",
     "factor": 1,
     "unit": "%",
@@ -6493,10 +6493,10 @@
     "min": 50.0,
     "max": 100.0,
     "default": 100.0,
-    "name": "maximum-speed-of-circulation-pump-for-heating-40858",
+    "name": "maximum-speed-of-circulation-pump-for-heating-40859",
     "write": true
   },
-  "40859": {
+  "40860": {
     "title": "Speed, brine pump, passive cooling mode",
     "factor": 1,
     "unit": "%",
@@ -6504,50 +6504,50 @@
     "min": 0.0,
     "max": 100.0,
     "default": 75.0,
-    "name": "speed-brine-pump-passive-cooling-mode-40859",
+    "name": "speed-brine-pump-passive-cooling-mode-40860",
     "write": true
   },
-  "40893": {
+  "40894": {
     "title": "External adjustment climate system 8",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-climate-system-8-40893",
+    "name": "external-adjustment-climate-system-8-40894",
     "write": true
   },
-  "40894": {
+  "40895": {
     "title": "External adjustment climate system 7",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-climate-system-7-40894",
+    "name": "external-adjustment-climate-system-7-40895",
     "write": true
   },
-  "40895": {
+  "40896": {
     "title": "External adjustment climate system 6",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-climate-system-6-40895",
+    "name": "external-adjustment-climate-system-6-40896",
     "write": true
   },
-  "40896": {
+  "40897": {
     "title": "External adjustment climate system 5",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-climate-system-5-40896",
+    "name": "external-adjustment-climate-system-5-40897",
     "write": true
   },
-  "40897": {
+  "40898": {
     "title": "External adjustment with room sensor climate system 8",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6555,10 +6555,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-climate-system-8-40897",
+    "name": "external-adjustment-with-room-sensor-climate-system-8-40898",
     "write": true
   },
-  "40898": {
+  "40899": {
     "title": "External adjustment with room sensor climate system 7",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6566,10 +6566,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-climate-system-7-40898",
+    "name": "external-adjustment-with-room-sensor-climate-system-7-40899",
     "write": true
   },
-  "40899": {
+  "40900": {
     "title": "External adjustment with room sensor climate system 6",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6577,10 +6577,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-climate-system-6-40899",
+    "name": "external-adjustment-with-room-sensor-climate-system-6-40900",
     "write": true
   },
-  "40900": {
+  "40901": {
     "title": "External adjustment with room sensor climate system 5",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6588,144 +6588,144 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-climate-system-5-40900",
+    "name": "external-adjustment-with-room-sensor-climate-system-5-40901",
     "write": true
   },
-  "40902": {
+  "40903": {
     "title": "(SPA), hot water influence",
     "factor": 1,
     "size": "s8",
     "min": 1.0,
     "max": 4.0,
     "default": 2.0,
-    "name": "spa-hot-water-influence-40902",
-    "write": true
-  },
-  "40903": {
-    "title": "Initiate inverter",
-    "factor": 1,
-    "size": "u8",
-    "name": "initiate-inverter-40903",
+    "name": "spa-hot-water-influence-40903",
     "write": true
   },
   "40904": {
-    "title": "Force initiated inverter",
+    "title": "Initiate inverter",
     "factor": 1,
     "size": "u8",
-    "name": "force-initiated-inverter-40904",
+    "name": "initiate-inverter-40904",
     "write": true
   },
   "40905": {
+    "title": "Force initiated inverter",
+    "factor": 1,
+    "size": "u8",
+    "name": "force-initiated-inverter-40905",
+    "write": true
+  },
+  "40906": {
     "title": "Climate system 5",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "climate-system-5-40905",
+    "name": "climate-system-5-40906",
     "write": true
   },
-  "40906": {
+  "40907": {
     "title": "Climate system 6",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "climate-system-6-40906",
+    "name": "climate-system-6-40907",
     "write": true
   },
-  "40907": {
+  "40908": {
     "title": "Climate system 7",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "climate-system-7-40907",
+    "name": "climate-system-7-40908",
     "write": true
   },
-  "40908": {
+  "40909": {
     "title": "Climate system 8",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "climate-system-8-40908",
+    "name": "climate-system-8-40909",
     "write": true
   },
-  "40932": {
+  "40933": {
     "title": "Heating connected, climate system 1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "heating-connected-climate-system-1-40932",
+    "name": "heating-connected-climate-system-1-40933",
     "write": true
   },
-  "40933": {
+  "40934": {
     "title": "ERS 1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "ers-1-40933",
+    "name": "ers-1-40934",
     "write": true
   },
-  "40939": {
+  "40940": {
     "title": "EB103/104-GP12",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "eb103-104-gp12-40939",
+    "name": "eb103-104-gp12-40940",
     "write": true
   },
-  "40940": {
+  "40941": {
     "title": "EB105/106-GP12",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "eb105-106-gp12-40940",
+    "name": "eb105-106-gp12-40941",
     "write": true
   },
-  "40941": {
+  "40942": {
     "title": "EB107/108-GP12",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "eb107-108-gp12-40941",
+    "name": "eb107-108-gp12-40942",
     "write": true
   },
-  "40942": {
+  "40943": {
     "title": "BlockFreq 2 activated",
     "factor": 1,
     "size": "s8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "blockfreq-2-activated-40942",
+    "name": "blockfreq-2-activated-40943",
     "write": true
   },
-  "40943": {
+  "40944": {
     "title": "BlockFreq 1 activated",
     "factor": 1,
     "size": "s8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "blockfreq-1-activated-40943",
+    "name": "blockfreq-1-activated-40944",
     "write": true
   },
-  "40945": {
+  "40946": {
     "title": "BlockFreq 1 start",
     "factor": 1,
     "unit": "Hz",
@@ -6733,10 +6733,10 @@
     "min": 20.0,
     "max": 113.0,
     "default": 91.0,
-    "name": "blockfreq-1-start-40945",
+    "name": "blockfreq-1-start-40946",
     "write": true
   },
-  "40947": {
+  "40948": {
     "title": "BlockFreq 1 stop",
     "factor": 1,
     "unit": "Hz",
@@ -6744,50 +6744,50 @@
     "min": 25.0,
     "max": 118.0,
     "default": 120.0,
-    "name": "blockfreq-1-stop-40947",
+    "name": "blockfreq-1-stop-40948",
     "write": true
   },
-  "40948": {
+  "40949": {
     "title": "Use room sensor climate system 8",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "use-room-sensor-climate-system-8-40948",
+    "name": "use-room-sensor-climate-system-8-40949",
     "write": true
   },
-  "40949": {
+  "40950": {
     "title": "Use room sensor climate system 7",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "use-room-sensor-climate-system-7-40949",
+    "name": "use-room-sensor-climate-system-7-40950",
     "write": true
   },
-  "40950": {
+  "40951": {
     "title": "Use room sensor climate system 6",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "use-room-sensor-climate-system-6-40950",
+    "name": "use-room-sensor-climate-system-6-40951",
     "write": true
   },
-  "40951": {
+  "40952": {
     "title": "Use room sensor climate system 5",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "use-room-sensor-climate-system-5-40951",
+    "name": "use-room-sensor-climate-system-5-40952",
     "write": true
   },
-  "40952": {
+  "40953": {
     "title": "Room sensor set point value climate system 8",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6795,10 +6795,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "room-sensor-set-point-value-climate-system-8-40952",
+    "name": "room-sensor-set-point-value-climate-system-8-40953",
     "write": true
   },
-  "40953": {
+  "40954": {
     "title": "Room sensor set point value climate system 7",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6806,10 +6806,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "room-sensor-set-point-value-climate-system-7-40953",
+    "name": "room-sensor-set-point-value-climate-system-7-40954",
     "write": true
   },
-  "40954": {
+  "40955": {
     "title": "Room sensor set point value climate system 6",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6817,10 +6817,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "room-sensor-set-point-value-climate-system-6-40954",
+    "name": "room-sensor-set-point-value-climate-system-6-40955",
     "write": true
   },
-  "40955": {
+  "40956": {
     "title": "Room sensor set point value climate system 5",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6828,70 +6828,70 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "room-sensor-set-point-value-climate-system-5-40955",
+    "name": "room-sensor-set-point-value-climate-system-5-40956",
     "write": true
   },
-  "40956": {
+  "40957": {
     "title": "Room sensor factor climate system 8",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 20.0,
-    "name": "room-sensor-factor-climate-system-8-40956",
+    "name": "room-sensor-factor-climate-system-8-40957",
     "write": true
   },
-  "40957": {
+  "40958": {
     "title": "Room sensor factor climate system 7",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 20.0,
-    "name": "room-sensor-factor-climate-system-7-40957",
+    "name": "room-sensor-factor-climate-system-7-40958",
     "write": true
   },
-  "40958": {
+  "40959": {
     "title": "Room sensor factor climate system 6",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 20.0,
-    "name": "room-sensor-factor-climate-system-6-40958",
+    "name": "room-sensor-factor-climate-system-6-40959",
     "write": true
   },
-  "40959": {
+  "40960": {
     "title": "Room sensor factor climate system 5",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 20.0,
-    "name": "room-sensor-factor-climate-system-5-40959",
+    "name": "room-sensor-factor-climate-system-5-40960",
     "write": true
   },
-  "40967": {
+  "40968": {
     "title": "Cooling curve climate system 1",
     "factor": 1,
     "size": "s8",
     "min": 0.0,
     "max": 9.0,
     "default": 0.0,
-    "name": "cooling-curve-climate-system-1-40967",
+    "name": "cooling-curve-climate-system-1-40968",
     "write": true
   },
-  "40975": {
+  "40976": {
     "title": "Cooling offset climate system 1",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "cooling-offset-climate-system-1-40975",
+    "name": "cooling-offset-climate-system-1-40976",
     "write": true
   },
-  "40976": {
+  "40977": {
     "title": "Own curve, cooling P4",
     "factor": 1,
     "unit": "\u00b0C",
@@ -6899,10 +6899,10 @@
     "min": -5.0,
     "max": 40.0,
     "default": 20.0,
-    "name": "own-curve-cooling-p4-40976",
+    "name": "own-curve-cooling-p4-40977",
     "write": true
   },
-  "40977": {
+  "40978": {
     "title": "Own curve, cooling P2",
     "factor": 1,
     "unit": "\u00b0C",
@@ -6910,10 +6910,10 @@
     "min": -5.0,
     "max": 40.0,
     "default": 20.0,
-    "name": "own-curve-cooling-p2-40977",
+    "name": "own-curve-cooling-p2-40978",
     "write": true
   },
-  "40978": {
+  "40979": {
     "title": "Own curve, cooling P1",
     "factor": 1,
     "unit": "\u00b0C",
@@ -6921,20 +6921,20 @@
     "min": -5.0,
     "max": 40.0,
     "default": 20.0,
-    "name": "own-curve-cooling-p1-40978",
+    "name": "own-curve-cooling-p1-40979",
     "write": true
   },
-  "40980": {
+  "40981": {
     "title": "Current transformer ratio",
     "factor": 1,
     "size": "u16",
     "min": 300.0,
     "max": 3000.0,
     "default": 300.0,
-    "name": "current-transformer-ratio-40980",
+    "name": "current-transformer-ratio-40981",
     "write": true
   },
-  "40981": {
+  "40982": {
     "title": "Room sensor set point value climate system 8, cooling",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6942,10 +6942,10 @@
     "min": 50.0,
     "max": 350.0,
     "default": 250.0,
-    "name": "room-sensor-set-point-value-climate-system-8-cooling-40981",
+    "name": "room-sensor-set-point-value-climate-system-8-cooling-40982",
     "write": true
   },
-  "40982": {
+  "40983": {
     "title": "Room sensor set point value climate system 7, cooling",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6953,10 +6953,10 @@
     "min": 50.0,
     "max": 350.0,
     "default": 250.0,
-    "name": "room-sensor-set-point-value-climate-system-7-cooling-40982",
+    "name": "room-sensor-set-point-value-climate-system-7-cooling-40983",
     "write": true
   },
-  "40983": {
+  "40984": {
     "title": "Room sensor set point value climate system 6, cooling",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6964,10 +6964,10 @@
     "min": 50.0,
     "max": 350.0,
     "default": 250.0,
-    "name": "room-sensor-set-point-value-climate-system-6-cooling-40983",
+    "name": "room-sensor-set-point-value-climate-system-6-cooling-40984",
     "write": true
   },
-  "40984": {
+  "40985": {
     "title": "Room sensor set point value climate system 5, cooling",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6975,10 +6975,10 @@
     "min": 50.0,
     "max": 350.0,
     "default": 250.0,
-    "name": "room-sensor-set-point-value-climate-system-5-cooling-40984",
+    "name": "room-sensor-set-point-value-climate-system-5-cooling-40985",
     "write": true
   },
-  "40985": {
+  "40986": {
     "title": "Room sensor set point value climate system 4, cooling",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6986,10 +6986,10 @@
     "min": 50.0,
     "max": 350.0,
     "default": 250.0,
-    "name": "room-sensor-set-point-value-climate-system-4-cooling-40985",
+    "name": "room-sensor-set-point-value-climate-system-4-cooling-40986",
     "write": true
   },
-  "40986": {
+  "40987": {
     "title": "Room sensor set point value climate system 3, cooling",
     "factor": 10,
     "unit": "\u00b0C",
@@ -6997,10 +6997,10 @@
     "min": 50.0,
     "max": 350.0,
     "default": 250.0,
-    "name": "room-sensor-set-point-value-climate-system-3-cooling-40986",
+    "name": "room-sensor-set-point-value-climate-system-3-cooling-40987",
     "write": true
   },
-  "40987": {
+  "40988": {
     "title": "Room sensor set point value climate system 2, cooling",
     "factor": 10,
     "unit": "\u00b0C",
@@ -7008,10 +7008,10 @@
     "min": 50.0,
     "max": 350.0,
     "default": 250.0,
-    "name": "room-sensor-set-point-value-climate-system-2-cooling-40987",
+    "name": "room-sensor-set-point-value-climate-system-2-cooling-40988",
     "write": true
   },
-  "40988": {
+  "40989": {
     "title": "Room sensor set point value climate system 1, cooling",
     "factor": 10,
     "unit": "\u00b0C",
@@ -7019,90 +7019,90 @@
     "min": 50.0,
     "max": 350.0,
     "default": 250.0,
-    "name": "room-sensor-set-point-value-climate-system-1-cooling-40988",
+    "name": "room-sensor-set-point-value-climate-system-1-cooling-40989",
     "write": true
   },
-  "40989": {
+  "40990": {
     "title": "Room sensor factor climate system 8, cooling",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 10.0,
-    "name": "room-sensor-factor-climate-system-8-cooling-40989",
+    "name": "room-sensor-factor-climate-system-8-cooling-40990",
     "write": true
   },
-  "40990": {
+  "40991": {
     "title": "Room sensor factor climate system 7, cooling",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 10.0,
-    "name": "room-sensor-factor-climate-system-7-cooling-40990",
+    "name": "room-sensor-factor-climate-system-7-cooling-40991",
     "write": true
   },
-  "40991": {
+  "40992": {
     "title": "Room sensor factor climate system 6, cooling",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 10.0,
-    "name": "room-sensor-factor-climate-system-6-cooling-40991",
+    "name": "room-sensor-factor-climate-system-6-cooling-40992",
     "write": true
   },
-  "40992": {
+  "40993": {
     "title": "Room sensor factor climate system 5, cooling",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 10.0,
-    "name": "room-sensor-factor-climate-system-5-cooling-40992",
+    "name": "room-sensor-factor-climate-system-5-cooling-40993",
     "write": true
   },
-  "40993": {
+  "40994": {
     "title": "Room sensor factor climate system 4, cooling",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 10.0,
-    "name": "room-sensor-factor-climate-system-4-cooling-40993",
+    "name": "room-sensor-factor-climate-system-4-cooling-40994",
     "write": true
   },
-  "40994": {
+  "40995": {
     "title": "Room sensor factor climate system 3, cooling",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 10.0,
-    "name": "room-sensor-factor-climate-system-3-cooling-40994",
+    "name": "room-sensor-factor-climate-system-3-cooling-40995",
     "write": true
   },
-  "40995": {
+  "40996": {
     "title": "Room sensor factor climate system 2, cooling",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 10.0,
-    "name": "room-sensor-factor-climate-system-2-cooling-40995",
+    "name": "room-sensor-factor-climate-system-2-cooling-40996",
     "write": true
   },
-  "40996": {
+  "40997": {
     "title": "Room sensor factor climate system 1, cooling",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 60.0,
     "default": 10.0,
-    "name": "room-sensor-factor-climate-system-1-cooling-40996",
+    "name": "room-sensor-factor-climate-system-1-cooling-40997",
     "write": true
   },
-  "40997": {
+  "40998": {
     "title": "Set point value (RH)",
     "factor": 1,
     "unit": "%",
@@ -7110,30 +7110,30 @@
     "min": 30.0,
     "max": 90.0,
     "default": 60.0,
-    "name": "set-point-value-rh-40997",
+    "name": "set-point-value-rh-40998",
     "write": true
   },
-  "40998": {
+  "40999": {
     "title": "HTS 1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "hts-1-40998",
+    "name": "hts-1-40999",
     "write": true
   },
-  "41015": {
+  "41016": {
     "title": "OPT",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "opt-41015",
+    "name": "opt-41016",
     "write": true
   },
-  "41016": {
+  "41017": {
     "title": "DM start difference (OPT)",
     "factor": 1,
     "unit": "DM",
@@ -7141,10 +7141,10 @@
     "min": 10.0,
     "max": 2000.0,
     "default": 700.0,
-    "name": "dm-start-difference-opt-41016",
+    "name": "dm-start-difference-opt-41017",
     "write": true
   },
-  "41021": {
+  "41022": {
     "title": "Exhaust air fan speed 4 (ERS 1)",
     "factor": 1,
     "unit": "%",
@@ -7152,10 +7152,10 @@
     "min": 0.0,
     "max": 100.0,
     "default": 100.0,
-    "name": "exhaust-air-fan-speed-4-ers-1-41021",
+    "name": "exhaust-air-fan-speed-4-ers-1-41022",
     "write": true
   },
-  "41022": {
+  "41023": {
     "title": "Exhaust air fan speed 3 (ERS 1)",
     "factor": 1,
     "unit": "%",
@@ -7163,10 +7163,10 @@
     "min": 0.0,
     "max": 100.0,
     "default": 80.0,
-    "name": "exhaust-air-fan-speed-3-ers-1-41022",
+    "name": "exhaust-air-fan-speed-3-ers-1-41023",
     "write": true
   },
-  "41023": {
+  "41024": {
     "title": "Exhaust air fan speed 2 (ERS 1)",
     "factor": 1,
     "unit": "%",
@@ -7174,10 +7174,10 @@
     "min": 0.0,
     "max": 100.0,
     "default": 30.0,
-    "name": "exhaust-air-fan-speed-2-ers-1-41023",
+    "name": "exhaust-air-fan-speed-2-ers-1-41024",
     "write": true
   },
-  "41024": {
+  "41025": {
     "title": "Exhaust air fan speed 1 (ERS 1)",
     "factor": 1,
     "unit": "%",
@@ -7185,10 +7185,10 @@
     "min": 0.0,
     "max": 100.0,
     "default": 0.0,
-    "name": "exhaust-air-fan-speed-1-ers-1-41024",
+    "name": "exhaust-air-fan-speed-1-ers-1-41025",
     "write": true
   },
-  "41025": {
+  "41026": {
     "title": "Exhaust air fan speed normal (ERS 1)",
     "factor": 1,
     "unit": "%",
@@ -7196,20 +7196,20 @@
     "min": 1.0,
     "max": 100.0,
     "default": 75.0,
-    "name": "exhaust-air-fan-speed-normal-ers-1-41025",
+    "name": "exhaust-air-fan-speed-normal-ers-1-41026",
     "write": true
   },
-  "41026": {
+  "41027": {
     "title": "Thermostat (ACS)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "thermostat-acs-41026",
+    "name": "thermostat-acs-41027",
     "write": true
   },
-  "41027": {
+  "41028": {
     "title": "Filtering time (BT64)",
     "factor": 1,
     "unit": "min",
@@ -7217,10 +7217,10 @@
     "min": 5.0,
     "max": 30.0,
     "default": 5.0,
-    "name": "filtering-time-bt64-41027",
+    "name": "filtering-time-bt64-41028",
     "write": true
   },
-  "41028": {
+  "41029": {
     "title": "(ACS) - Thermostat, hysteresis between compressors",
     "factor": 1,
     "unit": "\u00b0C",
@@ -7228,10 +7228,10 @@
     "min": 1.0,
     "max": 10.0,
     "default": 2.0,
-    "name": "acs-thermostat-hysteresis-between-compressors-41028",
+    "name": "acs-thermostat-hysteresis-between-compressors-41029",
     "write": true
   },
-  "41029": {
+  "41030": {
     "title": "Start temperature (BT64)",
     "factor": 1,
     "unit": "\u00b0C",
@@ -7239,10 +7239,10 @@
     "min": -8.0,
     "max": 30.0,
     "default": 10.0,
-    "name": "start-temperature-bt64-41029",
+    "name": "start-temperature-bt64-41030",
     "write": true
   },
-  "41030": {
+  "41031": {
     "title": "Temperature to transfer to borehole",
     "factor": 1,
     "unit": "\u00b0C",
@@ -7250,20 +7250,20 @@
     "min": -8.0,
     "max": 30.0,
     "default": 0.0,
-    "name": "temperature-to-transfer-to-borehole-41030",
+    "name": "temperature-to-transfer-to-borehole-41031",
     "write": true
   },
-  "41031": {
+  "41032": {
     "title": "Flow sensor activated X21",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "flow-sensor-activated-x21-41031",
+    "name": "flow-sensor-activated-x21-41032",
     "write": true
   },
-  "41044": {
+  "41045": {
     "title": "Bypass temp. (ERS 1)",
     "factor": 1,
     "unit": "\u00b0C",
@@ -7271,20 +7271,20 @@
     "min": 2.0,
     "max": 10.0,
     "default": 4.0,
-    "name": "bypass-temp-ers-1-41044",
+    "name": "bypass-temp-ers-1-41045",
     "write": true
   },
-  "41049": {
+  "41050": {
     "title": "Flow sensor activated X22",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "flow-sensor-activated-x22-41049",
+    "name": "flow-sensor-activated-x22-41050",
     "write": true
   },
-  "41052": {
+  "41053": {
     "title": "Max. internal additional heat SG Ready",
     "factor": 100,
     "unit": "kW",
@@ -7292,57 +7292,57 @@
     "min": 0.0,
     "max": 900.0,
     "default": 700.0,
-    "name": "max-internal-additional-heat-sg-ready-41052",
+    "name": "max-internal-additional-heat-sg-ready-41053",
     "write": true
   },
-  "41066": {
+  "41067": {
     "title": "Hysteresis (OPT)",
     "factor": 1,
     "size": "s16",
     "min": 10.0,
     "max": 2000.0,
     "default": 100.0,
-    "name": "hysteresis-opt-41066",
+    "name": "hysteresis-opt-41067",
     "write": true
   },
-  "41068": {
+  "41069": {
     "title": "Activated (EME10)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "activated-eme10-41068",
+    "name": "activated-eme10-41069",
     "write": true
   },
-  "41069": {
+  "41070": {
     "title": "PV panel affects heating (EME)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "pv-panel-affects-heating-eme-41069",
+    "name": "pv-panel-affects-heating-eme-41070",
     "write": true
   },
-  "41070": {
+  "41071": {
     "title": "PV panel affects hot water (EME)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "pv-panel-affects-hot-water-eme-41070",
-    "write": true
-  },
-  "41071": {
-    "title": "Delay timer EME",
-    "factor": 1,
-    "size": "u16",
-    "name": "delay-timer-eme-41071",
+    "name": "pv-panel-affects-hot-water-eme-41071",
     "write": true
   },
   "41072": {
+    "title": "Delay timer EME",
+    "factor": 1,
+    "size": "u16",
+    "name": "delay-timer-eme-41072",
+    "write": true
+  },
+  "41073": {
     "title": "Low brine out alarm temperature (EP15)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -7350,40 +7350,40 @@
     "min": -120.0,
     "max": 150.0,
     "default": -80.0,
-    "name": "low-brine-out-alarm-temperature-ep15-41072",
+    "name": "low-brine-out-alarm-temperature-ep15-41073",
     "write": true
   },
-  "41074": {
+  "41075": {
     "title": "Pump 4 (FLM)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "pump-4-flm-41074",
+    "name": "pump-4-flm-41075",
     "write": true
   },
-  "41075": {
+  "41076": {
     "title": "Pump 3 (FLM)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "pump-3-flm-41075",
+    "name": "pump-3-flm-41076",
     "write": true
   },
-  "41076": {
+  "41077": {
     "title": "Pump 2 (FLM)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "pump-2-flm-41076",
+    "name": "pump-2-flm-41077",
     "write": true
   },
-  "41077": {
+  "41078": {
     "title": "Defrosting time (FLM 4)",
     "factor": 1,
     "unit": "h",
@@ -7391,10 +7391,10 @@
     "min": 1.0,
     "max": 30.0,
     "default": 10.0,
-    "name": "defrosting-time-flm-4-41077",
+    "name": "defrosting-time-flm-4-41078",
     "write": true
   },
-  "41078": {
+  "41079": {
     "title": "Defrosting time (FLM 3)",
     "factor": 1,
     "unit": "h",
@@ -7402,10 +7402,10 @@
     "min": 1.0,
     "max": 30.0,
     "default": 10.0,
-    "name": "defrosting-time-flm-3-41078",
+    "name": "defrosting-time-flm-3-41079",
     "write": true
   },
-  "41079": {
+  "41080": {
     "title": "Defrosting time (FLM 2)",
     "factor": 1,
     "unit": "h",
@@ -7413,40 +7413,40 @@
     "min": 1.0,
     "max": 30.0,
     "default": 10.0,
-    "name": "defrosting-time-flm-2-41079",
+    "name": "defrosting-time-flm-2-41080",
     "write": true
   },
-  "41080": {
+  "41081": {
     "title": "Cooling (FLM 4)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "cooling-flm-4-41080",
+    "name": "cooling-flm-4-41081",
     "write": true
   },
-  "41081": {
+  "41082": {
     "title": "Cooling (FLM 3)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "cooling-flm-3-41081",
+    "name": "cooling-flm-3-41082",
     "write": true
   },
-  "41082": {
+  "41083": {
     "title": "Cooling (FLM 2)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "cooling-flm-2-41082",
+    "name": "cooling-flm-2-41083",
     "write": true
   },
-  "41083": {
+  "41084": {
     "title": "Pump speed (FLM 4)",
     "factor": 1,
     "unit": "%",
@@ -7454,10 +7454,10 @@
     "min": 1.0,
     "max": 100.0,
     "default": 100.0,
-    "name": "pump-speed-flm-4-41083",
+    "name": "pump-speed-flm-4-41084",
     "write": true
   },
-  "41084": {
+  "41085": {
     "title": "Pump speed (FLM 3)",
     "factor": 1,
     "unit": "%",
@@ -7465,10 +7465,10 @@
     "min": 1.0,
     "max": 100.0,
     "default": 100.0,
-    "name": "pump-speed-flm-3-41084",
+    "name": "pump-speed-flm-3-41085",
     "write": true
   },
-  "41085": {
+  "41086": {
     "title": "Pump speed (FLM 2)",
     "factor": 1,
     "unit": "%",
@@ -7476,10 +7476,10 @@
     "min": 1.0,
     "max": 100.0,
     "default": 100.0,
-    "name": "pump-speed-flm-2-41085",
+    "name": "pump-speed-flm-2-41086",
     "write": true
   },
-  "41086": {
+  "41087": {
     "title": "Pump speed (FLM 1)",
     "factor": 1,
     "unit": "%",
@@ -7487,10 +7487,10 @@
     "min": 1.0,
     "max": 100.0,
     "default": 100.0,
-    "name": "pump-speed-flm-1-41086",
+    "name": "pump-speed-flm-1-41087",
     "write": true
   },
-  "41087": {
+  "41088": {
     "title": "Excess temperature (FLM 4)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -7498,10 +7498,10 @@
     "min": 10.0,
     "max": 100.0,
     "default": 30.0,
-    "name": "excess-temperature-flm-4-41087",
+    "name": "excess-temperature-flm-4-41088",
     "write": true
   },
-  "41088": {
+  "41089": {
     "title": "Excess temperature (FLM 3)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -7509,10 +7509,10 @@
     "min": 10.0,
     "max": 100.0,
     "default": 30.0,
-    "name": "excess-temperature-flm-3-41088",
+    "name": "excess-temperature-flm-3-41089",
     "write": true
   },
-  "41089": {
+  "41090": {
     "title": "Excess temperature (FLM 2)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -7520,10 +7520,10 @@
     "min": 10.0,
     "max": 100.0,
     "default": 30.0,
-    "name": "excess-temperature-flm-2-41089",
+    "name": "excess-temperature-flm-2-41090",
     "write": true
   },
-  "41090": {
+  "41091": {
     "title": "Excess temperature (FLM 1)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -7531,10 +7531,10 @@
     "min": 10.0,
     "max": 100.0,
     "default": 30.0,
-    "name": "excess-temperature-flm-1-41090",
+    "name": "excess-temperature-flm-1-41091",
     "write": true
   },
-  "41091": {
+  "41092": {
     "title": "Set point value, cooling (FLM 4)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -7542,10 +7542,10 @@
     "min": 50.0,
     "max": 400.0,
     "default": 210.0,
-    "name": "set-point-value-cooling-flm-4-41091",
+    "name": "set-point-value-cooling-flm-4-41092",
     "write": true
   },
-  "41092": {
+  "41093": {
     "title": "Set point value, cooling (FLM 3)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -7553,10 +7553,10 @@
     "min": 50.0,
     "max": 400.0,
     "default": 210.0,
-    "name": "set-point-value-cooling-flm-3-41092",
+    "name": "set-point-value-cooling-flm-3-41093",
     "write": true
   },
-  "41093": {
+  "41094": {
     "title": "Set point value, cooling (FLM 2)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -7564,10 +7564,10 @@
     "min": 50.0,
     "max": 400.0,
     "default": 210.0,
-    "name": "set-point-value-cooling-flm-2-41093",
+    "name": "set-point-value-cooling-flm-2-41094",
     "write": true
   },
-  "41094": {
+  "41095": {
     "title": "Set point value, cooling (FLM 1)",
     "factor": 10,
     "unit": "\u00b0C",
@@ -7575,37 +7575,37 @@
     "min": 50.0,
     "max": 400.0,
     "default": 210.0,
-    "name": "set-point-value-cooling-flm-1-41094",
-    "write": true
-  },
-  "41095": {
-    "title": "AUX blocking (OPT)",
-    "factor": 1,
-    "size": "u8",
-    "name": "aux-blocking-opt-41095",
+    "name": "set-point-value-cooling-flm-1-41095",
     "write": true
   },
   "41096": {
+    "title": "AUX blocking (OPT)",
+    "factor": 1,
+    "size": "u8",
+    "name": "aux-blocking-opt-41096",
+    "write": true
+  },
+  "41097": {
     "title": "Outdoor air mixing",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "outdoor-air-mixing-41096",
+    "name": "outdoor-air-mixing-41097",
     "write": true
   },
-  "41102": {
+  "41103": {
     "title": "Smart home room control",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "smart-home-room-control-41102",
+    "name": "smart-home-room-control-41103",
     "write": true
   },
-  "41103": {
+  "41104": {
     "title": "Speed, brine pump, standby mode (EP14)",
     "factor": 1,
     "unit": "%",
@@ -7613,530 +7613,530 @@
     "min": 0.0,
     "max": 100.0,
     "default": 30.0,
-    "name": "speed-brine-pump-standby-mode-ep14-41103",
+    "name": "speed-brine-pump-standby-mode-ep14-41104",
     "write": true
   },
-  "41105": {
+  "41106": {
     "title": "Smart Energy Source",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "smart-energy-source-41105",
+    "name": "smart-energy-source-41106",
     "write": true
   },
-  "41106": {
+  "41107": {
     "title": "Control method, smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "control-method-smart-energy-source-41106",
+    "name": "control-method-smart-energy-source-41107",
     "write": true
   },
-  "41107": {
+  "41108": {
     "title": "El. price, special, smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 2.0,
     "default": 0.0,
-    "name": "el-price-special-smart-energy-source-41107",
-    "write": true
-  },
-  "41108": {
-    "title": "El. price, fixed, smart energy source",
-    "factor": 1,
-    "size": "u16",
-    "min": 0.0,
-    "max": 10000.0,
-    "default": 100.0,
-    "name": "el-price-fixed-smart-energy-source-41108",
+    "name": "el-price-special-smart-energy-source-41108",
     "write": true
   },
   "41109": {
-    "title": "El. price, smart energy source",
+    "title": "El. price, fixed, smart energy source",
     "factor": 1,
-    "size": "u8",
+    "size": "u16",
     "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "el-price-smart-energy-source-41109",
+    "max": 10000.0,
+    "default": 100.0,
+    "name": "el-price-fixed-smart-energy-source-41109",
     "write": true
   },
   "41110": {
-    "title": "El. price, fixed, smart energy source",
+    "title": "El. price, smart energy source",
     "factor": 1,
-    "size": "u16",
+    "size": "u8",
     "min": 0.0,
-    "max": 10000.0,
-    "default": 100.0,
-    "name": "el-price-fixed-smart-energy-source-41110",
+    "max": 1.0,
+    "default": 0.0,
+    "name": "el-price-smart-energy-source-41110",
     "write": true
   },
   "41111": {
-    "title": "El. price, smart energy source",
+    "title": "El. price, fixed, smart energy source",
     "factor": 1,
-    "size": "u8",
+    "size": "u16",
     "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "el-price-smart-energy-source-41111",
+    "max": 10000.0,
+    "default": 100.0,
+    "name": "el-price-fixed-smart-energy-source-41111",
     "write": true
   },
   "41112": {
-    "title": "El. price, fixed, smart energy source",
+    "title": "El. price, smart energy source",
     "factor": 1,
-    "size": "u16",
+    "size": "u8",
     "min": 0.0,
-    "max": 10000.0,
-    "default": 100.0,
-    "name": "el-price-fixed-smart-energy-source-41112",
+    "max": 1.0,
+    "default": 0.0,
+    "name": "el-price-smart-energy-source-41112",
     "write": true
   },
   "41113": {
-    "title": "El. price, smart energy source",
+    "title": "El. price, fixed, smart energy source",
     "factor": 1,
-    "size": "u8",
+    "size": "u16",
     "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "el-price-smart-energy-source-41113",
+    "max": 10000.0,
+    "default": 100.0,
+    "name": "el-price-fixed-smart-energy-source-41113",
     "write": true
   },
   "41114": {
-    "title": "El. price, fixed, smart energy source",
-    "factor": 1,
-    "size": "u16",
-    "min": 0.0,
-    "max": 10000.0,
-    "default": 100.0,
-    "name": "el-price-fixed-smart-energy-source-41114",
-    "write": true
-  },
-  "41115": {
     "title": "El. price, smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "el-price-smart-energy-source-41115",
+    "name": "el-price-smart-energy-source-41114",
     "write": true
   },
-  "41116": {
+  "41115": {
     "title": "El. price, fixed, smart energy source",
     "factor": 1,
     "size": "u16",
     "min": 0.0,
     "max": 10000.0,
     "default": 100.0,
-    "name": "el-price-fixed-smart-energy-source-41116",
+    "name": "el-price-fixed-smart-energy-source-41115",
+    "write": true
+  },
+  "41116": {
+    "title": "El. price, smart energy source",
+    "factor": 1,
+    "size": "u8",
+    "min": 0.0,
+    "max": 1.0,
+    "default": 0.0,
+    "name": "el-price-smart-energy-source-41116",
     "write": true
   },
   "41117": {
+    "title": "El. price, fixed, smart energy source",
+    "factor": 1,
+    "size": "u16",
+    "min": 0.0,
+    "max": 10000.0,
+    "default": 100.0,
+    "name": "el-price-fixed-smart-energy-source-41117",
+    "write": true
+  },
+  "41118": {
     "title": "Prim. factor, smart energy source",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 50.0,
     "default": 25.0,
-    "name": "prim-factor-smart-energy-source-41117",
+    "name": "prim-factor-smart-energy-source-41118",
     "write": true
   },
-  "41118": {
+  "41119": {
     "title": "Prim. factor, shunt add. heat smart energy source",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 50.0,
     "default": 10.0,
-    "name": "prim-factor-shunt-add-heat-smart-energy-source-41118",
+    "name": "prim-factor-shunt-add-heat-smart-energy-source-41119",
     "write": true
   },
-  "41119": {
+  "41120": {
     "title": "Prim. factor, ext. step add. heat smart energy source",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 50.0,
     "default": 10.0,
-    "name": "prim-factor-ext-step-add-heat-smart-energy-source-41119",
+    "name": "prim-factor-ext-step-add-heat-smart-energy-source-41120",
     "write": true
   },
-  "41120": {
+  "41121": {
     "title": "Prim. factor, OPT10 smart energy source",
     "factor": 10,
     "size": "u8",
     "min": 0.0,
     "max": 50.0,
     "default": 10.0,
-    "name": "prim-factor-opt10-smart-energy-source-41120",
+    "name": "prim-factor-opt10-smart-energy-source-41121",
     "write": true
   },
-  "41121": {
+  "41122": {
     "title": "OPT10, high tariff price smart energy source",
     "factor": 1,
     "size": "u16",
     "min": 1.0,
     "max": 10000.0,
     "default": 100.0,
-    "name": "opt10-high-tariff-price-smart-energy-source-41121",
+    "name": "opt10-high-tariff-price-smart-energy-source-41122",
     "write": true
   },
-  "41122": {
+  "41123": {
     "title": "OPT10, low tariff price smart energy source",
     "factor": 1,
     "size": "u16",
     "min": 1.0,
     "max": 10000.0,
     "default": 100.0,
-    "name": "opt10-low-tariff-price-smart-energy-source-41122",
+    "name": "opt10-low-tariff-price-smart-energy-source-41123",
     "write": true
   },
-  "41123": {
+  "41124": {
     "title": "ext. step add. heat, high tariff price smart energy source",
     "factor": 1,
     "size": "u16",
     "min": 1.0,
     "max": 10000.0,
     "default": 100.0,
-    "name": "ext-step-add-heat-high-tariff-price-smart-energy-source-41123",
+    "name": "ext-step-add-heat-high-tariff-price-smart-energy-source-41124",
     "write": true
   },
-  "41124": {
+  "41125": {
     "title": "ext. step add. heat, low tariff price smart energy source",
     "factor": 1,
     "size": "u16",
     "min": 1.0,
     "max": 10000.0,
     "default": 100.0,
-    "name": "ext-step-add-heat-low-tariff-price-smart-energy-source-41124",
+    "name": "ext-step-add-heat-low-tariff-price-smart-energy-source-41125",
     "write": true
   },
-  "41125": {
+  "41126": {
     "title": "Shunt add. heat, high tariff price smart energy source",
     "factor": 1,
     "size": "u16",
     "min": 1.0,
     "max": 10000.0,
     "default": 100.0,
-    "name": "shunt-add-heat-high-tariff-price-smart-energy-source-41125",
+    "name": "shunt-add-heat-high-tariff-price-smart-energy-source-41126",
     "write": true
   },
-  "41126": {
+  "41127": {
     "title": "Shunt add. heat, low tariff price smart energy source",
     "factor": 1,
     "size": "u16",
     "min": 1.0,
     "max": 10000.0,
     "default": 100.0,
-    "name": "shunt-add-heat-low-tariff-price-smart-energy-source-41126",
+    "name": "shunt-add-heat-low-tariff-price-smart-energy-source-41127",
     "write": true
   },
-  "41127": {
+  "41128": {
     "title": "El. price, fixed, high tariff smart energy source",
     "factor": 1,
     "size": "u16",
     "min": 1.0,
     "max": 10000.0,
     "default": 100.0,
-    "name": "el-price-fixed-high-tariff-smart-energy-source-41127",
+    "name": "el-price-fixed-high-tariff-smart-energy-source-41128",
     "write": true
   },
-  "41128": {
+  "41129": {
     "title": "El. price, fixed, low tariff smart energy source",
     "factor": 1,
     "size": "u16",
     "min": 1.0,
     "max": 10000.0,
     "default": 100.0,
-    "name": "el-price-fixed-low-tariff-smart-energy-source-41128",
+    "name": "el-price-fixed-low-tariff-smart-energy-source-41129",
     "write": true
   },
-  "41129": {
+  "41130": {
     "title": "El. price, variable, high tariff smart energy source",
     "factor": 1,
     "size": "u16",
     "min": 1.0,
     "max": 10000.0,
     "default": 100.0,
-    "name": "el-price-variable-high-tariff-smart-energy-source-41129",
+    "name": "el-price-variable-high-tariff-smart-energy-source-41130",
     "write": true
   },
-  "41130": {
+  "41131": {
     "title": "El. price, variable, low tariff smart energy source",
     "factor": 1,
     "size": "u16",
     "min": 1.0,
     "max": 10000.0,
     "default": 100.0,
-    "name": "el-price-variable-low-tariff-smart-energy-source-41130",
+    "name": "el-price-variable-low-tariff-smart-energy-source-41131",
     "write": true
   },
-  "41131": {
+  "41132": {
     "title": "DM start source, priority 5 smart energy source",
     "factor": 1,
     "size": "s16",
     "min": 100.0,
     "max": 2000.0,
     "default": 400.0,
-    "name": "dm-start-source-priority-5-smart-energy-source-41131",
+    "name": "dm-start-source-priority-5-smart-energy-source-41132",
     "write": true
   },
-  "41132": {
+  "41133": {
     "title": "DM start source, priority 4 smart energy source",
     "factor": 1,
     "size": "s16",
     "min": 100.0,
     "max": 2000.0,
     "default": 400.0,
-    "name": "dm-start-source-priority-4-smart-energy-source-41132",
+    "name": "dm-start-source-priority-4-smart-energy-source-41133",
     "write": true
   },
-  "41133": {
+  "41134": {
     "title": "DM start source, priority 3 smart energy source",
     "factor": 1,
     "size": "s16",
     "min": 100.0,
     "max": 2000.0,
     "default": 400.0,
-    "name": "dm-start-source-priority-3-smart-energy-source-41133",
+    "name": "dm-start-source-priority-3-smart-energy-source-41134",
     "write": true
   },
-  "41134": {
+  "41135": {
     "title": "DM start source, priority 2 smart energy source",
     "factor": 1,
     "size": "s16",
     "min": 100.0,
     "max": 2000.0,
     "default": 400.0,
-    "name": "dm-start-source-priority-2-smart-energy-source-41134",
+    "name": "dm-start-source-priority-2-smart-energy-source-41135",
     "write": true
   },
-  "41135": {
+  "41136": {
     "title": "DM start source, priority 1 smart energy source",
     "factor": 1,
     "size": "s16",
     "min": -2000.0,
     "max": -10.0,
     "default": -60.0,
-    "name": "dm-start-source-priority-1-smart-energy-source-41135",
+    "name": "dm-start-source-priority-1-smart-energy-source-41136",
     "write": true
   },
-  "41136": {
+  "41137": {
     "title": "Start day, tariff smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 31.0,
     "default": 1.0,
-    "name": "start-day-tariff-smart-energy-source-41136",
+    "name": "start-day-tariff-smart-energy-source-41137",
     "write": true
   },
-  "41137": {
+  "41138": {
     "title": "End day, tariff smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 31.0,
     "default": 31.0,
-    "name": "end-day-tariff-smart-energy-source-41137",
+    "name": "end-day-tariff-smart-energy-source-41138",
     "write": true
   },
-  "41138": {
+  "41139": {
     "title": "Start month, tariff smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 12.0,
     "default": 1.0,
-    "name": "start-month-tariff-smart-energy-source-41138",
+    "name": "start-month-tariff-smart-energy-source-41139",
     "write": true
   },
-  "41139": {
+  "41140": {
     "title": "End month, tariff smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 12.0,
     "default": 12.0,
-    "name": "end-month-tariff-smart-energy-source-41139",
+    "name": "end-month-tariff-smart-energy-source-41140",
     "write": true
   },
-  "41172": {
+  "41173": {
     "title": "Start day, fixed tariff smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 31.0,
     "default": 1.0,
-    "name": "start-day-fixed-tariff-smart-energy-source-41172",
+    "name": "start-day-fixed-tariff-smart-energy-source-41173",
     "write": true
   },
-  "41173": {
+  "41174": {
     "title": "End day, fixed tariff smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 31.0,
     "default": 31.0,
-    "name": "end-day-fixed-tariff-smart-energy-source-41173",
+    "name": "end-day-fixed-tariff-smart-energy-source-41174",
     "write": true
   },
-  "41174": {
+  "41175": {
     "title": "Start month, fixed tariff smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 12.0,
     "default": 1.0,
-    "name": "start-month-fixed-tariff-smart-energy-source-41174",
+    "name": "start-month-fixed-tariff-smart-energy-source-41175",
     "write": true
   },
-  "41175": {
+  "41176": {
     "title": "End month, fixed tariff smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 12.0,
     "default": 12.0,
-    "name": "end-month-fixed-tariff-smart-energy-source-41175",
+    "name": "end-month-fixed-tariff-smart-energy-source-41176",
     "write": true
   },
-  "41208": {
+  "41209": {
     "title": "Start day, tariff OPT10 smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 31.0,
     "default": 1.0,
-    "name": "start-day-tariff-opt10-smart-energy-source-41208",
+    "name": "start-day-tariff-opt10-smart-energy-source-41209",
     "write": true
   },
-  "41209": {
+  "41210": {
     "title": "End day, tariff OPT10 smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 31.0,
     "default": 31.0,
-    "name": "end-day-tariff-opt10-smart-energy-source-41209",
+    "name": "end-day-tariff-opt10-smart-energy-source-41210",
     "write": true
   },
-  "41210": {
+  "41211": {
     "title": "Start month, tariff OPT10 smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 12.0,
     "default": 1.0,
-    "name": "start-month-tariff-opt10-smart-energy-source-41210",
+    "name": "start-month-tariff-opt10-smart-energy-source-41211",
     "write": true
   },
-  "41211": {
+  "41212": {
     "title": "End month, tariff OPT10 smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 12.0,
     "default": 12.0,
-    "name": "end-month-tariff-opt10-smart-energy-source-41211",
+    "name": "end-month-tariff-opt10-smart-energy-source-41212",
     "write": true
   },
-  "41244": {
+  "41245": {
     "title": "Start day tariff, shunt additional heat smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 31.0,
     "default": 1.0,
-    "name": "start-day-tariff-shunt-additional-heat-smart-energy-source-41244",
+    "name": "start-day-tariff-shunt-additional-heat-smart-energy-source-41245",
     "write": true
   },
-  "41245": {
+  "41246": {
     "title": "End day tariff, shunt additional heat  smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 31.0,
     "default": 31.0,
-    "name": "end-day-tariff-shunt-additional-heat-smart-energy-source-41245",
+    "name": "end-day-tariff-shunt-additional-heat-smart-energy-source-41246",
     "write": true
   },
-  "41246": {
+  "41247": {
     "title": "Start month tariff, shunt additional heat smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 12.0,
     "default": 1.0,
-    "name": "start-month-tariff-shunt-additional-heat-smart-energy-source-41246",
+    "name": "start-month-tariff-shunt-additional-heat-smart-energy-source-41247",
     "write": true
   },
-  "41247": {
+  "41248": {
     "title": "End month tariff, shunt additional heat smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 12.0,
     "default": 12.0,
-    "name": "end-month-tariff-shunt-additional-heat-smart-energy-source-41247",
+    "name": "end-month-tariff-shunt-additional-heat-smart-energy-source-41248",
     "write": true
   },
-  "41280": {
+  "41281": {
     "title": "Start day tariff, ext. step add. heat smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 31.0,
     "default": 1.0,
-    "name": "start-day-tariff-ext-step-add-heat-smart-energy-source-41280",
+    "name": "start-day-tariff-ext-step-add-heat-smart-energy-source-41281",
     "write": true
   },
-  "41281": {
+  "41282": {
     "title": "End day tariff, ext. step add. heat  smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 31.0,
     "default": 31.0,
-    "name": "end-day-tariff-ext-step-add-heat-smart-energy-source-41281",
+    "name": "end-day-tariff-ext-step-add-heat-smart-energy-source-41282",
     "write": true
   },
-  "41282": {
+  "41283": {
     "title": "Start month tariff, ext. step add. heat smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 12.0,
     "default": 1.0,
-    "name": "start-month-tariff-ext-step-add-heat-smart-energy-source-41282",
+    "name": "start-month-tariff-ext-step-add-heat-smart-energy-source-41283",
     "write": true
   },
-  "41283": {
+  "41284": {
     "title": "End month tariff, ext. step add. heat smart energy source",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 12.0,
     "default": 12.0,
-    "name": "end-month-tariff-ext-step-add-heat-smart-energy-source-41283",
+    "name": "end-month-tariff-ext-step-add-heat-smart-energy-source-41284",
     "write": true
   },
-  "41316": {
+  "41317": {
     "title": "Ground water pump temperature alarm",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "ground-water-pump-temperature-alarm-41316",
+    "name": "ground-water-pump-temperature-alarm-41317",
     "write": true
   },
-  "41317": {
+  "41318": {
     "title": "Ground water pump temperature alarm level",
     "factor": 1,
     "unit": "\u00b0C",
@@ -8144,10 +8144,10 @@
     "min": -15.0,
     "max": 20.0,
     "default": 3.0,
-    "name": "ground-water-pump-temperature-alarm-level-41317",
+    "name": "ground-water-pump-temperature-alarm-level-41318",
     "write": true
   },
-  "41318": {
+  "41319": {
     "title": "Constant delta T, brine pump",
     "factor": 1,
     "unit": "\u00b0C",
@@ -8155,20 +8155,20 @@
     "min": 2.0,
     "max": 10.0,
     "default": 4.0,
-    "name": "constant-delta-t-brine-pump-41318",
+    "name": "constant-delta-t-brine-pump-41319",
     "write": true
   },
-  "41319": {
+  "41320": {
     "title": "Brine pump auto mode",
     "factor": 1,
     "size": "s8",
     "min": 0.0,
     "max": 2.0,
     "default": 1.0,
-    "name": "brine-pump-auto-mode-41319",
+    "name": "brine-pump-auto-mode-41320",
     "write": true
   },
-  "41326": {
+  "41327": {
     "title": "Max difference, SES priority 1 energy source",
     "factor": 10,
     "unit": "\u00b0C",
@@ -8176,10 +8176,10 @@
     "min": 10.0,
     "max": 250.0,
     "default": 100.0,
-    "name": "max-difference-ses-priority-1-energy-source-41326",
+    "name": "max-difference-ses-priority-1-energy-source-41327",
     "write": true
   },
-  "41327": {
+  "41328": {
     "title": "Max difference, SES lower priority energy source",
     "factor": 10,
     "unit": "\u00b0C",
@@ -8187,10 +8187,10 @@
     "min": 10.0,
     "max": 250.0,
     "default": 70.0,
-    "name": "max-difference-ses-lower-priority-energy-source-41327",
+    "name": "max-difference-ses-lower-priority-energy-source-41328",
     "write": true
   },
-  "41328": {
+  "41329": {
     "title": "Delta brine pump passive cooling",
     "factor": 1,
     "unit": "\u00b0C",
@@ -8198,37 +8198,37 @@
     "min": 1.0,
     "max": 15.0,
     "default": 4.0,
-    "name": "delta-brine-pump-passive-cooling-41328",
+    "name": "delta-brine-pump-passive-cooling-41329",
     "write": true
   },
-  "41550": {
+  "41551": {
     "title": "Installed (EB101)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "installed-eb101-41550",
+    "name": "installed-eb101-41551",
     "write": true
   },
-  "44000": {
+  "44001": {
     "title": "EME20",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "eme20-44000",
+    "name": "eme20-44001",
     "write": true
   },
-  "32176": {
+  "32177": {
     "title": "Current power (EME 20)",
     "factor": 1,
     "unit": "W",
     "size": "u32",
-    "name": "current-power-eme-20-32176"
+    "name": "current-power-eme-20-32177"
   },
-  "44006": {
+  "44007": {
     "title": "Speed of circulation pump passive cooling (EP15)",
     "factor": 1,
     "unit": "%",
@@ -8236,10 +8236,10 @@
     "min": 1.0,
     "max": 100.0,
     "default": 70.0,
-    "name": "speed-of-circulation-pump-passive-cooling-ep15-44006",
+    "name": "speed-of-circulation-pump-passive-cooling-ep15-44007",
     "write": true
   },
-  "44007": {
+  "44008": {
     "title": "Speed of circulation pump active cooling (EP15)",
     "factor": 1,
     "unit": "%",
@@ -8247,17 +8247,17 @@
     "min": 1.0,
     "max": 100.0,
     "default": 70.0,
-    "name": "speed-of-circulation-pump-active-cooling-ep15-44007",
+    "name": "speed-of-circulation-pump-active-cooling-ep15-44008",
     "write": true
   },
-  "44012": {
+  "44013": {
     "title": "Ground water pump's control signal",
     "factor": 1,
     "size": "s8",
-    "name": "ground-water-pump-s-control-signal-44012",
+    "name": "ground-water-pump-s-control-signal-44013",
     "write": true
   },
-  "44014": {
+  "44015": {
     "title": "BT12 offset",
     "factor": 10,
     "unit": "\u00b0C",
@@ -8265,164 +8265,164 @@
     "min": -50.0,
     "max": 50.0,
     "default": 0.0,
-    "name": "bt12-offset-44014",
+    "name": "bt12-offset-44015",
     "write": true
   },
-  "32178": {
+  "32179": {
     "title": "Total average power (EME 20)",
     "factor": 1,
     "unit": "W",
     "size": "u32",
-    "name": "total-average-power-eme-20-32178"
+    "name": "total-average-power-eme-20-32179"
   },
-  "32180": {
+  "32181": {
     "title": "Total energy (EME 20)",
     "factor": 10,
     "unit": "kWh",
     "size": "s32",
-    "name": "total-energy-eme-20-32180"
+    "name": "total-energy-eme-20-32181"
   },
-  "44076": {
+  "44077": {
     "title": "ERS 2",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "ers-2-44076",
+    "name": "ers-2-44077",
     "write": true
   },
-  "44077": {
+  "44078": {
     "title": "ERS 3",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "ers-3-44077",
+    "name": "ers-3-44078",
     "write": true
   },
-  "44078": {
+  "44079": {
     "title": "ERS 4",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "ers-4-44078",
+    "name": "ers-4-44079",
     "write": true
   },
-  "41981": {
+  "41982": {
     "title": "HTS 2",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "hts-2-41981",
+    "name": "hts-2-41982",
     "write": true
   },
-  "41982": {
+  "41983": {
     "title": "HTS 3",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "hts-3-41982",
+    "name": "hts-3-41983",
     "write": true
   },
-  "41983": {
+  "41984": {
     "title": "HTS 4",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "hts-4-41983",
+    "name": "hts-4-41984",
     "write": true
   },
-  "44138": {
+  "44139": {
     "title": "External adjustment, cooling climate system 8",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-cooling-climate-system-8-44138",
+    "name": "external-adjustment-cooling-climate-system-8-44139",
     "write": true
   },
-  "44139": {
+  "44140": {
     "title": "External adjustment, cooling climate system 7",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-cooling-climate-system-7-44139",
+    "name": "external-adjustment-cooling-climate-system-7-44140",
     "write": true
   },
-  "44140": {
+  "44141": {
     "title": "External adjustment, cooling climate system 6",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-cooling-climate-system-6-44140",
+    "name": "external-adjustment-cooling-climate-system-6-44141",
     "write": true
   },
-  "44141": {
+  "44142": {
     "title": "External adjustment, cooling climate system 5",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-cooling-climate-system-5-44141",
+    "name": "external-adjustment-cooling-climate-system-5-44142",
     "write": true
   },
-  "44142": {
+  "44143": {
     "title": "External adjustment, cooling climate system 4",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-cooling-climate-system-4-44142",
+    "name": "external-adjustment-cooling-climate-system-4-44143",
     "write": true
   },
-  "44143": {
+  "44144": {
     "title": "External adjustment, cooling climate system 3",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-cooling-climate-system-3-44143",
+    "name": "external-adjustment-cooling-climate-system-3-44144",
     "write": true
   },
-  "44144": {
+  "44145": {
     "title": "External adjustment, cooling climate system 2",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-cooling-climate-system-2-44144",
+    "name": "external-adjustment-cooling-climate-system-2-44145",
     "write": true
   },
-  "44145": {
+  "44146": {
     "title": "External adjustment, cooling climate system 1",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 10.0,
     "default": 0.0,
-    "name": "external-adjustment-cooling-climate-system-1-44145",
+    "name": "external-adjustment-cooling-climate-system-1-44146",
     "write": true
   },
-  "44146": {
+  "44147": {
     "title": "External adjustment with room sensor, cooling climate system 8",
     "factor": 10,
     "unit": "\u00b0C",
@@ -8430,10 +8430,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-cooling-climate-system-8-44146",
+    "name": "external-adjustment-with-room-sensor-cooling-climate-system-8-44147",
     "write": true
   },
-  "44147": {
+  "44148": {
     "title": "External adjustment with room sensor, cooling climate system 7",
     "factor": 10,
     "unit": "\u00b0C",
@@ -8441,10 +8441,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-cooling-climate-system-7-44147",
+    "name": "external-adjustment-with-room-sensor-cooling-climate-system-7-44148",
     "write": true
   },
-  "44148": {
+  "44149": {
     "title": "External adjustment with room sensor, cooling climate system 6",
     "factor": 10,
     "unit": "\u00b0C",
@@ -8452,10 +8452,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-cooling-climate-system-6-44148",
+    "name": "external-adjustment-with-room-sensor-cooling-climate-system-6-44149",
     "write": true
   },
-  "44149": {
+  "44150": {
     "title": "External adjustment with room sensor, cooling climate system 5",
     "factor": 10,
     "unit": "\u00b0C",
@@ -8463,10 +8463,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-cooling-climate-system-5-44149",
+    "name": "external-adjustment-with-room-sensor-cooling-climate-system-5-44150",
     "write": true
   },
-  "44150": {
+  "44151": {
     "title": "External adjustment with room sensor, cooling climate system 4",
     "factor": 10,
     "unit": "\u00b0C",
@@ -8474,10 +8474,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-cooling-climate-system-4-44150",
+    "name": "external-adjustment-with-room-sensor-cooling-climate-system-4-44151",
     "write": true
   },
-  "44151": {
+  "44152": {
     "title": "External adjustment with room sensor, cooling climate system 3",
     "factor": 10,
     "unit": "\u00b0C",
@@ -8485,10 +8485,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-cooling-climate-system-3-44151",
+    "name": "external-adjustment-with-room-sensor-cooling-climate-system-3-44152",
     "write": true
   },
-  "44152": {
+  "44153": {
     "title": "External adjustment with room sensor, cooling climate system 2",
     "factor": 10,
     "unit": "\u00b0C",
@@ -8496,10 +8496,10 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-cooling-climate-system-2-44152",
+    "name": "external-adjustment-with-room-sensor-cooling-climate-system-2-44153",
     "write": true
   },
-  "44153": {
+  "44154": {
     "title": "External adjustment with room sensor, cooling climate system 1",
     "factor": 10,
     "unit": "\u00b0C",
@@ -8507,90 +8507,90 @@
     "min": 50.0,
     "max": 300.0,
     "default": 200.0,
-    "name": "external-adjustment-with-room-sensor-cooling-climate-system-1-44153",
+    "name": "external-adjustment-with-room-sensor-cooling-climate-system-1-44154",
     "write": true
   },
-  "44164": {
+  "44165": {
     "title": "BlockFreq 1 (EB102)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "blockfreq-1-eb102-44164",
+    "name": "blockfreq-1-eb102-44165",
     "write": true
   },
-  "44165": {
+  "44166": {
     "title": "BlockFreq 1 (EB103)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "blockfreq-1-eb103-44165",
+    "name": "blockfreq-1-eb103-44166",
     "write": true
   },
-  "44166": {
+  "44167": {
     "title": "BlockFreq 1 (EB104)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "blockfreq-1-eb104-44166",
+    "name": "blockfreq-1-eb104-44167",
     "write": true
   },
-  "44167": {
+  "44168": {
     "title": "BlockFreq 1 (EB105)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "blockfreq-1-eb105-44167",
+    "name": "blockfreq-1-eb105-44168",
     "write": true
   },
-  "44168": {
+  "44169": {
     "title": "BlockFreq 1 (EB106)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "blockfreq-1-eb106-44168",
+    "name": "blockfreq-1-eb106-44169",
     "write": true
   },
-  "44169": {
+  "44170": {
     "title": "BlockFreq 1 (EB107)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "blockfreq-1-eb107-44169",
+    "name": "blockfreq-1-eb107-44170",
     "write": true
   },
-  "44170": {
+  "44171": {
     "title": "BlockFreq 1 (EB108)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "blockfreq-1-eb108-44170",
+    "name": "blockfreq-1-eb108-44171",
     "write": true
   },
-  "44199": {
+  "44200": {
     "title": "Power [kW] required for dimensioned outdoor temperature",
     "factor": 1,
     "size": "u16",
     "min": 1.0,
     "max": 1000.0,
     "default": 10.0,
-    "name": "power-kw-required-for-dimensioned-outdoor-temperature-44199",
+    "name": "power-kw-required-for-dimensioned-outdoor-temperature-44200",
     "write": true
   },
-  "44200": {
+  "44201": {
     "title": "Power at DOT, manual value",
     "factor": 1,
     "unit": "kW",
@@ -8598,40 +8598,40 @@
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "power-at-dot-manual-value-44200",
+    "name": "power-at-dot-manual-value-44201",
     "write": true
   },
-  "44100": {
+  "44101": {
     "title": "Blocking actions (ERS 3)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 2.0,
     "default": 2.0,
-    "name": "blocking-actions-ers-3-44100",
+    "name": "blocking-actions-ers-3-44101",
     "write": true
   },
-  "44101": {
+  "44102": {
     "title": "Blocking actions (ERS 4)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 2.0,
     "default": 2.0,
-    "name": "blocking-actions-ers-4-44101",
+    "name": "blocking-actions-ers-4-44102",
     "write": true
   },
-  "44022": {
+  "44023": {
     "title": "EB103/104-GP12",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "eb103-104-gp12-44022",
+    "name": "eb103-104-gp12-44023",
     "write": true
   },
-  "43242": {
+  "43243": {
     "title": "Minimum permitted speed (EB100 GP1)",
     "factor": 1,
     "unit": "%",
@@ -8639,57 +8639,47 @@
     "min": 1.0,
     "max": 50.0,
     "default": 1.0,
-    "name": "minimum-permitted-speed-eb100-gp1-43242",
+    "name": "minimum-permitted-speed-eb100-gp1-43243",
     "write": true
   },
-  "40176": {
+  "40177": {
     "title": "System 1 (RMU)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "system-1-rmu-40176",
+    "name": "system-1-rmu-40177",
     "write": true
   },
-  "40177": {
+  "40178": {
     "title": "System 2 (RMU)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "system-2-rmu-40177",
+    "name": "system-2-rmu-40178",
     "write": true
   },
-  "40178": {
+  "40179": {
     "title": "System 3 (RMU)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "system-3-rmu-40178",
+    "name": "system-3-rmu-40179",
     "write": true
   },
-  "40179": {
+  "40180": {
     "title": "System 4 (RMU)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "system-4-rmu-40179",
-    "write": true
-  },
-  "41998": {
-    "title": "System 4 (RMU)",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "system-4-rmu-41998",
+    "name": "system-4-rmu-40180",
     "write": true
   },
   "41999": {
@@ -8722,118 +8712,118 @@
     "name": "system-4-rmu-42001",
     "write": true
   },
-  "42742": {
+  "42002": {
+    "title": "System 4 (RMU)",
+    "factor": 1,
+    "size": "u8",
+    "min": 0.0,
+    "max": 1.0,
+    "default": 0.0,
+    "name": "system-4-rmu-42002",
+    "write": true
+  },
+  "42743": {
     "title": "The start guide has been run",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "the-start-guide-has-been-run-42742",
+    "name": "the-start-guide-has-been-run-42743",
     "write": true
   },
-  "43232": {
+  "43233": {
     "title": "Audio signal on alarm",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "audio-signal-on-alarm-43232",
+    "name": "audio-signal-on-alarm-43233",
     "write": true
   },
-  "43233": {
+  "43234": {
     "title": "Sound when pressing button",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "sound-when-pressing-button-43233",
+    "name": "sound-when-pressing-button-43234",
     "write": true
   },
-  "43057": {
+  "43058": {
     "title": "ERS S40 7",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "ers-s40-7-43057",
+    "name": "ers-s40-7-43058",
     "write": true
   },
-  "43059": {
+  "43060": {
     "title": "Heating, auto",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 1.0,
-    "name": "heating-auto-43059",
+    "name": "heating-auto-43060",
     "write": true
   },
-  "43033": {
+  "43034": {
     "title": "Factor",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 10.0,
     "default": 5.0,
-    "name": "factor-43033",
+    "name": "factor-43034",
     "write": true
   },
-  "43088": {
+  "43089": {
     "title": "Period",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "period-43088",
+    "name": "period-43089",
     "write": true
   },
-  "43089": {
+  "43090": {
     "title": "Number of years",
     "factor": 1,
     "size": "u8",
     "min": 1.0,
     "max": 5.0,
     "default": 1.0,
-    "name": "number-of-years-43089",
+    "name": "number-of-years-43090",
     "write": true
   },
-  "43090": {
+  "43091": {
     "title": "Months",
     "factor": 1,
     "size": "u32",
     "min": 0.0,
     "max": 4095.0,
     "default": 4095.0,
-    "name": "months-43090",
-    "write": true
-  },
-  "43096": {
-    "title": "Show outdoor temperature",
-    "factor": 1,
-    "size": "u8",
-    "name": "show-outdoor-temperature-43096",
+    "name": "months-43091",
     "write": true
   },
   "43097": {
+    "title": "Show outdoor temperature",
+    "factor": 1,
+    "size": "u8",
+    "name": "show-outdoor-temperature-43097",
+    "write": true
+  },
+  "43098": {
     "title": "Show indoor temperature",
     "factor": 1,
     "size": "u8",
-    "name": "show-indoor-temperature-43097",
-    "write": true
-  },
-  "43066": {
-    "title": "Active days",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 127.0,
-    "default": 0.0,
-    "name": "active-days-43066",
+    "name": "show-indoor-temperature-43098",
     "write": true
   },
   "43067": {
@@ -8877,67 +8867,77 @@
     "write": true
   },
   "43071": {
+    "title": "Active days",
+    "factor": 1,
+    "size": "u8",
+    "min": 0.0,
+    "max": 127.0,
+    "default": 0.0,
+    "name": "active-days-43071",
+    "write": true
+  },
+  "43072": {
     "title": "Start time",
     "factor": 1,
     "size": "u16",
-    "name": "start-time-43071",
+    "name": "start-time-43072",
     "write": true
   },
-  "43073": {
+  "43074": {
     "title": "Start time",
     "factor": 1,
     "size": "u16",
-    "name": "start-time-43073",
+    "name": "start-time-43074",
     "write": true
   },
-  "43075": {
+  "43076": {
     "title": "Stop time",
     "factor": 1,
     "size": "u16",
-    "name": "stop-time-43075",
+    "name": "stop-time-43076",
     "write": true
   },
-  "42766": {
+  "42767": {
     "title": "Allow add. heat during defrosting",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "allow-add-heat-during-defrosting-42766",
+    "name": "allow-add-heat-during-defrosting-42767",
     "write": true
   },
-  "42764": {
+  "42765": {
     "title": "K4 relay is Normally Closed",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "k4-relay-is-normally-closed-42764",
+    "name": "k4-relay-is-normally-closed-42765",
     "write": true
   },
-  "42667": {
+  "42668": {
     "title": "Offset cooling (EME20)",
     "factor": 1,
     "size": "s8",
     "min": -10.0,
     "max": 0.0,
     "default": -1.0,
-    "name": "offset-cooling-eme20-42667",
+    "name": "offset-cooling-eme20-42668",
     "write": true
   },
-  "42668": {
+  "42669": {
     "title": "Offset heating (EME20)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 10.0,
     "default": 1.0,
-    "name": "offset-heating-eme20-42668",
+    "name": "offset-heating-eme20-42669",
     "write": true
   },
-  "42669": {
+  "42670": {
     "title": "Offset pool (EME20)",
     "factor": 1,
     "unit": "\u00b0C",
@@ -8945,30 +8945,30 @@
     "min": 0.0,
     "max": 10.0,
     "default": 10.0,
-    "name": "offset-pool-eme20-42669",
+    "name": "offset-pool-eme20-42670",
     "write": true
   },
-  "42666": {
+  "42667": {
     "title": "Cooling (EME20)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "cooling-eme20-42666",
+    "name": "cooling-eme20-42667",
     "write": true
   },
-  "42675": {
+  "42676": {
     "title": "AUX (EME20)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "aux-eme20-42675",
+    "name": "aux-eme20-42676",
     "write": true
   },
-  "40000": {
+  "40001": {
     "title": "Temperature, Overload, pool",
     "factor": 1,
     "unit": "\u00b0C",
@@ -8976,617 +8976,607 @@
     "min": 1.0,
     "max": 50.0,
     "default": 1.0,
-    "name": "temperature-overload-pool-40000",
+    "name": "temperature-overload-pool-40001",
     "write": true
   },
-  "42107": {
+  "42108": {
     "title": "EME20 API",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "eme20-api-42107",
+    "name": "eme20-api-42108",
     "write": true
   },
-  "42108": {
+  "42109": {
     "title": "EME20 API Include own consumption",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "eme20-api-include-own-consumption-42108",
+    "name": "eme20-api-include-own-consumption-42109",
     "write": true
   },
-  "42109": {
+  "42110": {
     "title": "EME20 API Available power",
     "factor": 1,
     "size": "u16",
     "min": 0.0,
     "max": 65535.0,
     "default": 0.0,
-    "name": "eme20-api-available-power-42109",
+    "name": "eme20-api-available-power-42110",
     "write": true
   },
-  "42111": {
+  "42112": {
     "title": "External adjustment input, main unit (ECS1)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "external-adjustment-input-main-unit-ecs1-42111",
+    "name": "external-adjustment-input-main-unit-ecs1-42112",
     "write": true
   },
-  "42112": {
+  "42113": {
     "title": "External adjustment input (ECS2)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "external-adjustment-input-ecs2-42112",
+    "name": "external-adjustment-input-ecs2-42113",
     "write": true
   },
-  "42113": {
+  "42114": {
     "title": "External adjustment input (ECS3)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "external-adjustment-input-ecs3-42113",
+    "name": "external-adjustment-input-ecs3-42114",
     "write": true
   },
-  "42114": {
+  "42115": {
     "title": "External adjustment input (ECS4)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "external-adjustment-input-ecs4-42114",
+    "name": "external-adjustment-input-ecs4-42115",
     "write": true
   },
-  "42115": {
+  "42116": {
     "title": "External adjustment input (ECS5)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "external-adjustment-input-ecs5-42115",
+    "name": "external-adjustment-input-ecs5-42116",
     "write": true
   },
-  "42116": {
+  "42117": {
     "title": "External adjustment input (ECS6)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "external-adjustment-input-ecs6-42116",
+    "name": "external-adjustment-input-ecs6-42117",
     "write": true
   },
-  "42117": {
+  "42118": {
     "title": "External adjustment input (ECS7)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "external-adjustment-input-ecs7-42117",
+    "name": "external-adjustment-input-ecs7-42118",
     "write": true
   },
-  "42118": {
+  "42119": {
     "title": "External adjustment input (ECS8)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "external-adjustment-input-ecs8-42118",
+    "name": "external-adjustment-input-ecs8-42119",
     "write": true
   },
-  "42119": {
+  "42120": {
     "title": "Zone 1 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-1-affected-by-ecs1-42119",
+    "name": "zone-1-affected-by-ecs1-42120",
     "write": true
   },
-  "42120": {
+  "42121": {
     "title": "Zone 2 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-2-affected-by-ecs1-42120",
+    "name": "zone-2-affected-by-ecs1-42121",
     "write": true
   },
-  "42121": {
+  "42122": {
     "title": "Zone 3 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-3-affected-by-ecs1-42121",
+    "name": "zone-3-affected-by-ecs1-42122",
     "write": true
   },
-  "42122": {
+  "42123": {
     "title": "Zone 4 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-4-affected-by-ecs1-42122",
+    "name": "zone-4-affected-by-ecs1-42123",
     "write": true
   },
-  "42123": {
+  "42124": {
     "title": "Zone 5 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-5-affected-by-ecs1-42123",
+    "name": "zone-5-affected-by-ecs1-42124",
     "write": true
   },
-  "42124": {
+  "42125": {
     "title": "Zone 6 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-6-affected-by-ecs1-42124",
+    "name": "zone-6-affected-by-ecs1-42125",
     "write": true
   },
-  "42125": {
+  "42126": {
     "title": "Zone 7 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-7-affected-by-ecs1-42125",
+    "name": "zone-7-affected-by-ecs1-42126",
     "write": true
   },
-  "42126": {
+  "42127": {
     "title": "Zone 8 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-8-affected-by-ecs1-42126",
+    "name": "zone-8-affected-by-ecs1-42127",
     "write": true
   },
-  "42127": {
+  "42128": {
     "title": "Zone 9 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-9-affected-by-ecs1-42127",
+    "name": "zone-9-affected-by-ecs1-42128",
     "write": true
   },
-  "42128": {
+  "42129": {
     "title": "Zone 10 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-10-affected-by-ecs1-42128",
+    "name": "zone-10-affected-by-ecs1-42129",
     "write": true
   },
-  "42129": {
+  "42130": {
     "title": "Zone 11 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-11-affected-by-ecs1-42129",
+    "name": "zone-11-affected-by-ecs1-42130",
     "write": true
   },
-  "42130": {
+  "42131": {
     "title": "Zone 12 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-12-affected-by-ecs1-42130",
+    "name": "zone-12-affected-by-ecs1-42131",
     "write": true
   },
-  "42131": {
+  "42132": {
     "title": "Zone 13 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-13-affected-by-ecs1-42131",
+    "name": "zone-13-affected-by-ecs1-42132",
     "write": true
   },
-  "42132": {
+  "42133": {
     "title": "Zone 14 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-14-affected-by-ecs1-42132",
+    "name": "zone-14-affected-by-ecs1-42133",
     "write": true
   },
-  "42133": {
+  "42134": {
     "title": "Zone 15 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-15-affected-by-ecs1-42133",
+    "name": "zone-15-affected-by-ecs1-42134",
     "write": true
   },
-  "42134": {
+  "42135": {
     "title": "Zone 16 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-16-affected-by-ecs1-42134",
+    "name": "zone-16-affected-by-ecs1-42135",
     "write": true
   },
-  "42135": {
+  "42136": {
     "title": "Zone 17 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-17-affected-by-ecs1-42135",
+    "name": "zone-17-affected-by-ecs1-42136",
     "write": true
   },
-  "42136": {
+  "42137": {
     "title": "Zone 18 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-18-affected-by-ecs1-42136",
+    "name": "zone-18-affected-by-ecs1-42137",
     "write": true
   },
-  "42137": {
+  "42138": {
     "title": "Zone 19 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-19-affected-by-ecs1-42137",
+    "name": "zone-19-affected-by-ecs1-42138",
     "write": true
   },
-  "42138": {
+  "42139": {
     "title": "Zone 20 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-20-affected-by-ecs1-42138",
+    "name": "zone-20-affected-by-ecs1-42139",
     "write": true
   },
-  "42139": {
+  "42140": {
     "title": "Zone 21 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-21-affected-by-ecs1-42139",
+    "name": "zone-21-affected-by-ecs1-42140",
     "write": true
   },
-  "42140": {
+  "42141": {
     "title": "Zone 22 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-22-affected-by-ecs1-42140",
+    "name": "zone-22-affected-by-ecs1-42141",
     "write": true
   },
-  "42141": {
+  "42142": {
     "title": "Zone 23 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-23-affected-by-ecs1-42141",
+    "name": "zone-23-affected-by-ecs1-42142",
     "write": true
   },
-  "42142": {
+  "42143": {
     "title": "Zone 24 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-24-affected-by-ecs1-42142",
+    "name": "zone-24-affected-by-ecs1-42143",
     "write": true
   },
-  "42143": {
+  "42144": {
     "title": "Zone 25 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-25-affected-by-ecs1-42143",
+    "name": "zone-25-affected-by-ecs1-42144",
     "write": true
   },
-  "42144": {
+  "42145": {
     "title": "Zone 26 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-26-affected-by-ecs1-42144",
+    "name": "zone-26-affected-by-ecs1-42145",
     "write": true
   },
-  "42145": {
+  "42146": {
     "title": "Zone 27 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-27-affected-by-ecs1-42145",
+    "name": "zone-27-affected-by-ecs1-42146",
     "write": true
   },
-  "42146": {
+  "42147": {
     "title": "Zone 28 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-28-affected-by-ecs1-42146",
+    "name": "zone-28-affected-by-ecs1-42147",
     "write": true
   },
-  "42147": {
+  "42148": {
     "title": "Zone 29 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-29-affected-by-ecs1-42147",
+    "name": "zone-29-affected-by-ecs1-42148",
     "write": true
   },
-  "42148": {
+  "42149": {
     "title": "Zone 30 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-30-affected-by-ecs1-42148",
+    "name": "zone-30-affected-by-ecs1-42149",
     "write": true
   },
-  "42149": {
+  "42150": {
     "title": "Zone 31 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-31-affected-by-ecs1-42149",
+    "name": "zone-31-affected-by-ecs1-42150",
     "write": true
   },
-  "42150": {
+  "42151": {
     "title": "Zone 32 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-32-affected-by-ecs1-42150",
+    "name": "zone-32-affected-by-ecs1-42151",
     "write": true
   },
-  "42151": {
+  "42152": {
     "title": "Zone 33 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-33-affected-by-ecs1-42151",
+    "name": "zone-33-affected-by-ecs1-42152",
     "write": true
   },
-  "42152": {
+  "42153": {
     "title": "Zone 34 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-34-affected-by-ecs1-42152",
+    "name": "zone-34-affected-by-ecs1-42153",
     "write": true
   },
-  "42153": {
+  "42154": {
     "title": "Zone 35 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-35-affected-by-ecs1-42153",
+    "name": "zone-35-affected-by-ecs1-42154",
     "write": true
   },
-  "42154": {
+  "42155": {
     "title": "Zone 36 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-36-affected-by-ecs1-42154",
+    "name": "zone-36-affected-by-ecs1-42155",
     "write": true
   },
-  "42155": {
+  "42156": {
     "title": "Zone 37 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-37-affected-by-ecs1-42155",
+    "name": "zone-37-affected-by-ecs1-42156",
     "write": true
   },
-  "42156": {
+  "42157": {
     "title": "Zone 38 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-38-affected-by-ecs1-42156",
+    "name": "zone-38-affected-by-ecs1-42157",
     "write": true
   },
-  "42157": {
+  "42158": {
     "title": "Zone 39 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-39-affected-by-ecs1-42157",
+    "name": "zone-39-affected-by-ecs1-42158",
     "write": true
   },
-  "42158": {
+  "42159": {
     "title": "Zone 40 affected by ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "zone-40-affected-by-ecs1-42158",
+    "name": "zone-40-affected-by-ecs1-42159",
     "write": true
   },
-  "42439": {
+  "42440": {
     "title": "Input on ECS1 affects ECS1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "input-on-ecs1-affects-ecs1-42439",
+    "name": "input-on-ecs1-affects-ecs1-42440",
     "write": true
   },
-  "42440": {
+  "42441": {
     "title": "Input on ECS1 affects ECS2",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "input-on-ecs1-affects-ecs2-42440",
+    "name": "input-on-ecs1-affects-ecs2-42441",
     "write": true
   },
-  "42441": {
+  "42442": {
     "title": "Input on ECS1 affects ECS3",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "input-on-ecs1-affects-ecs3-42441",
+    "name": "input-on-ecs1-affects-ecs3-42442",
     "write": true
   },
-  "42442": {
+  "42443": {
     "title": "Input on ECS1 affects ECS4",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "input-on-ecs1-affects-ecs4-42442",
+    "name": "input-on-ecs1-affects-ecs4-42443",
     "write": true
   },
-  "42443": {
+  "42444": {
     "title": "Input on ECS1 affects ECS5",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "input-on-ecs1-affects-ecs5-42443",
+    "name": "input-on-ecs1-affects-ecs5-42444",
     "write": true
   },
-  "42444": {
+  "42445": {
     "title": "Input on ECS1 affects ECS6",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "input-on-ecs1-affects-ecs6-42444",
+    "name": "input-on-ecs1-affects-ecs6-42445",
     "write": true
   },
-  "42445": {
+  "42446": {
     "title": "Input on ECS1 affects ECS7",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "input-on-ecs1-affects-ecs7-42445",
+    "name": "input-on-ecs1-affects-ecs7-42446",
     "write": true
   },
-  "42446": {
+  "42447": {
     "title": "Input on ECS1 affects ECS8",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "input-on-ecs1-affects-ecs8-42446",
+    "name": "input-on-ecs1-affects-ecs8-42447",
     "write": true
   },
-  "42503": {
+  "42504": {
     "title": "External setting for adjustment migrated",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "external-setting-for-adjustment-migrated-42503",
-    "write": true
-  },
-  "42676": {
-    "title": "Time between filter replacement",
-    "factor": 1,
-    "size": "u8",
-    "min": 1.0,
-    "max": 24.0,
-    "default": 3.0,
-    "name": "time-between-filter-replacement-42676",
+    "name": "external-setting-for-adjustment-migrated-42504",
     "write": true
   },
   "42677": {
@@ -9619,7 +9609,17 @@
     "name": "time-between-filter-replacement-42679",
     "write": true
   },
-  "32019": {
+  "42680": {
+    "title": "Time between filter replacement",
+    "factor": 1,
+    "size": "u8",
+    "min": 1.0,
+    "max": 24.0,
+    "default": 3.0,
+    "name": "time-between-filter-replacement-42680",
+    "write": true
+  },
+  "32020": {
     "title": "Cooling, passive",
     "factor": 10,
     "unit": "kWh",
@@ -9627,18 +9627,7 @@
     "min": 0.0,
     "max": 9999999.0,
     "default": 0.0,
-    "name": "cooling-passive-32019"
-  },
-  "42700": {
-    "title": "Return time fan 4",
-    "factor": 1,
-    "unit": "h",
-    "size": "u8",
-    "min": 1.0,
-    "max": 24.0,
-    "default": 4.0,
-    "name": "return-time-fan-4-42700",
-    "write": true
+    "name": "cooling-passive-32020"
   },
   "42701": {
     "title": "Return time fan 4",
@@ -9805,14 +9794,15 @@
     "name": "return-time-fan-4-42715",
     "write": true
   },
-  "42728": {
-    "title": "Time between filter replacement",
+  "42716": {
+    "title": "Return time fan 4",
     "factor": 1,
+    "unit": "h",
     "size": "u8",
     "min": 1.0,
     "max": 24.0,
-    "default": 3.0,
-    "name": "time-between-filter-replacement-42728",
+    "default": 4.0,
+    "name": "return-time-fan-4-42716",
     "write": true
   },
   "42729": {
@@ -9845,24 +9835,34 @@
     "name": "time-between-filter-replacement-42731",
     "write": true
   },
-  "42740": {
+  "42732": {
+    "title": "Time between filter replacement",
+    "factor": 1,
+    "size": "u8",
+    "min": 1.0,
+    "max": 24.0,
+    "default": 3.0,
+    "name": "time-between-filter-replacement-42732",
+    "write": true
+  },
+  "42741": {
     "title": "AUX from Modbus",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 59.0,
     "default": 0.0,
-    "name": "aux-from-modbus-42740",
-    "write": true
-  },
-  "42741": {
-    "title": "AUX from Modbus",
-    "factor": 1,
-    "size": "s16",
     "name": "aux-from-modbus-42741",
     "write": true
   },
-  "32166": {
+  "42742": {
+    "title": "AUX from Modbus",
+    "factor": 1,
+    "size": "s16",
+    "name": "aux-from-modbus-42742",
+    "write": true
+  },
+  "32167": {
     "title": "Instantaneous used power",
     "factor": 1,
     "unit": "Ws",
@@ -9870,36 +9870,26 @@
     "min": 0.0,
     "max": 9999999.0,
     "default": 0.0,
-    "name": "instantaneous-used-power-32166"
+    "name": "instantaneous-used-power-32167"
   },
-  "42820": {
+  "42821": {
     "title": "ERS 2",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "ers-2-42820",
+    "name": "ers-2-42821",
     "write": true
   },
-  "42821": {
+  "42822": {
     "title": "ERS 3",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "ers-3-42821",
-    "write": true
-  },
-  "42822": {
-    "title": "ERS 4",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "ers-4-42822",
+    "name": "ers-3-42822",
     "write": true
   },
   "42823": {
@@ -9918,7 +9908,7 @@
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
-    "default": 1.0,
+    "default": 0.0,
     "name": "ers-4-42824",
     "write": true
   },
@@ -9952,15 +9942,14 @@
     "name": "ers-4-42827",
     "write": true
   },
-  "42857": {
-    "title": "Min. vent temp. (ERS 4)",
+  "42828": {
+    "title": "ERS 4",
     "factor": 1,
-    "unit": "\u00b0C",
     "size": "u8",
     "min": 0.0,
-    "max": 10.0,
-    "default": 3.0,
-    "name": "min-vent-temp-ers-4-42857",
+    "max": 1.0,
+    "default": 1.0,
+    "name": "ers-4-42828",
     "write": true
   },
   "42858": {
@@ -9996,14 +9985,15 @@
     "name": "min-vent-temp-ers-4-42860",
     "write": true
   },
-  "42828": {
-    "title": "Blocking actions (ERS 4)",
+  "42861": {
+    "title": "Min. vent temp. (ERS 4)",
     "factor": 1,
+    "unit": "\u00b0C",
     "size": "u8",
     "min": 0.0,
-    "max": 2.0,
-    "default": 2.0,
-    "name": "blocking-actions-ers-4-42828",
+    "max": 10.0,
+    "default": 3.0,
+    "name": "min-vent-temp-ers-4-42861",
     "write": true
   },
   "42829": {
@@ -10036,35 +10026,45 @@
     "name": "blocking-actions-ers-4-42831",
     "write": true
   },
-  "32168": {
+  "42832": {
+    "title": "Blocking actions (ERS 4)",
+    "factor": 1,
+    "size": "u8",
+    "min": 0.0,
+    "max": 2.0,
+    "default": 2.0,
+    "name": "blocking-actions-ers-4-42832",
+    "write": true
+  },
+  "32169": {
     "title": "Fan mode 5",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "fan-mode-5-32168"
+    "name": "fan-mode-5-32169"
   },
-  "32169": {
+  "32170": {
     "title": "Fan mode 6",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "fan-mode-6-32169"
+    "name": "fan-mode-6-32170"
   },
-  "32170": {
+  "32171": {
     "title": "Fan mode 7",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "fan-mode-7-32170"
+    "name": "fan-mode-7-32171"
   },
-  "32171": {
+  "32172": {
     "title": "Fan mode 8",
     "factor": 1,
     "unit": "%",
     "size": "u8",
-    "name": "fan-mode-8-32171"
+    "name": "fan-mode-8-32172"
   },
-  "43028": {
+  "43029": {
     "title": "Immersion heater power, emergency mode",
     "factor": 100,
     "unit": "kW",
@@ -10072,31 +10072,31 @@
     "min": 0.0,
     "max": 4500.0,
     "default": 600.0,
-    "name": "immersion-heater-power-emergency-mode-43028",
+    "name": "immersion-heater-power-emergency-mode-43029",
     "write": true
   },
-  "43986": {
+  "43987": {
     "title": "Disable emergency restart GP1",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "disable-emergency-restart-gp1-43986",
+    "name": "disable-emergency-restart-gp1-43987",
     "write": true
   },
-  "32190": {
+  "32191": {
     "title": "Return line (AZ2-BT69)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "return-line-az2-bt69-32190"
+    "name": "return-line-az2-bt69-32191"
   },
-  "32191": {
+  "32192": {
     "title": "Supply line (AZ2-BT68)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "supply-line-az2-bt68-32191"
+    "name": "supply-line-az2-bt68-32192"
   }
 }

--- a/nibe/data/s320.csv
+++ b/nibe/data/s320.csv
@@ -1,0 +1,1109 @@
+Title	Register type	Register	Division factor	Unit	Size of variable	Min value	Max value	Default value
+Current outdoor temperature (BT1)	MODBUS_INPUT_REGISTER	1	10	°C	2	0	0	0
+Supply line (EP23-BT2)	MODBUS_INPUT_REGISTER	2	10	°C	2	0	0	0
+Supply line (EP22-BT2)	MODBUS_INPUT_REGISTER	3	10	°C	2	0	0	0
+Supply line (EP21-BT2)	MODBUS_INPUT_REGISTER	4	10	°C	2	0	0	0
+Supply line (BT2)	MODBUS_INPUT_REGISTER	5	10	°C	2	0	0	0
+Return line (BT3)	MODBUS_INPUT_REGISTER	7	10	°C	2	0	0	0
+Hot water top (BT7)	MODBUS_INPUT_REGISTER	8	10	°C	2	0	0	0
+Hot water charging (BT6)	MODBUS_INPUT_REGISTER	9	10	°C	2	0	0	0
+Roomsensor 1-1	MODBUS_INPUT_REGISTER	26	10	°C	2	0	0	0
+Temperature limiter (EB100-FD1)	MODBUS_INPUT_REGISTER	36	1		2	0	0	0
+Average temperature (BT1)	MODBUS_INPUT_REGISTER	37	10	°C	2	0	0	0
+Boiler temperature (BT52)	MODBUS_INPUT_REGISTER	38	10	°C	2	0	0	0
+Flow sensor (BF1)	MODBUS_INPUT_REGISTER	40	10	l/m	2	0	0	0
+Electrical anode (EB100-FR1)	MODBUS_INPUT_REGISTER	41	1		2	0	0	0
+Current (BE3)	MODBUS_INPUT_REGISTER	46	10	A	6	0	0	0
+Current (BE2)	MODBUS_INPUT_REGISTER	48	10	A	6	0	0	0
+Current (BE1)	MODBUS_INPUT_REGISTER	50	10	A	6	0	0	0
+-	MODBUS_INPUT_REGISTER	60	10	°C	2	0	0	0
+-	MODBUS_INPUT_REGISTER	61	10	°C	2	0	0	0
+-	MODBUS_INPUT_REGISTER	62	10	°C	2	0	0	0
+-	MODBUS_INPUT_REGISTER	63	10	°C	2	0	0	0
+-	MODBUS_INPUT_REGISTER	64	10	°C	2	0	0	0
+-	MODBUS_INPUT_REGISTER	65	10	°C	2	0	0	0
+Additional heat (BT63)	MODBUS_INPUT_REGISTER	72	10	°C	2	0	0	0
+Return line (EP23-BT3)	MODBUS_INPUT_REGISTER	75	10	°C	2	0	0	0
+Return line (EP22-BT3)	MODBUS_INPUT_REGISTER	76	10	°C	2	0	0	0
+Return line (EP21-BT3)	MODBUS_INPUT_REGISTER	77	10	°C	2	0	0	0
+Return line (EP15-BT3)	MODBUS_INPUT_REGISTER	78	10	°C	2	0	0	0
+Outgoing hot water (BT70)	MODBUS_INPUT_REGISTER	87	10	°C	2	0	0	0
+Supply line (EP47-BT2)	MODBUS_INPUT_REGISTER	94	10	°C	2	0	0	0
+Supply line (EP46-BT2)	MODBUS_INPUT_REGISTER	95	10	°C	2	0	0	0
+Supply line (EP45-BT2)	MODBUS_INPUT_REGISTER	96	10	°C	2	0	0	0
+Supply line (EP44-BT2)	MODBUS_INPUT_REGISTER	97	10	°C	2	0	0	0
+Return line (EP47-BT3)	MODBUS_INPUT_REGISTER	98	10	°C	2	0	0	0
+Return line (EP46-BT3)	MODBUS_INPUT_REGISTER	99	10	°C	2	0	0	0
+Return line (EP45-BT3)	MODBUS_INPUT_REGISTER	100	10	°C	2	0	0	0
+Return line (EP44-BT3)	MODBUS_INPUT_REGISTER	101	10	°C	2	0	0	0
+id:149	MODBUS_INPUT_REGISTER	108	10	°C	2	0	0	0
+Room average temp. clim. system 8 (BT50)	MODBUS_INPUT_REGISTER	109	10	°C	2	0	0	0
+Room average temp. clim. system 7 (BT50)	MODBUS_INPUT_REGISTER	110	10	°C	2	0	0	0
+Room average temp. clim. system 6 (BT50)	MODBUS_INPUT_REGISTER	111	10	°C	2	0	0	0
+Room average temp. clim. system 5 (BT50)	MODBUS_INPUT_REGISTER	112	10	°C	2	0	0	0
+Room average temp. clim. system 4 (BT50)	MODBUS_INPUT_REGISTER	113	10	°C	2	0	0	0
+Room average temp. clim. system 3 (BT50)	MODBUS_INPUT_REGISTER	114	10	°C	2	0	0	0
+Room average temp. clim. system 2 (BT50)	MODBUS_INPUT_REGISTER	115	10	°C	2	0	0	0
+Room average temp. clim. system 1 (BT50)	MODBUS_INPUT_REGISTER	116	10	°C	2	0	0	0
+External cooling supply temperature (BT25)	MODBUS_INPUT_REGISTER	119	10	°C	2	0	0	0
+id:193	MODBUS_INPUT_REGISTER	128	1		4	0	0	0
+Oper. mode shunt climate system 8	MODBUS_INPUT_REGISTER	129	1		4	0	0	0
+Oper. mode shunt climate system 7	MODBUS_INPUT_REGISTER	130	1		4	0	0	0
+Oper. mode shunt climate system 6	MODBUS_INPUT_REGISTER	131	1		4	0	0	0
+Oper. mode shunt climate system 5	MODBUS_INPUT_REGISTER	132	1		4	0	0	0
+id:246	MODBUS_INPUT_REGISTER	133	1		4	0	0	0
+Relay status (ERS 1)	MODBUS_INPUT_REGISTER	134	1		4	0	0	0
+Fan speed (AZ30-GQ2)	MODBUS_INPUT_REGISTER	135	1	%	4	0	0	0
+Fan speed (AZ30-GQ3)	MODBUS_INPUT_REGISTER	136	1	%	4	0	0	0
+Current hot water mode controlled by	MODBUS_INPUT_REGISTER	137	1		1	0	0	0
+Max. compressor frequency, heating	MODBUS_INPUT_REGISTER	141	100	Hz	5	0	0	0
+Inverter alarm code	MODBUS_INPUT_REGISTER	142	1		5	0	0	0
+Inverter alarm code	MODBUS_INPUT_REGISTER	143	1		5	0	0	0
+External adjustment climate system 8	MODBUS_INPUT_REGISTER	151	1		4	0	0	0
+External adjustment climate system 7	MODBUS_INPUT_REGISTER	152	1		4	0	0	0
+External adjustment climate system 6	MODBUS_INPUT_REGISTER	153	1		4	0	0	0
+External adjustment climate system 5	MODBUS_INPUT_REGISTER	154	1		4	0	0	0
+Climate system 8	MODBUS_INPUT_REGISTER	156	1		4	0	0	0
+Climate system 7	MODBUS_INPUT_REGISTER	157	1		4	0	0	0
+Climate system 6	MODBUS_INPUT_REGISTER	158	1		4	0	0	0
+Climate system 5	MODBUS_INPUT_REGISTER	159	1		4	0	0	0
+Hot water comfort return (BT82)	MODBUS_INPUT_REGISTER	174	10	°C	2	0	0	0
+Hot water comfort heater (BT83)	MODBUS_INPUT_REGISTER	175	10	°C	2	0	0	0
+id:599	MODBUS_INPUT_REGISTER	267	1	h	6	-2147483648	2147483647	0
+id:600	MODBUS_INPUT_REGISTER	269	1	h	6	-2147483648	2147483647	0
+id:601	MODBUS_INPUT_REGISTER	271	1	h	6	-2147483648	2147483647	0
+Compressor, total time cooling, main unit (EP14)	MODBUS_INPUT_REGISTER	279	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool, main unit (EP14)	MODBUS_INPUT_REGISTER	281	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool 2, main unit (EP14)	MODBUS_INPUT_REGISTER	283	1	h	6	-2147483648	2147483647	0
+Heat pump 1 requested compressor frequency	MODBUS_INPUT_REGISTER	301	1	Hz	4	0	0	0
+Main unit, requested compressor freq	MODBUS_INPUT_REGISTER	302	1	Hz	4	0	0	0
+Frost protection heat exchanger, main unit	MODBUS_INPUT_REGISTER	310	1		4	0	0	0
+Status (OPT)	MODBUS_INPUT_REGISTER	311	1		4	0	0	0
+Version (OPT)	MODBUS_INPUT_REGISTER	312	1		5	0	0	0
+OPT relay, modulation level	MODBUS_INPUT_REGISTER	313	10	%	2	0	0	0
+OPT operating time	MODBUS_INPUT_REGISTER	315	1	h	5	0	0	0
+Available compressors heating	MODBUS_INPUT_REGISTER	317	1		4	0	0	0
+Available compressors hot water	MODBUS_INPUT_REGISTER	318	1		4	0	0	0
+Available compressors pool 1	MODBUS_INPUT_REGISTER	319	1		4	0	0	0
+Available compressors cooling	MODBUS_INPUT_REGISTER	321	1		4	0	0	0
++Adjust, port	MODBUS_INPUT_REGISTER	327	1		4	0	0	0
++Adjust, operating mode	MODBUS_INPUT_REGISTER	328	1		4	0	0	0
++Adjust, comfort	MODBUS_INPUT_REGISTER	329	1		4	0	0	0
++Adjust, parallel adjustment	MODBUS_INPUT_REGISTER	330	1		1	0	0	0
++Adjust, humidity	MODBUS_INPUT_REGISTER	331	10	%RH	2	0	0	0
++Adjust, indoor temperature	MODBUS_INPUT_REGISTER	332	10	°C	2	0	0	0
++Adjust, outdoor temperature	MODBUS_INPUT_REGISTER	333	10	°C	2	0	0	0
++Adjust, version	MODBUS_INPUT_REGISTER	334	1		5	0	0	0
++Adjust, active	MODBUS_INPUT_REGISTER	335	1		4	0	0	0
++Adjust, demand	MODBUS_INPUT_REGISTER	336	1		4	0	0	0
++Adjust, parallel factor	MODBUS_HOLDING_REGISTER	1	1		1	1	10	5
++Adjust, Parallel (min-max)	MODBUS_HOLDING_REGISTER	2	1		1	1	100	100
+Supply temperature (BT64)	MODBUS_INPUT_REGISTER	337	10	°C	2	0	0	0
+Heat pump functionality 2	MODBUS_INPUT_REGISTER	338	1		6	0	0	0
+Status (S135)	MODBUS_INPUT_REGISTER	344	1		4	0	0	0
+Status, demand, pump speed (S135)	MODBUS_INPUT_REGISTER	345	1		4	0	0	0
+Status, demand, fan speed (S135)	MODBUS_INPUT_REGISTER	346	1		4	0	0	0
+Status, solenoid (S135)	MODBUS_INPUT_REGISTER	347	1		4	0	0	0
+Status, compressor, heater(S135)	MODBUS_INPUT_REGISTER	348	1		4	0	0	0
+Status, compressor, demand (S135)	MODBUS_INPUT_REGISTER	350	1		4	0	0	0
+No. of starts (S135)	MODBUS_INPUT_REGISTER	351	1		6	0	9999999	0
+Operating time (S135)	MODBUS_INPUT_REGISTER	353	1	h	6	0	9999999	0
+Degree minutes	MODBUS_HOLDING_REGISTER	11	10	DM	3	-30000	30000	0
+Blocking (ERS 1)	MODBUS_INPUT_REGISTER	358	1		4	0	0	0
+AZ30-EB17	MODBUS_INPUT_REGISTER	359	1		4	0	0	0
+Supply line (S135-BT12)	MODBUS_INPUT_REGISTER	360	10	°C	2	0	0	0
+Return line (S135-BT13)	MODBUS_INPUT_REGISTER	361	10	°C	2	0	0	0
+Evaporator (S135-BT16)	MODBUS_INPUT_REGISTER	362	10	°C	2	0	0	0
+Defrosting sensor (S135-BT76)	MODBUS_INPUT_REGISTER	363	10	°C	2	0	0	0
+Incoming air (S135-BT77)	MODBUS_INPUT_REGISTER	364	10	°C	2	0	0	0
+Alarm number (S135)	MODBUS_INPUT_REGISTER	365	1		5	0	0	0
+Defrosting (S135)	MODBUS_INPUT_REGISTER	366	1		4	0	0	0
+Status, relay 5 (S135)	MODBUS_INPUT_REGISTER	367	1		4	0	0	0
+Status, relay 4 (S135)	MODBUS_INPUT_REGISTER	368	1		4	0	0	0
+Status, relay 3 (S135)	MODBUS_INPUT_REGISTER	369	1		4	0	0	0
+Status, relay 2 (S135)	MODBUS_INPUT_REGISTER	370	1		4	0	0	0
+Status, relay 1 (S135)	MODBUS_INPUT_REGISTER	371	1		4	0	0	0
+Status, relay 0 (S135)	MODBUS_INPUT_REGISTER	372	1		4	0	0	0
+Pump speed (S135)	MODBUS_INPUT_REGISTER	373	1	%	4	0	0	0
+Selected fan speed	MODBUS_INPUT_REGISTER	374	1	%	4	0	0	0
+Version (S135)	MODBUS_INPUT_REGISTER	376	1		5	0	0	0
+id:803	MODBUS_INPUT_REGISTER	377	1		6	0	2147483647	0
+id:804	MODBUS_INPUT_REGISTER	379	1		6	0	0	0
+id:805	MODBUS_INPUT_REGISTER	381	1		6	0	2147483647	0
+id:806	MODBUS_INPUT_REGISTER	383	1		6	0	0	0
+Seconds of blank time left, charge pump 1	MODBUS_INPUT_REGISTER	392	1		4	0	0	0
+Seconds of blank time left, charge pump 0	MODBUS_INPUT_REGISTER	393	1		4	0	0	0
+Max fan speed (EB101)	MODBUS_INPUT_REGISTER	402	1	rpm	5	0	0	0
+Min fan speed (EB101)	MODBUS_INPUT_REGISTER	403	1	rpm	5	0	0	0
+Power (EB101)	MODBUS_INPUT_REGISTER	406	10	kW	5	0	0	0
+Time to defrosting (EB101)	MODBUS_INPUT_REGISTER	407	1	min	5	0	0	0
+Defrosting index (EB101)	MODBUS_INPUT_REGISTER	408	1		5	0	0	0
+Superheat reference EEV (EB101)	MODBUS_INPUT_REGISTER	409	10	°C	2	0	0	0
+Superheat EEV (EB101)	MODBUS_INPUT_REGISTER	410	10	°C	2	0	0	0
+EEV-ssh-error (EB101)	MODBUS_INPUT_REGISTER	411	10	°C	2	0	0	0
+Superheat temp. reference EEV (EB101)	MODBUS_INPUT_REGISTER	412	10	°C	2	0	0	0
+Set point value EEV (EB101)	MODBUS_INPUT_REGISTER	413	10	°C	2	0	0	0
+EEV PV (EB101)	MODBUS_INPUT_REGISTER	414	10	°C	2	0	0	0
+EEV-te-error average open (EB101)	MODBUS_INPUT_REGISTER	415	10	°C	2	0	0	0
+Degree of opening EEV (EB101)	MODBUS_INPUT_REGISTER	416	1		5	0	0	0
+Superheat reference EVI (EB101)	MODBUS_INPUT_REGISTER	417	10	°C	2	0	0	0
+Superheat EVI (EB101)	MODBUS_INPUT_REGISTER	418	10	°C	2	0	0	0
+EEV-ssh-error (EVI)(EB101)	MODBUS_INPUT_REGISTER	419	10	°C	2	0	0	0
+Superheat temp. reference EVI (EB101)	MODBUS_INPUT_REGISTER	420	10	°C	2	0	0	0
+Set point value EVI (EB101)	MODBUS_INPUT_REGISTER	421	10	°C	2	0	0	0
+EVI PV (EB101)	MODBUS_INPUT_REGISTER	422	10	°C	2	0	0	0
+EEV-te-error average open in (EVI)(EB101)	MODBUS_INPUT_REGISTER	423	10	°C	2	0	0	0
+Degree of opening EVI (EB101)	MODBUS_INPUT_REGISTER	424	1		5	0	0	0
+id:859	MODBUS_INPUT_REGISTER	426	10	%RH	2	0	0	0
+id:861	MODBUS_INPUT_REGISTER	427	1		6	0	0	0
+id:862	MODBUS_INPUT_REGISTER	429	1		5	0	0	0
+Low press (EB101 BP8 dew)	MODBUS_INPUT_REGISTER	550	10	°C	2	0	0	0
+Hi press (EB101 BP9 dew)	MODBUS_INPUT_REGISTER	551	10	°C	2	0	0	0
+Injection (EB101-BT81)	MODBUS_INPUT_REGISTER	552	10	°C	2	0	0	0
+Pressure sensor, injection (EB101-BP11)	MODBUS_INPUT_REGISTER	553	10		2	0	0	0
+EVI pressure (EB101-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	554	10	°C	2	0	0	0
+Fan status (EB101-EP14)	MODBUS_INPUT_REGISTER	556	1		4	0	0	0
+Fan rpm (EB101-EP14)	MODBUS_INPUT_REGISTER	557	1	rpm	5	0	0	0
+High condenser out alarm (S135)	MODBUS_INPUT_REGISTER	575	1		5	0	0	0
+High condenser in alarm (S135)	MODBUS_INPUT_REGISTER	576	1		5	0	0	0
+Average current (EME 10)	MODBUS_INPUT_REGISTER	578	10	A	2	0	0	0
+Operating mode PV panels	MODBUS_INPUT_REGISTER	579	1		4	0	0	0
+EME lux mode without EME	MODBUS_INPUT_REGISTER	581	1		4	0	0	0
+Timer (EME)	MODBUS_INPUT_REGISTER	582	60	min	5	0	0	0
+Fan mode 4	MODBUS_INPUT_REGISTER	590	1	%	4	0	0	0
+Fan mode 3	MODBUS_INPUT_REGISTER	591	1	%	4	0	0	0
+Fan mode 2	MODBUS_INPUT_REGISTER	592	1	%	4	0	0	0
+Is the compressor accessible	MODBUS_INPUT_REGISTER	593	1		4	0	0	0
+Prio, hot water (OPT)	MODBUS_INPUT_REGISTER	604	1		4	0	0	0
+Permit (undefined)	MODBUS_INPUT_REGISTER	683	1		4	0	0	0
+Permit (undefined)	MODBUS_INPUT_REGISTER	684	1		4	0	0	0
+Permit (undefined)	MODBUS_INPUT_REGISTER	685	1		4	0	0	0
+Permit (OPT 10) additional heat	MODBUS_INPUT_REGISTER	686	1		4	0	0	0
+Permit ext. imm. heater step	MODBUS_INPUT_REGISTER	687	1		4	0	0	0
+Permit int. imm. heater step	MODBUS_INPUT_REGISTER	688	1		4	0	0	0
+Permit shunted additional heat	MODBUS_INPUT_REGISTER	689	1		4	0	0	0
+Permit prioritised additional heat	MODBUS_INPUT_REGISTER	690	1		4	0	0	0
+Permit (EB108-EP15)	MODBUS_INPUT_REGISTER	691	1		4	0	0	0
+Permit (EB107-EP15)	MODBUS_INPUT_REGISTER	692	1		4	0	0	0
+Permit (EB106-EP15)	MODBUS_INPUT_REGISTER	693	1		4	0	0	0
+Permit (EB105-EP15)	MODBUS_INPUT_REGISTER	694	1		4	0	0	0
+Permit (EB104-EP15)	MODBUS_INPUT_REGISTER	695	1		4	0	0	0
+Permit (EB103-EP15)	MODBUS_INPUT_REGISTER	696	1		4	0	0	0
+Permit (EB102-EP15)	MODBUS_INPUT_REGISTER	697	1		4	0	0	0
+Permit (EB101-EP15)	MODBUS_INPUT_REGISTER	698	1		4	0	0	0
+Permit (EB100-EP15)	MODBUS_INPUT_REGISTER	699	1		4	0	0	0
+Permit (EB108-EP14)	MODBUS_INPUT_REGISTER	700	1		4	0	0	0
+Permit (EB107-EP14)	MODBUS_INPUT_REGISTER	701	1		4	0	0	0
+Permit (EB106-EP14)	MODBUS_INPUT_REGISTER	702	1		4	0	0	0
+Permit (EB105-EP14)	MODBUS_INPUT_REGISTER	703	1		4	0	0	0
+Permit (EB104-EP14)	MODBUS_INPUT_REGISTER	704	1		4	0	0	0
+Permit (EB103-EP14)	MODBUS_INPUT_REGISTER	705	1		4	0	0	0
+Permit (EB102-EP14)	MODBUS_INPUT_REGISTER	706	1		4	0	0	0
+Permit (EB101-EP14)	MODBUS_INPUT_REGISTER	707	1		4	0	0	0
+Permit (EB100-EP14)	MODBUS_INPUT_REGISTER	708	1		4	0	0	0
+Smart energy source, priority 7, start DM	MODBUS_INPUT_REGISTER	709	1		3	0	0	0
+Smart energy source, priority 6, start DM	MODBUS_INPUT_REGISTER	711	1		3	0	0	0
+Smart energy source, priority 5, start DM	MODBUS_INPUT_REGISTER	713	1		3	0	0	0
+Smart energy source, priority 4, start DM	MODBUS_INPUT_REGISTER	715	1		3	0	0	0
+Smart energy source, priority 3, start DM	MODBUS_INPUT_REGISTER	717	1		3	0	0	0
+Smart energy source, priority 2, start DM	MODBUS_INPUT_REGISTER	719	1		3	0	0	0
+Smart energy source, priority 1, start DM	MODBUS_INPUT_REGISTER	721	1		3	0	0	0
+Smart energy source, priority 7, stop DM	MODBUS_INPUT_REGISTER	723	1		3	0	0	0
+Smart energy source, priority 6, stop DM	MODBUS_INPUT_REGISTER	725	1		3	0	0	0
+Smart energy source, priority 5, stop DM	MODBUS_INPUT_REGISTER	727	1		3	0	0	0
+Smart energy source, priority 4, stop DM	MODBUS_INPUT_REGISTER	729	1		3	0	0	0
+Smart energy source, priority 3, stop DM	MODBUS_INPUT_REGISTER	731	1		3	0	0	0
+Smart energy source, priority 2, stop DM	MODBUS_INPUT_REGISTER	733	1		3	0	0	0
+Smart energy source, priority 1, stop DM	MODBUS_INPUT_REGISTER	735	1		3	0	0	0
+Smart energy source, DM minimum value	MODBUS_INPUT_REGISTER	737	1		3	0	0	0
+External guide status	MODBUS_INPUT_REGISTER	745	1		4	0	0	0
+Test guide value	MODBUS_INPUT_REGISTER	746	1		5	0	0	0
+Temp. lux forces start of hot water demand	MODBUS_INPUT_REGISTER	747	1		4	0	0	0
+Smart energy source, prio OPT10 for hot water	MODBUS_INPUT_REGISTER	757	1		4	0	0	0
+Smart energy source, Permit OPT to produce hot water	MODBUS_INPUT_REGISTER	758	1		4	0	0	0
+Wood boiler activated	MODBUS_INPUT_REGISTER	759	1		4	0	0	0
+Time to defrosting (EB108)	MODBUS_INPUT_REGISTER	767	1	min	5	0	0	0
+Time to defrosting (EB107)	MODBUS_INPUT_REGISTER	792	1	min	5	0	0	0
+Time to defrosting (EB106)	MODBUS_INPUT_REGISTER	817	1	min	5	0	0	0
+Time to defrosting (EB105)	MODBUS_INPUT_REGISTER	842	1	min	5	0	0	0
+Time to defrosting (EB104)	MODBUS_INPUT_REGISTER	867	1	min	5	0	0	0
+Time to defrosting (EB103)	MODBUS_INPUT_REGISTER	892	1	min	5	0	0	0
+Time to defrosting (EB102)	MODBUS_INPUT_REGISTER	917	1	min	5	0	0	0
+Alarm number (EB100)	MODBUS_INPUT_REGISTER	935	1		4	0	0	0
+Fan speed (EB100)	MODBUS_INPUT_REGISTER	936	1	rpm	5	0	0	0
+Max fan speed (EB100)	MODBUS_INPUT_REGISTER	937	1	rpm	5	0	0	0
+Min fan speed (EB100)	MODBUS_INPUT_REGISTER	938	1	rpm	5	0	0	0
+Max compressor speed (EB100)	MODBUS_INPUT_REGISTER	939	10	Hz	5	0	0	0
+Min compressor speed (EB100)	MODBUS_INPUT_REGISTER	940	10	Hz	5	0	0	0
+Power (EB100)	MODBUS_INPUT_REGISTER	941	10	kW	5	0	0	0
+Time to defrosting (EB100)	MODBUS_INPUT_REGISTER	942	1	min	5	0	0	0
+Defrosting index (EB100)	MODBUS_INPUT_REGISTER	943	1		5	0	0	0
+Superheat reference (EEV)(EB100)	MODBUS_INPUT_REGISTER	944	10	°C	2	0	0	0
+Superheat EEV (EB100)	MODBUS_INPUT_REGISTER	945	10	°C	2	0	0	0
+EEV-ssh-error EB100)	MODBUS_INPUT_REGISTER	946	10	°C	2	0	0	0
+Superheat temp. reference (EEV)(EB100)	MODBUS_INPUT_REGISTER	947	10	°C	2	0	0	0
+Set point value EEV (EB100)	MODBUS_INPUT_REGISTER	948	10	°C	2	0	0	0
+EEV PV (EB100)	MODBUS_INPUT_REGISTER	949	10	°C	2	0	0	0
+EEV-te-error average open (EB100)	MODBUS_INPUT_REGISTER	950	10	°C	2	0	0	0
+Opening degree EEV (EB100)	MODBUS_INPUT_REGISTER	951	1		5	0	0	0
+Superheat reference EVI (EB100)	MODBUS_INPUT_REGISTER	952	10	°C	2	0	0	0
+Superheat EVI (EB100)	MODBUS_INPUT_REGISTER	953	10	°C	2	0	0	0
+EEV-ssh-error (EVI)(EB100)	MODBUS_INPUT_REGISTER	954	10	°C	2	0	0	0
+Superheat temp. reference (EVI)(EB100)	MODBUS_INPUT_REGISTER	955	10	°C	2	0	0	0
+Set point value EVI (EB100)	MODBUS_INPUT_REGISTER	956	10	°C	2	0	0	0
+EVI PV (EB100)	MODBUS_INPUT_REGISTER	957	10	°C	2	0	0	0
+EEV-te-error average open (EVI)(EB100)	MODBUS_INPUT_REGISTER	958	10	°C	2	0	0	0
+Opening degree EVI EB100)	MODBUS_INPUT_REGISTER	959	1		5	0	0	0
+Wind speed, weather forecast	MODBUS_INPUT_REGISTER	960	10		5	0	0	0
+Humidity, weather forecast	MODBUS_INPUT_REGISTER	961	10	%	5	0	0	0
+Temperature, weather forecast	MODBUS_INPUT_REGISTER	962	10	°C	2	0	0	0
+Temperature, weather data (forecast)	MODBUS_INPUT_REGISTER	963	10	°C	2	0	0	0
+Smart energy source, priority select. in hot water	MODBUS_INPUT_REGISTER	991	1		4	0	0	0
+Outd. air heat pump, inverter, limits	MODBUS_INPUT_REGISTER	992	1		4	0	0	0
+Outd. air heat pump, inverter, speed reducing	MODBUS_INPUT_REGISTER	993	1		4	0	0	0
+Serial index (EB100)	MODBUS_INPUT_REGISTER	1011	1		4	0	0	0
+Alarm incompatible (heat pump)	MODBUS_INPUT_REGISTER	1012	1		5	0	0	0
+Limit DM	MODBUS_HOLDING_REGISTER	18	10	DM	2	-30000	30000	0
+Calculated supply climate system 1	MODBUS_INPUT_REGISTER	1017	10	°C	2	0	0	0
+Class 1 alarm	MODBUS_INPUT_REGISTER	2195	1		4	0	0	0
+Frost protection status	MODBUS_INPUT_REGISTER	1018	1		5	0	0	0
+Cooling status	MODBUS_INPUT_REGISTER	1019	1		4	0	0	0
+id:1726	MODBUS_HOLDING_REGISTER	2757	1		2	0	30000	0
+Total run time additional heat	MODBUS_INPUT_REGISTER	1025	10	h	3	0	1000000	0
+Power internal additional heat	MODBUS_INPUT_REGISTER	1027	100	kW	2	0	0	0
+id:1757	MODBUS_HOLDING_REGISTER	2758	1		4	0	1	0
+Priority	MODBUS_INPUT_REGISTER	1028	1		4	0	0	0
+Operating mode internal add. heat	MODBUS_INPUT_REGISTER	1029	1		4	0	0	0
+Oper. mode shunt climate system 4	MODBUS_INPUT_REGISTER	1030	1		4	0	0	0
+Oper. mode shunt climate system 3	MODBUS_INPUT_REGISTER	1031	1		4	0	0	0
+Oper. mode shunt climate system 2	MODBUS_INPUT_REGISTER	1032	1		4	0	0	0
+Oper. mode shunt climate system 1	MODBUS_INPUT_REGISTER	1033	1		4	0	0	0
+Operating. mode shunt controlled additional heat	MODBUS_INPUT_REGISTER	1034	1		4	0	0	0
+Fan mode 1	MODBUS_INPUT_REGISTER	1037	1	%	4	0	0	0
+Current hot water mode	MODBUS_INPUT_REGISTER	1038	1		1	0	0	0
+Blocking cooling	MODBUS_INPUT_REGISTER	1053	1		4	0	0	0
+External adjustment climate system 4	MODBUS_INPUT_REGISTER	1054	1		4	0	0	0
+External adjustment climate system 3	MODBUS_INPUT_REGISTER	1055	1		4	0	0	0
+External adjustment climate system 2	MODBUS_INPUT_REGISTER	1056	1		4	0	0	0
+External adjustment climate system 1	MODBUS_INPUT_REGISTER	1057	1		4	0	0	0
+External blocking	MODBUS_INPUT_REGISTER	1058	1		4	0	0	0
+Step controlled add. heat blocking	MODBUS_INPUT_REGISTER	1062	1		4	0	0	0
+Energy meter	MODBUS_INPUT_REGISTER	1067	10	kWh	6	0	9999999	0
+Total HW run time additional heat	MODBUS_INPUT_REGISTER	1069	10	h	3	0	9999999	0
+More hot water status	MODBUS_INPUT_REGISTER	1078	1		4	0	0	0
+Holiday function status	MODBUS_HOLDING_REGISTER	19	1		1	0	0	0
+Heating medium pump speed (GP1)	MODBUS_INPUT_REGISTER	1102	1	%	4	0	0	0
+Docked compressors heating	MODBUS_INPUT_REGISTER	1108	1		4	0	0	0
+Docked compressors hot water	MODBUS_INPUT_REGISTER	1109	1		4	0	0	0
+Docked compressors pool 1	MODBUS_INPUT_REGISTER	1110	1		4	0	0	0
+Reversing valve hot water (QN10)	MODBUS_INPUT_REGISTER	2196	1		4	0	0	0
+Operating mode step controlled additional heat	MODBUS_INPUT_REGISTER	1115	1		4	0	0	0
+Relay status, base board (EB100-EP14)	MODBUS_INPUT_REGISTER	1117	1		4	0	0	0
+Relay status, imm. heat. board (EB100-EP14)	MODBUS_INPUT_REGISTER	1119	1		4	0	0	0
+Current status	MODBUS_INPUT_REGISTER	1120	1		6	0	0	0
+Functionality, heat pump (EP14)	MODBUS_INPUT_REGISTER	1122	1		6	0	0	0
+Active heat pumps	MODBUS_INPUT_REGISTER	1124	1		5	0	0	0
+Functionality, heat pump (EP15)	MODBUS_INPUT_REGISTER	1125	1		6	0	0	0
+Operating mode HW comfort	MODBUS_INPUT_REGISTER	1129	1		4	0	0	0
+Operating mode HW comfort additional heat	MODBUS_INPUT_REGISTER	1130	1		4	0	0	0
+Blocked	MODBUS_INPUT_REGISTER	1132	1		4	0	0	0
+Pool 1 (QN19)	MODBUS_INPUT_REGISTER	1134	1		4	0	0	0
+Heat pump type (EB100)	MODBUS_INPUT_REGISTER	1497	1		4	0	0	0
+Compressor size (EB100)	MODBUS_INPUT_REGISTER	1498	1		4	0	0	0
+Compressor, requested (EB101-EP14)	MODBUS_INPUT_REGISTER	1556	1		4	0	0	0
+Cooling blocking	MODBUS_INPUT_REGISTER	1559	1		4	0	0	0
+Date, periodic hot water	MODBUS_INPUT_REGISTER	1561	1		-	-	-	-
+Blocked compressors	MODBUS_INPUT_REGISTER	2174	1		6	0	0	0
+Cooling degree minutes	MODBUS_HOLDING_REGISTER	20	10	DM	2	-30000	30000	0
+Hot water, including int. add. heat	MODBUS_INPUT_REGISTER	1575	10	kWh	6	0	9999999	0
+Heating, including int. add. heat	MODBUS_INPUT_REGISTER	1577	10	kWh	6	0	9999999	0
+Hot water, compressor only	MODBUS_INPUT_REGISTER	1583	10	kWh	6	0	9999999	0
+Heating, compressor only	MODBUS_INPUT_REGISTER	1585	10	kWh	6	0	9999999	0
+id:2728	MODBUS_HOLDING_REGISTER	3099	1		3	0	9999999	0
+Speed (GP12)	MODBUS_INPUT_REGISTER	1589	1	%	4	0	0	0
+id:2793	MODBUS_INPUT_REGISTER	1637	1	%	4	0	0	0
+Frost protection heat exchanger heat pump 1	MODBUS_INPUT_REGISTER	1638	1		4	0	0	0
+Operating mode extra additional heat	MODBUS_INPUT_REGISTER	1693	1		4	0	0	0
+Docked compressors cooling	MODBUS_INPUT_REGISTER	1694	1		4	0	0	0
+BP4, unprocessed (EB101-EP14)	MODBUS_INPUT_REGISTER	1800	1		2	0	0	0
+Defrosting (EB101)	MODBUS_INPUT_REGISTER	1805	1		4	0	0	0
+Power (EB101-EP14)	MODBUS_INPUT_REGISTER	1806	1	kW	4	0	0	0
+Internal charge pump (GP12)	MODBUS_INPUT_REGISTER	1822	1		4	0	0	0
+Climate system 4	MODBUS_INPUT_REGISTER	1823	1		4	0	0	0
+Climate system 3	MODBUS_INPUT_REGISTER	1824	1		4	0	0	0
+Climate system 2	MODBUS_INPUT_REGISTER	1825	1		4	0	0	0
+Climate system 1 (HMP)	MODBUS_INPUT_REGISTER	1826	1		4	0	0	0
+Pool 1 pump status	MODBUS_INPUT_REGISTER	1828	1		4	0	0	0
+Operating mode (SG Ready)	MODBUS_INPUT_REGISTER	1911	1		4	0	0	0
+SG ready, input A	MODBUS_INPUT_REGISTER	1912	1		4	0	0	0
+SG ready, input B	MODBUS_INPUT_REGISTER	1913	1		4	0	0	0
+Heating offset (SPA)	MODBUS_INPUT_REGISTER	1914	10		1	0	0	0
+Hot water comfort mode (SPA)	MODBUS_INPUT_REGISTER	1915	1		1	0	0	0
+Pool offset (SPA)	MODBUS_INPUT_REGISTER	1916	1		1	0	0	0
+Cooling offset (SPA)	MODBUS_INPUT_REGISTER	1917	1		1	0	0	0
+Operating mode (Smart Price Adaption)	MODBUS_INPUT_REGISTER	1918	1		4	0	0	0
+Evaporator 2 (EB100-EP15-BT16)	MODBUS_INPUT_REGISTER	1969	10	°C	2	0	0	0
+Temperature, inverter (EB100-EP15)	MODBUS_INPUT_REGISTER	1970	10	°C	2	0	0	0
+fan speed (EB100-EP15)	MODBUS_INPUT_REGISTER	1971	1		4	0	0	0
+Evaporator 2 (EB100-EP14-BT16)	MODBUS_INPUT_REGISTER	1972	10	°C	2	0	0	0
+Temperature, inverter (EB100-EP14)	MODBUS_INPUT_REGISTER	1973	10	°C	2	0	0	0
+fan speed (EB100-EP14)	MODBUS_INPUT_REGISTER	1974	1		4	0	0	0
+Alarm number	MODBUS_INPUT_REGISTER	1975	1		2	0	0	0
+Reset alarm	MODBUS_HOLDING_REGISTER	22	1		4	0	0	0
+Non module-specific alarm numbers	MODBUS_INPUT_REGISTER	1976	1		2	0	0	0
+Heating curve climate system 1	MODBUS_HOLDING_REGISTER	26	1		1	0	15	9
+Heating offset climate system 1	MODBUS_HOLDING_REGISTER	30	1		1	-10	10	0
+Min supply climate system 1	MODBUS_HOLDING_REGISTER	34	10	°C	2	50	800	200
+Max supply climate system 1	MODBUS_HOLDING_REGISTER	38	10	°C	2	50	800	600
+Own curve, heating P7	MODBUS_HOLDING_REGISTER	39	1	°C	1	5	80	15
+Own curve, heating P6	MODBUS_HOLDING_REGISTER	40	1	°C	1	5	80	15
+Own curve, heating P5	MODBUS_HOLDING_REGISTER	41	1	°C	1	5	80	26
+Own curve, heating P4	MODBUS_HOLDING_REGISTER	42	1	°C	1	5	80	32
+Own curve, heating P3	MODBUS_HOLDING_REGISTER	43	1	°C	1	5	80	35
+Own curve, heating P2	MODBUS_HOLDING_REGISTER	44	1	°C	1	5	80	40
+Own curve, heating P1	MODBUS_HOLDING_REGISTER	45	1	°C	1	5	80	45
+Point offset outdoor temperature	MODBUS_HOLDING_REGISTER	46	1	°C	1	-40	30	0
+Point offset	MODBUS_HOLDING_REGISTER	47	1	°C	1	-10	10	0
+External adjustment climate system 1	MODBUS_HOLDING_REGISTER	51	1		1	-10	10	0
+External adjustment with room sensor climate system 1	MODBUS_HOLDING_REGISTER	55	10	°C	2	50	300	200
+Hot water demand mode	MODBUS_HOLDING_REGISTER	56	1		1	0	4	1
+Start temperature HW high temperature	MODBUS_HOLDING_REGISTER	58	10	°C	2	50	700	470
+Start temperature HW normal temperature	MODBUS_HOLDING_REGISTER	59	10	°C	2	50	700	440
+Start temperature HW low temperature	MODBUS_HOLDING_REGISTER	60	10	°C	2	50	700	400
+Stop temperature HW periodic increase	MODBUS_HOLDING_REGISTER	61	10	°C	2	550	700	550
+Stop temperature HW high temperature	MODBUS_HOLDING_REGISTER	62	10	°C	2	50	700	510
+Stop temperature HW normal temperature	MODBUS_HOLDING_REGISTER	63	10	°C	2	50	700	480
+Stop temperature HW low temperature	MODBUS_HOLDING_REGISTER	64	10	°C	2	50	700	440
+Periodic hot water	MODBUS_HOLDING_REGISTER	65	1		1	0	1	1
+Periodic hot water interval	MODBUS_HOLDING_REGISTER	66	1	days	1	1	90	7
+Start time periodic hot water	MODBUS_HOLDING_REGISTER	67	1		-	-	-	-
+Language	MODBUS_HOLDING_REGISTER	91	1		1	0	22	0
+Period time hot water	MODBUS_HOLDING_REGISTER	92	1	min	4	0	180	30
+Period time heating	MODBUS_HOLDING_REGISTER	93	1	min	4	0	180	30
+Operating mode	MODBUS_HOLDING_REGISTER	2743	1		4	0	2	0
+Operating mode heating medium pump	MODBUS_HOLDING_REGISTER	95	1		4	10	40	40
+Activate force control	MODBUS_HOLDING_REGISTER	5000	1		4	0	0	0
+Max. internal additional heat	MODBUS_HOLDING_REGISTER	102	100	kW	2	0	4500	900
+Fuse	MODBUS_HOLDING_REGISTER	103	1	A	5	1	400	16
+id:3826	MODBUS_HOLDING_REGISTER	2747	1		4	1	128	4
+id:3827	MODBUS_HOLDING_REGISTER	2746	1		4	1	128	2
+id:3828	MODBUS_HOLDING_REGISTER	2745	1		4	1	128	1
+Floor drying	MODBUS_HOLDING_REGISTER	120	1		4	0	1	0
+Floor drying period 7	MODBUS_HOLDING_REGISTER	121	1	days	4	0	30	2
+Floor drying period 6	MODBUS_HOLDING_REGISTER	122	1	days	4	0	30	2
+Floor drying period 5	MODBUS_HOLDING_REGISTER	123	1	days	4	0	30	2
+Floor drying period 4	MODBUS_HOLDING_REGISTER	124	1	days	4	0	30	3
+Floor drying period 3	MODBUS_HOLDING_REGISTER	125	1	days	4	0	30	2
+Floor drying period 2	MODBUS_HOLDING_REGISTER	126	1	days	4	0	30	2
+Floor drying period 1	MODBUS_HOLDING_REGISTER	127	1	days	4	0	30	2
+Floor drying temp. 7	MODBUS_HOLDING_REGISTER	128	1	°C	4	15	70	20
+Floor drying temp. 6	MODBUS_HOLDING_REGISTER	129	1	°C	4	15	70	30
+Floor drying temp. 5	MODBUS_HOLDING_REGISTER	130	1	°C	4	15	70	40
+Floor drying temp. 4	MODBUS_HOLDING_REGISTER	131	1	°C	4	15	70	45
+Floor drying temp. 3	MODBUS_HOLDING_REGISTER	132	1	°C	4	15	70	40
+Floor drying temp. 2	MODBUS_HOLDING_REGISTER	133	1	°C	4	15	70	30
+Floor drying temp. 1	MODBUS_HOLDING_REGISTER	134	1	°C	4	15	70	20
+Floor drying ongoing time.	MODBUS_INPUT_REGISTER	1977	1		5	0	10000	0
+Dimensioned outdoor temperature	MODBUS_HOLDING_REGISTER	140	10	°C	2	-400	200	-180
+Delta T for DOT	MODBUS_HOLDING_REGISTER	141	10	°C	2	10	250	100
+Climate system 2	MODBUS_HOLDING_REGISTER	142	1		4	0	1	0
+Climate system 3	MODBUS_HOLDING_REGISTER	143	1		4	0	1	0
+Climate system 4	MODBUS_HOLDING_REGISTER	144	1		4	0	1	0
+Shunt controlled additional heat	MODBUS_HOLDING_REGISTER	153	1		4	0	1	0
+Wait time shunt, shunt controlled additional heat	MODBUS_HOLDING_REGISTER	157	1	s	2	10	300	30
+Step controlled additional heat accessory	MODBUS_HOLDING_REGISTER	158	1		4	0	1	0
+DM start step controlled additional heat	MODBUS_HOLDING_REGISTER	159	1	DM	2	-2000	-30	-400
+Waiting time cooling/heating	MODBUS_HOLDING_REGISTER	165	1	h	1	0	48	2
+Heating start at under temp.	MODBUS_HOLDING_REGISTER	166	10	°C	1	5	100	10
+Cooling start at over temp.	MODBUS_HOLDING_REGISTER	167	10	°C	1	5	100	30
+Cooling with room sensors	MODBUS_HOLDING_REGISTER	170	10		4	0	41	0
+Start active cooling DM	MODBUS_HOLDING_REGISTER	173	1	DM	2	10	300	30
+Permit additional heat, heating	MODBUS_HOLDING_REGISTER	180	1		4	0	1	1
+Permit heating	MODBUS_HOLDING_REGISTER	181	1		4	0	1	1
+Permit cooling	MODBUS_HOLDING_REGISTER	182	1		4	0	1	1
+Auto mode, start temperature for cooling	MODBUS_HOLDING_REGISTER	183	10	°C	2	150	400	250
+Auto mode, stop temperature for heating	MODBUS_HOLDING_REGISTER	184	10	°C	2	-200	400	170
+Auto mode, additional heat stop temperature	MODBUS_HOLDING_REGISTER	185	10	°C	2	-250	400	50
+Auto mode filter time	MODBUS_HOLDING_REGISTER	186	1	h	4	0	48	24
+Max difference supply, compressor	MODBUS_HOLDING_REGISTER	187	10	°C	2	10	250	100
+Max difference supply, additional heat	MODBUS_HOLDING_REGISTER	188	10	°C	2	10	240	70
+Time format	MODBUS_HOLDING_REGISTER	194	1		4	0	1	1
+Alarm action, lower room temperature	MODBUS_HOLDING_REGISTER	196	1		4	0	1	0
+Alarm action lower HW temperature	MODBUS_HOLDING_REGISTER	197	1		4	0	1	1
+Auxiliary operation on alarm	MODBUS_HOLDING_REGISTER	198	1		4	0	0	0
+Use room sensor climate system 4	MODBUS_HOLDING_REGISTER	199	1		4	0	1	0
+Use room sensor climate system 3	MODBUS_HOLDING_REGISTER	200	1		4	0	1	0
+Use room sensor climate system 2	MODBUS_HOLDING_REGISTER	201	1		4	0	1	0
+Use room sensor climate system 1	MODBUS_HOLDING_REGISTER	202	1		4	0	1	0
+Room sensor set point value climate system 4	MODBUS_HOLDING_REGISTER	203	10	°C	2	50	300	200
+Room sensor set point value climate system 3	MODBUS_HOLDING_REGISTER	204	10	°C	2	50	300	200
+Room sensor set point value climate system 2	MODBUS_HOLDING_REGISTER	205	10	°C	2	50	300	200
+Room sensor set point value climate system 1	MODBUS_HOLDING_REGISTER	206	10	°C	2	50	300	200
+Room sensor factor climate system 4	MODBUS_HOLDING_REGISTER	207	10		4	0	60	20
+Room sensor factor climate system 3	MODBUS_HOLDING_REGISTER	208	10		4	0	60	20
+Room sensor factor climate system 2	MODBUS_HOLDING_REGISTER	209	10		4	0	60	20
+Room sensor factor climate system 1	MODBUS_HOLDING_REGISTER	210	10		4	0	60	20
+Input AUX5	MODBUS_HOLDING_REGISTER	211	1		4	0	59	0
+Input AUX4	MODBUS_HOLDING_REGISTER	212	1		4	0	59	0
+Input AUX3	MODBUS_HOLDING_REGISTER	213	1		4	0	59	0
+Input AUX2	MODBUS_HOLDING_REGISTER	214	1		4	0	59	0
+Input AUX1	MODBUS_HOLDING_REGISTER	215	1		4	0	59	0
+Output AUX1	MODBUS_HOLDING_REGISTER	216	1		4	0	25	0
+id:3968	MODBUS_HOLDING_REGISTER	2752	1		5	1	3600	5
+Preset flow setting for climate system	MODBUS_HOLDING_REGISTER	223	1		4	0	3	1
+id:3977	MODBUS_HOLDING_REGISTER	2753	1		4	21	22	22
+More hot water	MODBUS_HOLDING_REGISTER	225	10		-	-	-	-
+id:4050	MODBUS_HOLDING_REGISTER	4046	1		4	0	1	0
+Oper. mode	MODBUS_HOLDING_REGISTER	237	1		4	0	0	0
+Cooling heat sensor set point value	MODBUS_HOLDING_REGISTER	681	10		2	50	400	210
+Pool 1 accessory	MODBUS_HOLDING_REGISTER	685	1		4	0	1	0
+Hot water comfort	MODBUS_HOLDING_REGISTER	694	1		4	0	1	0
+More hot water	MODBUS_HOLDING_REGISTER	697	1		1	0	0	0
+Start diff. DM, step-controlled add. heat	MODBUS_HOLDING_REGISTER	703	1	DM	2	0	2000	400
+HW comfort shunt on/off	MODBUS_HOLDING_REGISTER	705	1		4	0	1	0
+External cooling accessory	MODBUS_HOLDING_REGISTER	709	1		4	0	1	0
+id:4591	MODBUS_HOLDING_REGISTER	4052	1		1	5	80	30
+Cooling connected, climate system 1	MODBUS_HOLDING_REGISTER	726	1		4	0	0	0
+id:4617	MODBUS_HOLDING_REGISTER	4053	1		1	0	1	0
+Operating mode charge pump climate system 1	MODBUS_HOLDING_REGISTER	748	1		4	0	1	1
+id:4660	MODBUS_HOLDING_REGISTER	4063	1		4	0	1	0
+Shunted brine max. temp.	MODBUS_HOLDING_REGISTER	4067	1	°C	4	0	30	20
+Heating (SG Ready)	MODBUS_HOLDING_REGISTER	760	1		4	0	1	1
+id:4703	MODBUS_HOLDING_REGISTER	4068	1		4	0	1	0
+id:4704	MODBUS_HOLDING_REGISTER	4069	1		4	0	1	0
+id:4705	MODBUS_HOLDING_REGISTER	4070	1		4	0	1	0
+id:4706	MODBUS_HOLDING_REGISTER	4071	1		4	0	1	0
+id:4707	MODBUS_HOLDING_REGISTER	4072	1		4	0	1	0
+id:4708	MODBUS_HOLDING_REGISTER	4073	1		4	0	1	0
+id:4709	MODBUS_HOLDING_REGISTER	4074	1		4	0	1	0
+id:4710	MODBUS_HOLDING_REGISTER	4075	1		4	0	1	0
+id:4711	MODBUS_HOLDING_REGISTER	0	1		4	0	1	0
+Input AUX5	MODBUS_HOLDING_REGISTER	767	1		4	0	59	0
+Operating mode circulation pump heating heat pump 1	MODBUS_HOLDING_REGISTER	783	1		4	0	1	1
+Operating mode circulation pump hot water heat pump 1	MODBUS_HOLDING_REGISTER	799	1		4	0	1	1
+Speed circulation pump waiting mode heat pump 1	MODBUS_HOLDING_REGISTER	841	1	%	4	1	100	30
+Speed, circulation pump, standby mode (EB100)	MODBUS_HOLDING_REGISTER	842	1	%	4	1	100	30
+Activated (Smart Price Adaption)	MODBUS_HOLDING_REGISTER	843	1		4	0	1	0
+(SPA), cooling activated	MODBUS_HOLDING_REGISTER	849	1		4	0	1	1
+(SPA), area	MODBUS_HOLDING_REGISTER	851	1		4	0	254	23
+Max. speed controlled charge pump (EB101)	MODBUS_HOLDING_REGISTER	867	1	%	4	80	100	100
+External adjustment climate system 8	MODBUS_HOLDING_REGISTER	893	1		1	-10	10	0
+External adjustment climate system 7	MODBUS_HOLDING_REGISTER	894	1		1	-10	10	0
+External adjustment climate system 6	MODBUS_HOLDING_REGISTER	895	1		1	-10	10	0
+External adjustment climate system 5	MODBUS_HOLDING_REGISTER	896	1		1	-10	10	0
+External adjustment with room sensor climate system 8	MODBUS_HOLDING_REGISTER	897	10	°C	2	50	300	200
+External adjustment with room sensor climate system 7	MODBUS_HOLDING_REGISTER	898	10	°C	2	50	300	200
+External adjustment with room sensor climate system 6	MODBUS_HOLDING_REGISTER	899	10	°C	2	50	300	200
+External adjustment with room sensor climate system 5	MODBUS_HOLDING_REGISTER	900	10	°C	2	50	300	200
+Climate system 5	MODBUS_HOLDING_REGISTER	905	1		4	0	1	0
+Climate system 6	MODBUS_HOLDING_REGISTER	906	1		4	0	1	0
+Climate system 7	MODBUS_HOLDING_REGISTER	907	1		4	0	1	0
+Climate system 8	MODBUS_HOLDING_REGISTER	908	1		4	0	1	0
+Heating connected, climate system 1	MODBUS_HOLDING_REGISTER	932	1		4	0	1	1
+ERS 1	MODBUS_HOLDING_REGISTER	933	1		4	0	1	0
+id:4969	MODBUS_HOLDING_REGISTER	4091	1		4	0	1	0
+id:4970	MODBUS_HOLDING_REGISTER	4092	1		4	0	1	0
+id:4971	MODBUS_HOLDING_REGISTER	4093	1	Hz	4	20	117	20
+id:4972	MODBUS_HOLDING_REGISTER	4094	1	Hz	4	20	117	20
+id:4973	MODBUS_HOLDING_REGISTER	4095	1	Hz	4	23	120	23
+id:4974	MODBUS_HOLDING_REGISTER	4096	1	Hz	4	23	120	23
+Use room sensor climate system 8	MODBUS_HOLDING_REGISTER	948	1		4	0	1	0
+Use room sensor climate system 7	MODBUS_HOLDING_REGISTER	949	1		4	0	1	0
+Use room sensor climate system 6	MODBUS_HOLDING_REGISTER	950	1		4	0	1	0
+Use room sensor climate system 5	MODBUS_HOLDING_REGISTER	951	1		4	0	1	0
+Room sensor set point value climate system 8	MODBUS_HOLDING_REGISTER	952	10	°C	2	50	300	200
+Room sensor set point value climate system 7	MODBUS_HOLDING_REGISTER	953	10	°C	2	50	300	200
+Room sensor set point value climate system 6	MODBUS_HOLDING_REGISTER	954	10	°C	2	50	300	200
+Room sensor set point value climate system 5	MODBUS_HOLDING_REGISTER	955	10	°C	2	50	300	200
+Room sensor factor climate system 8	MODBUS_HOLDING_REGISTER	956	10		4	0	60	20
+Room sensor factor climate system 7	MODBUS_HOLDING_REGISTER	957	10		4	0	60	20
+Room sensor factor climate system 6	MODBUS_HOLDING_REGISTER	958	10		4	0	60	20
+Room sensor factor climate system 5	MODBUS_HOLDING_REGISTER	959	10		4	0	60	20
+id:4992	MODBUS_HOLDING_REGISTER	4097	1		4	-999	999	70
+id:4993	MODBUS_HOLDING_REGISTER	4098	1		4	-999	999	70
+id:4994	MODBUS_HOLDING_REGISTER	4099	1		4	-999	999	70
+id:4995	MODBUS_HOLDING_REGISTER	4100	1		4	-999	999	70
+id:4996	MODBUS_HOLDING_REGISTER	4101	1		4	-999	999	70
+id:4997	MODBUS_HOLDING_REGISTER	4102	1		4	-999	999	75
+Current transformer ratio	MODBUS_HOLDING_REGISTER	980	1		5	300	3000	300
+Room sensor set point value climate system 8, cooling	MODBUS_HOLDING_REGISTER	981	10	°C	2	50	350	250
+Room sensor set point value climate system 7, cooling	MODBUS_HOLDING_REGISTER	982	10	°C	2	50	350	250
+Room sensor set point value climate system 6, cooling	MODBUS_HOLDING_REGISTER	983	10	°C	2	50	350	250
+Room sensor set point value climate system 5, cooling	MODBUS_HOLDING_REGISTER	984	10	°C	2	50	350	250
+Room sensor set point value climate system 4, cooling	MODBUS_HOLDING_REGISTER	985	10	°C	2	50	350	250
+Room sensor set point value climate system 3, cooling	MODBUS_HOLDING_REGISTER	986	10	°C	2	50	350	250
+Room sensor set point value climate system 2, cooling	MODBUS_HOLDING_REGISTER	987	10	°C	2	50	350	250
+Room sensor set point value climate system 1, cooling	MODBUS_HOLDING_REGISTER	988	10	°C	2	50	350	250
+Room sensor factor climate system 8, cooling	MODBUS_HOLDING_REGISTER	989	10		4	0	60	10
+Room sensor factor climate system 7, cooling	MODBUS_HOLDING_REGISTER	990	10		4	0	60	10
+Room sensor factor climate system 6, cooling	MODBUS_HOLDING_REGISTER	991	10		4	0	60	10
+Room sensor factor climate system 5, cooling	MODBUS_HOLDING_REGISTER	992	10		4	0	60	10
+Room sensor factor climate system 4, cooling	MODBUS_HOLDING_REGISTER	993	10		4	0	60	10
+Room sensor factor climate system 3, cooling	MODBUS_HOLDING_REGISTER	994	10		4	0	60	10
+Room sensor factor climate system 2, cooling	MODBUS_HOLDING_REGISTER	995	10		4	0	60	10
+Room sensor factor climate system 1, cooling	MODBUS_HOLDING_REGISTER	996	10		4	0	60	10
+Set point value (RH)	MODBUS_HOLDING_REGISTER	997	1	%	1	30	90	60
+HTS 1	MODBUS_HOLDING_REGISTER	998	1		4	0	1	0
+OPT	MODBUS_HOLDING_REGISTER	1015	1		4	0	1	0
+DM start difference (OPT)	MODBUS_HOLDING_REGISTER	1016	1	DM	2	10	2000	700
+Exhaust air fan speed 4 (ERS 1)	MODBUS_HOLDING_REGISTER	1021	1	%	4	0	100	100
+Exhaust air fan speed 3 (ERS 1)	MODBUS_HOLDING_REGISTER	1022	1	%	4	0	100	80
+Exhaust air fan speed 2 (ERS 1)	MODBUS_HOLDING_REGISTER	1023	1	%	4	0	100	30
+Exhaust air fan speed 1 (ERS 1)	MODBUS_HOLDING_REGISTER	1024	1	%	4	0	100	0
+Exhaust air fan speed normal (ERS 1)	MODBUS_HOLDING_REGISTER	1025	1	%	4	1	100	75
+Flow sensor activated X21	MODBUS_HOLDING_REGISTER	1031	1		4	0	1	0
+S135	MODBUS_HOLDING_REGISTER	1035	1		4	0	1	0
+Pump speed (S135)	MODBUS_HOLDING_REGISTER	1036	1	%	4	1	100	70
+Bypass temp. (ERS 1)	MODBUS_HOLDING_REGISTER	1044	1	°C	4	2	10	4
+Pool pump type	MODBUS_HOLDING_REGISTER	1045	1		4	0	1	1
+External cooling accessory pump type	MODBUS_HOLDING_REGISTER	1046	1		4	0	1	1
+Flow sensor activated X22	MODBUS_HOLDING_REGISTER	1049	1		4	0	1	0
+Max. internal additional heat SG Ready	MODBUS_HOLDING_REGISTER	1052	100	kW	2	0	900	900
+Hysteresis (OPT)	MODBUS_HOLDING_REGISTER	1066	1		2	10	2000	100
+Activated (EME10)	MODBUS_HOLDING_REGISTER	1068	1		4	0	1	0
+PV panel affects heating (EME)	MODBUS_HOLDING_REGISTER	1069	1		4	0	1	0
+PV panel affects hot water (EME)	MODBUS_HOLDING_REGISTER	1070	1		4	0	1	0
+Delay timer EME	MODBUS_HOLDING_REGISTER	1071	1		5	0	0	0
+AUX blocking (OPT)	MODBUS_HOLDING_REGISTER	1095	1		4	0	0	0
+Outdoor air mixing	MODBUS_HOLDING_REGISTER	1096	1		4	0	1	0
+Smart home room control	MODBUS_HOLDING_REGISTER	1102	1		4	0	1	0
+Smart Energy Source	MODBUS_HOLDING_REGISTER	1105	1		4	0	1	0
+Control method, smart energy source	MODBUS_HOLDING_REGISTER	1106	1		4	0	1	0
+El. price, special, smart energy source	MODBUS_HOLDING_REGISTER	1107	1		4	0	2	0
+El. price, fixed, smart energy source	MODBUS_HOLDING_REGISTER	1108	1		5	0	10000	100
+El. price, smart energy source	MODBUS_HOLDING_REGISTER	1109	1		4	0	1	0
+El. price, fixed, smart energy source	MODBUS_HOLDING_REGISTER	1110	1		5	0	10000	100
+El. price, smart energy source	MODBUS_HOLDING_REGISTER	1111	1		4	0	1	0
+El. price, fixed, smart energy source	MODBUS_HOLDING_REGISTER	1112	1		5	0	10000	100
+El. price, smart energy source	MODBUS_HOLDING_REGISTER	1113	1		4	0	1	0
+El. price, fixed, smart energy source	MODBUS_HOLDING_REGISTER	1114	1		5	0	10000	100
+El. price, smart energy source	MODBUS_HOLDING_REGISTER	1115	1		4	0	1	0
+El. price, fixed, smart energy source	MODBUS_HOLDING_REGISTER	1116	1		5	0	10000	100
+Prim. factor, smart energy source	MODBUS_HOLDING_REGISTER	1117	10		4	0	50	25
+Prim. factor, shunt add. heat smart energy source	MODBUS_HOLDING_REGISTER	1118	10		4	0	50	10
+Prim. factor, ext. step add. heat smart energy source	MODBUS_HOLDING_REGISTER	1119	10		4	0	50	10
+Prim. factor, OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1120	10		4	0	50	10
+OPT10, high tariff price smart energy source	MODBUS_HOLDING_REGISTER	1121	1		5	1	10000	100
+OPT10, low tariff price smart energy source	MODBUS_HOLDING_REGISTER	1122	1		5	1	10000	100
+ext. step add. heat, high tariff price smart energy source	MODBUS_HOLDING_REGISTER	1123	1		5	1	10000	100
+ext. step add. heat, low tariff price smart energy source	MODBUS_HOLDING_REGISTER	1124	1		5	1	10000	100
+Shunt add. heat, high tariff price smart energy source	MODBUS_HOLDING_REGISTER	1125	1		5	1	10000	100
+Shunt add. heat, low tariff price smart energy source	MODBUS_HOLDING_REGISTER	1126	1		5	1	10000	100
+El. price, fixed, high tariff smart energy source	MODBUS_HOLDING_REGISTER	1127	1		5	1	10000	100
+El. price, fixed, low tariff smart energy source	MODBUS_HOLDING_REGISTER	1128	1		5	1	10000	100
+El. price, variable, high tariff smart energy source	MODBUS_HOLDING_REGISTER	1129	1		5	1	10000	100
+El. price, variable, low tariff smart energy source	MODBUS_HOLDING_REGISTER	1130	1		5	1	10000	100
+DM start source, priority 5 smart energy source	MODBUS_HOLDING_REGISTER	1131	1		2	100	2000	400
+DM start source, priority 4 smart energy source	MODBUS_HOLDING_REGISTER	1132	1		2	100	2000	400
+DM start source, priority 3 smart energy source	MODBUS_HOLDING_REGISTER	1133	1		2	100	2000	400
+DM start source, priority 2 smart energy source	MODBUS_HOLDING_REGISTER	1134	1		2	100	2000	400
+DM start source, priority 1 smart energy source	MODBUS_HOLDING_REGISTER	1135	1		2	-2000	-10	-60
+Start day, tariff smart energy source	MODBUS_HOLDING_REGISTER	1136	1		4	1	31	1
+End day, tariff smart energy source	MODBUS_HOLDING_REGISTER	1137	1		4	1	31	31
+Start month, tariff smart energy source	MODBUS_HOLDING_REGISTER	1138	1		4	1	12	1
+End month, tariff smart energy source	MODBUS_HOLDING_REGISTER	1139	1		4	1	12	12
+Start day, fixed tariff smart energy source	MODBUS_HOLDING_REGISTER	1172	1		4	1	31	1
+End day, fixed tariff smart energy source	MODBUS_HOLDING_REGISTER	1173	1		4	1	31	31
+Start month, fixed tariff smart energy source	MODBUS_HOLDING_REGISTER	1174	1		4	1	12	1
+End month, fixed tariff smart energy source	MODBUS_HOLDING_REGISTER	1175	1		4	1	12	12
+Start day, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1208	1		4	1	31	1
+End day, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1209	1		4	1	31	31
+Start month, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1210	1		4	1	12	1
+End month, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1211	1		4	1	12	12
+Start day tariff, shunt additional heat smart energy source	MODBUS_HOLDING_REGISTER	1244	1		4	1	31	1
+End day tariff, shunt additional heat  smart energy source	MODBUS_HOLDING_REGISTER	1245	1		4	1	31	31
+Start month tariff, shunt additional heat smart energy source	MODBUS_HOLDING_REGISTER	1246	1		4	1	12	1
+End month tariff, shunt additional heat smart energy source	MODBUS_HOLDING_REGISTER	1247	1		4	1	12	12
+Start day tariff, ext. step add. heat smart energy source	MODBUS_HOLDING_REGISTER	1280	1		4	1	31	1
+End day tariff, ext. step add. heat  smart energy source	MODBUS_HOLDING_REGISTER	1281	1		4	1	31	31
+Start month tariff, ext. step add. heat smart energy source	MODBUS_HOLDING_REGISTER	1282	1		4	1	12	1
+End month tariff, ext. step add. heat smart energy source	MODBUS_HOLDING_REGISTER	1283	1		4	1	12	12
+Prioritise additional heat (AXC40)	MODBUS_HOLDING_REGISTER	1320	1		4	0	1	0
+Max difference, SES priority 1 energy source	MODBUS_HOLDING_REGISTER	1326	10	°C	2	10	250	100
+Max difference, SES lower priority energy source	MODBUS_HOLDING_REGISTER	1327	10	°C	2	10	250	70
+Installed (EB101)	MODBUS_HOLDING_REGISTER	1550	1		4	0	1	1
+EME20	MODBUS_HOLDING_REGISTER	4000	1		4	0	1	0
+Current power (EME 20)	MODBUS_INPUT_REGISTER	2176	1	W	6	0	0	0
+id:6012	MODBUS_HOLDING_REGISTER	4008	1	%	4	1	100	70
+id:6028	MODBUS_INPUT_REGISTER	1993	1		4	0	0	0
+id:6029	MODBUS_INPUT_REGISTER	1994	1		5	0	0	0
+Total average power (EME 20)	MODBUS_INPUT_REGISTER	2178	1	W	6	0	0	0
+Total energy (EME 20)	MODBUS_INPUT_REGISTER	2180	10	kWh	3	0	0	0
+ERS 2	MODBUS_HOLDING_REGISTER	4076	1		4	0	1	0
+ERS 3	MODBUS_HOLDING_REGISTER	4077	1		4	0	1	0
+ERS 4	MODBUS_HOLDING_REGISTER	4078	1		4	0	1	0
+id:6486	MODBUS_HOLDING_REGISTER	4135	1		4	0	1	0
+id:6756	MODBUS_INPUT_REGISTER	2004	10	%RH	2	0	0	0
+id:6757	MODBUS_INPUT_REGISTER	2005	10	%RH	2	0	0	0
+id:6758	MODBUS_INPUT_REGISTER	2006	10	%RH	2	0	0	0
+HTS 2	MODBUS_HOLDING_REGISTER	1981	1		4	0	1	0
+HTS 3	MODBUS_HOLDING_REGISTER	1982	1		4	0	1	0
+HTS 4	MODBUS_HOLDING_REGISTER	1983	1		4	0	1	0
+External adjustment, cooling climate system 8	MODBUS_HOLDING_REGISTER	4138	1		1	-10	10	0
+External adjustment, cooling climate system 7	MODBUS_HOLDING_REGISTER	4139	1		1	-10	10	0
+External adjustment, cooling climate system 6	MODBUS_HOLDING_REGISTER	4140	1		1	-10	10	0
+External adjustment, cooling climate system 5	MODBUS_HOLDING_REGISTER	4141	1		1	-10	10	0
+External adjustment, cooling climate system 4	MODBUS_HOLDING_REGISTER	4142	1		1	-10	10	0
+External adjustment, cooling climate system 3	MODBUS_HOLDING_REGISTER	4143	1		1	-10	10	0
+External adjustment, cooling climate system 2	MODBUS_HOLDING_REGISTER	4144	1		1	-10	10	0
+External adjustment, cooling climate system 1	MODBUS_HOLDING_REGISTER	4145	1		1	-10	10	0
+External adjustment with room sensor, cooling climate system 8	MODBUS_HOLDING_REGISTER	4146	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 7	MODBUS_HOLDING_REGISTER	4147	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 6	MODBUS_HOLDING_REGISTER	4148	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 5	MODBUS_HOLDING_REGISTER	4149	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 4	MODBUS_HOLDING_REGISTER	4150	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 3	MODBUS_HOLDING_REGISTER	4151	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 2	MODBUS_HOLDING_REGISTER	4152	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 1	MODBUS_HOLDING_REGISTER	4153	10	°C	2	50	300	200
+id:6917	MODBUS_HOLDING_REGISTER	4072	1		4	0	200	1
+id:6918	MODBUS_HOLDING_REGISTER	4073	1		4	0	20	1
+id:6920	MODBUS_HOLDING_REGISTER	4074	1		4	0	20	0
+id:6921	MODBUS_HOLDING_REGISTER	4075	1		4	1	100	15
+id:6922	MODBUS_HOLDING_REGISTER	4154	1		4	0	20	3
+id:6923	MODBUS_HOLDING_REGISTER	4155	1		4	0	20	2
+BlockFreq 1 (EB102)	MODBUS_HOLDING_REGISTER	4164	1		4	0	1	0
+BlockFreq 1 (EB103)	MODBUS_HOLDING_REGISTER	4165	1		4	0	1	0
+BlockFreq 1 (EB104)	MODBUS_HOLDING_REGISTER	4166	1		4	0	1	0
+BlockFreq 1 (EB105)	MODBUS_HOLDING_REGISTER	4167	1		4	0	1	0
+BlockFreq 1 (EB106)	MODBUS_HOLDING_REGISTER	4168	1		4	0	1	0
+BlockFreq 1 (EB107)	MODBUS_HOLDING_REGISTER	4169	1		4	0	1	0
+BlockFreq 1 (EB108)	MODBUS_HOLDING_REGISTER	4170	1		4	0	1	0
+id:6977	MODBUS_HOLDING_REGISTER	4201	1		4	0	100	0
+Power at DOT, manual value	MODBUS_HOLDING_REGISTER	4200	1		4	0	1	0
+Blocking actions (ERS 3)	MODBUS_HOLDING_REGISTER	4100	1		4	0	2	2
+Blocking actions (ERS 4)	MODBUS_HOLDING_REGISTER	4101	1		4	0	2	2
+id:7048	MODBUS_HOLDING_REGISTER	3987	1		4	0	1	0
+id:7138	MODBUS_HOLDING_REGISTER	4009	1	%	4	0	100	70
+id:7139	MODBUS_HOLDING_REGISTER	4010	1		4	0	1	0
+id:7140	MODBUS_HOLDING_REGISTER	4011	1		4	0	1	0
+id:7141	MODBUS_HOLDING_REGISTER	4012	1	%	4	0	100	70
+id:7142	MODBUS_HOLDING_REGISTER	4013	1		4	0	1	0
+id:7143	MODBUS_HOLDING_REGISTER	4014	1		4	0	1	0
+id:7144	MODBUS_HOLDING_REGISTER	4015	1	%	4	0	100	70
+id:7145	MODBUS_HOLDING_REGISTER	4016	1		4	0	1	0
+id:7146	MODBUS_HOLDING_REGISTER	4017	1		4	0	1	0
+id:7147	MODBUS_HOLDING_REGISTER	4018	1	%	4	0	100	70
+id:7148	MODBUS_HOLDING_REGISTER	4019	1		4	0	1	0
+id:7149	MODBUS_HOLDING_REGISTER	4020	1		4	0	1	0
+id:7150	MODBUS_HOLDING_REGISTER	4021	1	%	4	0	100	70
+id:7176	MODBUS_HOLDING_REGISTER	4023	1		4	0	1	0
+Night cooling 1	MODBUS_HOLDING_REGISTER	2955	1		4	0	1	0
+Start temperature night cooling 1	MODBUS_HOLDING_REGISTER	2942	1	°C	4	20	30	25
+Night cooling diff	MODBUS_HOLDING_REGISTER	2943	1	°C	4	3	10	6
+id:8002	MODBUS_HOLDING_REGISTER	1996	1	%	4	-15	10	-3
+id:8003	MODBUS_HOLDING_REGISTER	1997	1	%	4	1	254	65
+Minimum permitted speed (EB101 GP12)	MODBUS_HOLDING_REGISTER	3243	1	%	4	1	50	1
+id:8060	MODBUS_HOLDING_REGISTER	3259	1		1	0	1	0
+id:8061	MODBUS_HOLDING_REGISTER	3260	1		1	0	1	0
+id:8062	MODBUS_HOLDING_REGISTER	3261	1		1	0	1	0
+id:8063	MODBUS_HOLDING_REGISTER	3262	1		1	0	1	0
+id:8064	MODBUS_HOLDING_REGISTER	3263	1		1	0	1	0
+id:8065	MODBUS_HOLDING_REGISTER	3264	1		1	0	1	0
+id:8066	MODBUS_HOLDING_REGISTER	3265	1		1	0	1	0
+id:8067	MODBUS_HOLDING_REGISTER	3266	1		1	0	1	0
+System 1 (RMU)	MODBUS_HOLDING_REGISTER	176	1		4	0	1	0
+System 2 (RMU)	MODBUS_HOLDING_REGISTER	177	1		4	0	1	0
+System 3 (RMU)	MODBUS_HOLDING_REGISTER	178	1		4	0	1	0
+System 4 (RMU)	MODBUS_HOLDING_REGISTER	179	1		4	0	1	0
+System 4 (RMU)	MODBUS_HOLDING_REGISTER	1998	1		4	0	1	0
+System 4 (RMU)	MODBUS_HOLDING_REGISTER	1999	1		4	0	1	0
+System 4 (RMU)	MODBUS_HOLDING_REGISTER	2000	1		4	0	1	0
+System 4 (RMU)	MODBUS_HOLDING_REGISTER	2001	1		4	0	1	0
+id:8982	MODBUS_HOLDING_REGISTER	3346	1		4	0	0	0
+The start guide has been run	MODBUS_HOLDING_REGISTER	2742	1		4	0	1	1
+Audio signal on alarm	MODBUS_HOLDING_REGISTER	3232	1		4	0	1	1
+Sound when pressing button	MODBUS_HOLDING_REGISTER	3233	1		4	0	1	1
+Heating, auto	MODBUS_HOLDING_REGISTER	3059	1		4	0	1	1
+Factor	MODBUS_HOLDING_REGISTER	3033	1		4	1	10	5
+id:10881	MODBUS_HOLDING_REGISTER	3062	1		4	0	1	0
+id:10890	MODBUS_HOLDING_REGISTER	3063	1		4	0	1	0
+Pump: Heating medium (GP6)	MODBUS_INPUT_REGISTER	2128	1		4	0	0	0
+id:12332	MODBUS_HOLDING_REGISTER	2767	1		2	-600	600	-32768
+id:12333	MODBUS_HOLDING_REGISTER	2768	1		2	-600	600	-32768
+id:12334	MODBUS_HOLDING_REGISTER	2769	1		2	-600	600	-32768
+id:12335	MODBUS_HOLDING_REGISTER	2770	1		2	-600	600	-32768
+id:12336	MODBUS_HOLDING_REGISTER	2771	1		2	-600	600	-32768
+id:12337	MODBUS_HOLDING_REGISTER	2772	1		2	-600	600	-32768
+id:12338	MODBUS_HOLDING_REGISTER	2773	1		2	-600	600	-32768
+id:12339	MODBUS_HOLDING_REGISTER	2774	1		2	-600	600	-32768
+id:12340	MODBUS_HOLDING_REGISTER	2775	1		2	-600	600	-32768
+id:12341	MODBUS_HOLDING_REGISTER	2776	1		2	-600	600	-32768
+id:12342	MODBUS_HOLDING_REGISTER	2777	1		2	-600	600	-32768
+id:12343	MODBUS_HOLDING_REGISTER	2778	1		2	-600	600	-32768
+id:12344	MODBUS_HOLDING_REGISTER	2779	1		2	-600	600	-32768
+id:12345	MODBUS_HOLDING_REGISTER	2780	1		2	-600	600	-32768
+id:12346	MODBUS_HOLDING_REGISTER	2781	1		2	-600	600	-32768
+id:12347	MODBUS_HOLDING_REGISTER	2782	1		2	-600	600	-32768
+id:12348	MODBUS_HOLDING_REGISTER	2783	1		2	-600	600	-32768
+id:12349	MODBUS_HOLDING_REGISTER	2784	1		2	-600	600	-32768
+id:12350	MODBUS_HOLDING_REGISTER	2785	1		2	-600	600	-32768
+id:12351	MODBUS_HOLDING_REGISTER	2786	1		2	-600	600	-32768
+id:12352	MODBUS_HOLDING_REGISTER	2787	1		2	-600	600	-32768
+id:12353	MODBUS_HOLDING_REGISTER	2788	1		2	-600	600	-32768
+id:12354	MODBUS_HOLDING_REGISTER	2789	1		2	-600	600	-32768
+id:12355	MODBUS_HOLDING_REGISTER	2790	1		2	-600	600	-32768
+id:12356	MODBUS_HOLDING_REGISTER	2791	1		2	-600	600	-32768
+id:12357	MODBUS_HOLDING_REGISTER	2792	1		2	-600	600	-32768
+id:12358	MODBUS_HOLDING_REGISTER	2793	1		2	-600	600	-32768
+id:12359	MODBUS_HOLDING_REGISTER	2794	1		2	-600	600	-32768
+id:12360	MODBUS_HOLDING_REGISTER	2795	1		2	-600	600	-32768
+id:12361	MODBUS_HOLDING_REGISTER	2796	1		2	-600	600	-32768
+id:12362	MODBUS_HOLDING_REGISTER	2797	1		2	-600	600	-32768
+id:12363	MODBUS_HOLDING_REGISTER	2798	1		2	-600	600	-32768
+id:12364	MODBUS_HOLDING_REGISTER	2799	1		2	-600	600	-32768
+id:12365	MODBUS_HOLDING_REGISTER	2800	1		2	-600	600	-32768
+id:12366	MODBUS_HOLDING_REGISTER	2801	1		2	-600	600	-32768
+id:12367	MODBUS_HOLDING_REGISTER	2802	1		2	-600	600	-32768
+id:12368	MODBUS_HOLDING_REGISTER	2803	1		2	-600	600	-32768
+id:12369	MODBUS_HOLDING_REGISTER	2804	1		2	-600	600	-32768
+id:12370	MODBUS_HOLDING_REGISTER	2805	1		2	-600	600	-32768
+id:12371	MODBUS_HOLDING_REGISTER	2806	1		2	-600	600	-32768
+id:12372	MODBUS_HOLDING_REGISTER	2807	1		2	-600	600	-32768
+id:12373	MODBUS_HOLDING_REGISTER	2808	1		2	-600	600	-32768
+id:12374	MODBUS_HOLDING_REGISTER	2809	1		2	-600	600	-32768
+id:12375	MODBUS_HOLDING_REGISTER	2810	1		2	-600	600	-32768
+id:12376	MODBUS_HOLDING_REGISTER	2811	1		2	-600	600	-32768
+id:12377	MODBUS_HOLDING_REGISTER	2812	1		2	-600	600	-32768
+id:12378	MODBUS_HOLDING_REGISTER	2813	1		2	-600	600	-32768
+id:12379	MODBUS_HOLDING_REGISTER	2814	1		2	-600	600	-32768
+id:12380	MODBUS_HOLDING_REGISTER	2815	1		2	-600	600	-32768
+id:12381	MODBUS_HOLDING_REGISTER	2816	1		2	-600	600	-32768
+id:12382	MODBUS_HOLDING_REGISTER	2817	1		2	-600	600	-32768
+id:12383	MODBUS_HOLDING_REGISTER	2818	1		2	-600	600	-32768
+id:12384	MODBUS_HOLDING_REGISTER	2819	1		2	-600	600	-32768
+Period	MODBUS_HOLDING_REGISTER	3088	1		4	0	1	0
+Number of years	MODBUS_HOLDING_REGISTER	3089	1		4	1	5	1
+Months	MODBUS_HOLDING_REGISTER	3090	1		6	0	4095	4095
+id:12388	MODBUS_HOLDING_REGISTER	3092	1		4	0	0	0
+Show outdoor temperature	MODBUS_HOLDING_REGISTER	3096	1		4	0	0	0
+Show indoor temperature	MODBUS_HOLDING_REGISTER	3097	1		4	0	0	0
+Active days	MODBUS_HOLDING_REGISTER	3066	1		4	0	127	0
+Active days	MODBUS_HOLDING_REGISTER	3067	1		4	0	127	0
+Active days	MODBUS_HOLDING_REGISTER	3068	1		4	0	127	0
+Active days	MODBUS_HOLDING_REGISTER	3069	1		4	0	127	0
+Active days	MODBUS_HOLDING_REGISTER	3070	1		4	0	127	0
+Start time	MODBUS_HOLDING_REGISTER	3071	1		-	-	-	-
+Start time	MODBUS_HOLDING_REGISTER	3073	1		-	-	-	-
+Stop time	MODBUS_HOLDING_REGISTER	3075	1		-	-	-	-
+id:12650	MODBUS_HOLDING_REGISTER	3104	1		-	-	-	-
+id:12651	MODBUS_HOLDING_REGISTER	3144	1		-	-	-	-
+id:12652	MODBUS_HOLDING_REGISTER	3184	1		-	-	-	-
+id:12653	MODBUS_HOLDING_REGISTER	3224	1		-	-	-	-
+id:12654	MODBUS_HOLDING_REGISTER	3264	1		-	-	-	-
+id:12655	MODBUS_HOLDING_REGISTER	3304	1		-	-	-	-
+id:12656	MODBUS_HOLDING_REGISTER	3344	1		-	-	-	-
+id:12657	MODBUS_HOLDING_REGISTER	3384	1		-	-	-	-
+id:12658	MODBUS_HOLDING_REGISTER	3424	1		-	-	-	-
+id:12659	MODBUS_HOLDING_REGISTER	3464	1		-	-	-	-
+id:12660	MODBUS_HOLDING_REGISTER	3504	1		-	-	-	-
+id:12661	MODBUS_HOLDING_REGISTER	3544	1		-	-	-	-
+id:12662	MODBUS_HOLDING_REGISTER	3584	1		-	-	-	-
+id:12663	MODBUS_HOLDING_REGISTER	3624	1		-	-	-	-
+id:12664	MODBUS_HOLDING_REGISTER	3664	1		-	-	-	-
+id:12665	MODBUS_HOLDING_REGISTER	3704	1		-	-	-	-
+id:12666	MODBUS_HOLDING_REGISTER	3744	1		-	-	-	-
+id:12667	MODBUS_HOLDING_REGISTER	3784	1		-	-	-	-
+id:12668	MODBUS_HOLDING_REGISTER	3824	1		-	-	-	-
+id:12669	MODBUS_HOLDING_REGISTER	3864	1		-	-	-	-
+id:12670	MODBUS_HOLDING_REGISTER	3904	1		-	-	-	-
+id:12671	MODBUS_HOLDING_REGISTER	2978	1		4	0	3	0
+id:12672	MODBUS_HOLDING_REGISTER	2979	1		4	0	3	0
+id:12673	MODBUS_HOLDING_REGISTER	2980	1		4	0	3	0
+id:12674	MODBUS_HOLDING_REGISTER	2981	1		4	0	3	0
+id:12675	MODBUS_HOLDING_REGISTER	2982	1		4	0	3	0
+id:12676	MODBUS_HOLDING_REGISTER	2983	1		4	0	3	0
+id:12677	MODBUS_HOLDING_REGISTER	2984	1		4	0	3	0
+id:12678	MODBUS_HOLDING_REGISTER	2985	1		4	0	3	0
+id:12679	MODBUS_HOLDING_REGISTER	2986	1		4	0	15	0
+id:12680	MODBUS_HOLDING_REGISTER	2987	1		4	0	15	0
+id:12681	MODBUS_HOLDING_REGISTER	2988	1		4	0	15	0
+id:12682	MODBUS_HOLDING_REGISTER	2989	1		4	0	15	0
+id:12683	MODBUS_HOLDING_REGISTER	2990	1		4	0	15	0
+id:12684	MODBUS_HOLDING_REGISTER	2991	1		4	0	15	0
+id:12685	MODBUS_HOLDING_REGISTER	2992	1		4	0	15	0
+id:12686	MODBUS_HOLDING_REGISTER	2993	1		4	0	15	0
+id:12687	MODBUS_HOLDING_REGISTER	2994	1		4	0	15	0
+id:12688	MODBUS_HOLDING_REGISTER	2995	1		4	0	15	0
+id:12689	MODBUS_HOLDING_REGISTER	2996	1		4	0	15	0
+id:12690	MODBUS_HOLDING_REGISTER	2997	1		4	0	15	0
+id:12691	MODBUS_HOLDING_REGISTER	2998	1		4	0	3	0
+id:12692	MODBUS_HOLDING_REGISTER	3944	1		6	0	0	0
+id:12693	MODBUS_HOLDING_REGISTER	3946	1		6	0	0	0
+id:12694	MODBUS_HOLDING_REGISTER	3948	1		6	0	0	0
+id:12695	MODBUS_HOLDING_REGISTER	3950	1		6	0	0	0
+id:12696	MODBUS_HOLDING_REGISTER	3952	1		6	0	0	0
+id:12697	MODBUS_HOLDING_REGISTER	3954	1		6	0	0	0
+id:12698	MODBUS_HOLDING_REGISTER	3956	1		6	0	0	0
+id:12699	MODBUS_HOLDING_REGISTER	3958	1		6	0	0	0
+id:12700	MODBUS_HOLDING_REGISTER	3960	1		6	0	0	0
+id:12701	MODBUS_HOLDING_REGISTER	3962	1		6	0	0	0
+id:12702	MODBUS_HOLDING_REGISTER	3964	1		6	0	0	0
+id:12703	MODBUS_HOLDING_REGISTER	3966	1		6	0	0	0
+id:12704	MODBUS_HOLDING_REGISTER	3968	1		6	0	0	0
+id:12705	MODBUS_HOLDING_REGISTER	3970	1		6	0	0	0
+id:12706	MODBUS_HOLDING_REGISTER	3972	1		6	0	0	0
+id:12707	MODBUS_HOLDING_REGISTER	3974	1		6	0	0	0
+id:12708	MODBUS_HOLDING_REGISTER	3976	1		6	0	0	0
+id:12709	MODBUS_HOLDING_REGISTER	3978	1		6	0	0	0
+id:12710	MODBUS_HOLDING_REGISTER	3980	1		6	0	0	0
+id:12711	MODBUS_HOLDING_REGISTER	3982	1		6	0	0	0
+id:12712	MODBUS_HOLDING_REGISTER	3984	1		6	0	0	0
+id:12801	MODBUS_HOLDING_REGISTER	2505	10	°C	3	50	300	200
+id:12802	MODBUS_HOLDING_REGISTER	2507	10	°C	3	50	300	200
+id:12803	MODBUS_HOLDING_REGISTER	2509	10	°C	3	50	300	200
+id:12804	MODBUS_HOLDING_REGISTER	2511	10	°C	3	50	300	200
+id:12805	MODBUS_HOLDING_REGISTER	2513	10	°C	3	50	300	200
+id:12806	MODBUS_HOLDING_REGISTER	2515	10	°C	3	50	300	200
+id:12807	MODBUS_HOLDING_REGISTER	2517	10	°C	3	50	300	200
+id:12808	MODBUS_HOLDING_REGISTER	2519	10	°C	3	50	300	200
+id:12809	MODBUS_HOLDING_REGISTER	2521	10	°C	3	50	300	200
+id:12810	MODBUS_HOLDING_REGISTER	2523	10	°C	3	50	300	200
+id:12811	MODBUS_HOLDING_REGISTER	2525	10	°C	3	50	300	200
+id:12812	MODBUS_HOLDING_REGISTER	2527	10	°C	3	50	300	200
+id:12813	MODBUS_HOLDING_REGISTER	2529	10	°C	3	50	300	200
+id:12814	MODBUS_HOLDING_REGISTER	2531	10	°C	3	50	300	200
+id:12815	MODBUS_HOLDING_REGISTER	2533	10	°C	3	50	300	200
+id:12816	MODBUS_HOLDING_REGISTER	2535	10	°C	3	50	300	200
+id:12817	MODBUS_HOLDING_REGISTER	2537	10	°C	3	50	300	200
+id:12818	MODBUS_HOLDING_REGISTER	2539	10	°C	3	50	300	200
+id:12819	MODBUS_HOLDING_REGISTER	2541	10	°C	3	50	300	200
+id:12820	MODBUS_HOLDING_REGISTER	2543	10	°C	3	50	300	200
+id:12821	MODBUS_HOLDING_REGISTER	2545	10	°C	3	50	300	200
+id:12822	MODBUS_HOLDING_REGISTER	2547	10	°C	3	50	300	200
+id:12823	MODBUS_HOLDING_REGISTER	2549	10	°C	3	50	300	200
+id:12824	MODBUS_HOLDING_REGISTER	2551	10	°C	3	50	300	200
+id:12825	MODBUS_HOLDING_REGISTER	2553	10	°C	3	50	300	200
+id:12826	MODBUS_HOLDING_REGISTER	2555	10	°C	3	50	300	200
+id:12827	MODBUS_HOLDING_REGISTER	2557	10	°C	3	50	300	200
+id:12828	MODBUS_HOLDING_REGISTER	2559	10	°C	3	50	300	200
+id:12829	MODBUS_HOLDING_REGISTER	2561	10	°C	3	50	300	200
+id:12830	MODBUS_HOLDING_REGISTER	2563	10	°C	3	50	300	200
+id:12831	MODBUS_HOLDING_REGISTER	2565	10	°C	3	50	300	200
+id:12832	MODBUS_HOLDING_REGISTER	2567	10	°C	3	50	300	200
+id:12833	MODBUS_HOLDING_REGISTER	2569	10	°C	3	50	300	200
+id:12834	MODBUS_HOLDING_REGISTER	2571	10	°C	3	50	300	200
+id:12835	MODBUS_HOLDING_REGISTER	2573	10	°C	3	50	300	200
+id:12836	MODBUS_HOLDING_REGISTER	2575	10	°C	3	50	300	200
+id:12837	MODBUS_HOLDING_REGISTER	2577	10	°C	3	50	300	200
+id:12838	MODBUS_HOLDING_REGISTER	2579	10	°C	3	50	300	200
+id:12839	MODBUS_HOLDING_REGISTER	2581	10	°C	3	50	300	200
+id:12840	MODBUS_HOLDING_REGISTER	2583	10	°C	3	50	300	200
+id:12841	MODBUS_HOLDING_REGISTER	2585	10	°C	3	50	300	250
+id:12842	MODBUS_HOLDING_REGISTER	2587	10	°C	3	50	300	250
+id:12843	MODBUS_HOLDING_REGISTER	2589	10	°C	3	50	300	250
+id:12844	MODBUS_HOLDING_REGISTER	2591	10	°C	3	50	300	250
+id:12845	MODBUS_HOLDING_REGISTER	2593	10	°C	3	50	300	250
+id:12846	MODBUS_HOLDING_REGISTER	2595	10	°C	3	50	300	250
+id:12847	MODBUS_HOLDING_REGISTER	2597	10	°C	3	50	300	250
+id:12848	MODBUS_HOLDING_REGISTER	2599	10	°C	3	50	300	250
+id:12849	MODBUS_HOLDING_REGISTER	2601	10	°C	3	50	300	250
+id:12850	MODBUS_HOLDING_REGISTER	2603	10	°C	3	50	300	250
+id:12851	MODBUS_HOLDING_REGISTER	2605	10	°C	3	50	300	250
+id:12852	MODBUS_HOLDING_REGISTER	2607	10	°C	3	50	300	250
+id:12853	MODBUS_HOLDING_REGISTER	2609	10	°C	3	50	300	250
+id:12854	MODBUS_HOLDING_REGISTER	2611	10	°C	3	50	300	250
+id:12855	MODBUS_HOLDING_REGISTER	2613	10	°C	3	50	300	250
+id:12856	MODBUS_HOLDING_REGISTER	2615	10	°C	3	50	300	250
+id:12857	MODBUS_HOLDING_REGISTER	2617	10	°C	3	50	300	250
+id:12858	MODBUS_HOLDING_REGISTER	2619	10	°C	3	50	300	250
+id:12859	MODBUS_HOLDING_REGISTER	2621	10	°C	3	50	300	250
+id:12860	MODBUS_HOLDING_REGISTER	2623	10	°C	3	50	300	250
+id:12861	MODBUS_HOLDING_REGISTER	2625	10	°C	3	50	300	250
+id:12862	MODBUS_HOLDING_REGISTER	2627	10	°C	3	50	300	250
+id:12863	MODBUS_HOLDING_REGISTER	2629	10	°C	3	50	300	250
+id:12864	MODBUS_HOLDING_REGISTER	2631	10	°C	3	50	300	250
+id:12865	MODBUS_HOLDING_REGISTER	2633	10	°C	3	50	300	250
+id:12866	MODBUS_HOLDING_REGISTER	2635	10	°C	3	50	300	250
+id:12867	MODBUS_HOLDING_REGISTER	2637	10	°C	3	50	300	250
+id:12868	MODBUS_HOLDING_REGISTER	2639	10	°C	3	50	300	250
+id:12869	MODBUS_HOLDING_REGISTER	2641	10	°C	3	50	300	250
+id:12870	MODBUS_HOLDING_REGISTER	2643	10	°C	3	50	300	250
+id:12871	MODBUS_HOLDING_REGISTER	2645	10	°C	3	50	300	250
+id:12872	MODBUS_HOLDING_REGISTER	2647	10	°C	3	50	300	250
+id:12873	MODBUS_HOLDING_REGISTER	2649	10	°C	3	50	300	250
+id:12874	MODBUS_HOLDING_REGISTER	2651	10	°C	3	50	300	250
+id:12875	MODBUS_HOLDING_REGISTER	2653	10	°C	3	50	300	250
+id:12876	MODBUS_HOLDING_REGISTER	2655	10	°C	3	50	300	250
+id:12877	MODBUS_HOLDING_REGISTER	2657	10	°C	3	50	300	250
+id:12878	MODBUS_HOLDING_REGISTER	2659	10	°C	3	50	300	250
+id:12879	MODBUS_HOLDING_REGISTER	2661	10	°C	3	50	300	250
+id:12880	MODBUS_HOLDING_REGISTER	2663	10	°C	3	50	300	250
+id:13796	MODBUS_INPUT_REGISTER	2243	1		4	0	0	0
+id:13797	MODBUS_INPUT_REGISTER	2244	1		4	0	0	0
+id:13798	MODBUS_INPUT_REGISTER	2245	1		4	0	0	0
+id:13799	MODBUS_INPUT_REGISTER	2246	1		4	0	0	0
+id:13800	MODBUS_INPUT_REGISTER	2247	1		4	0	0	0
+id:13801	MODBUS_INPUT_REGISTER	2248	1		4	0	0	0
+id:13802	MODBUS_INPUT_REGISTER	2249	1		4	0	0	0
+id:13803	MODBUS_INPUT_REGISTER	2250	1		4	0	0	0
+Offset cooling (EME20)	MODBUS_HOLDING_REGISTER	2667	1		1	-10	0	-1
+Offset heating (EME20)	MODBUS_HOLDING_REGISTER	2668	1		4	0	10	1
+Offset pool (EME20)	MODBUS_HOLDING_REGISTER	2669	1	°C	4	0	10	10
+Cooling (EME20)	MODBUS_HOLDING_REGISTER	2666	1		4	0	1	0
+AUX (EME20)	MODBUS_HOLDING_REGISTER	2675	1		4	0	1	0
+id:14052	MODBUS_HOLDING_REGISTER	2670	1	kW	6	1	999	1
+id:14061	MODBUS_HOLDING_REGISTER	2672	1		4	0	1	0
+Temperature, Overload, pool	MODBUS_HOLDING_REGISTER	0	1	°C	4	1	50	1
+EME20 API	MODBUS_HOLDING_REGISTER	2107	1		4	0	1	0
+EME20 API Include own consumption	MODBUS_HOLDING_REGISTER	2108	1		4	0	1	0
+EME20 API Available power	MODBUS_HOLDING_REGISTER	2109	1		5	0	65535	0
+External adjustment input, main unit (ECS1)	MODBUS_HOLDING_REGISTER	2111	1		4	0	1	0
+External adjustment input (ECS2)	MODBUS_HOLDING_REGISTER	2112	1		4	0	1	0
+External adjustment input (ECS3)	MODBUS_HOLDING_REGISTER	2113	1		4	0	1	0
+External adjustment input (ECS4)	MODBUS_HOLDING_REGISTER	2114	1		4	0	1	0
+External adjustment input (ECS5)	MODBUS_HOLDING_REGISTER	2115	1		4	0	1	0
+External adjustment input (ECS6)	MODBUS_HOLDING_REGISTER	2116	1		4	0	1	0
+External adjustment input (ECS7)	MODBUS_HOLDING_REGISTER	2117	1		4	0	1	0
+External adjustment input (ECS8)	MODBUS_HOLDING_REGISTER	2118	1		4	0	1	0
+Zone 1 affected by ECS1	MODBUS_HOLDING_REGISTER	2119	1		4	0	1	0
+Zone 2 affected by ECS1	MODBUS_HOLDING_REGISTER	2120	1		4	0	1	0
+Zone 3 affected by ECS1	MODBUS_HOLDING_REGISTER	2121	1		4	0	1	0
+Zone 4 affected by ECS1	MODBUS_HOLDING_REGISTER	2122	1		4	0	1	0
+Zone 5 affected by ECS1	MODBUS_HOLDING_REGISTER	2123	1		4	0	1	0
+Zone 6 affected by ECS1	MODBUS_HOLDING_REGISTER	2124	1		4	0	1	0
+Zone 7 affected by ECS1	MODBUS_HOLDING_REGISTER	2125	1		4	0	1	0
+Zone 8 affected by ECS1	MODBUS_HOLDING_REGISTER	2126	1		4	0	1	0
+Zone 9 affected by ECS1	MODBUS_HOLDING_REGISTER	2127	1		4	0	1	0
+Zone 10 affected by ECS1	MODBUS_HOLDING_REGISTER	2128	1		4	0	1	0
+Zone 11 affected by ECS1	MODBUS_HOLDING_REGISTER	2129	1		4	0	1	0
+Zone 12 affected by ECS1	MODBUS_HOLDING_REGISTER	2130	1		4	0	1	0
+Zone 13 affected by ECS1	MODBUS_HOLDING_REGISTER	2131	1		4	0	1	0
+Zone 14 affected by ECS1	MODBUS_HOLDING_REGISTER	2132	1		4	0	1	0
+Zone 15 affected by ECS1	MODBUS_HOLDING_REGISTER	2133	1		4	0	1	0
+Zone 16 affected by ECS1	MODBUS_HOLDING_REGISTER	2134	1		4	0	1	0
+Zone 17 affected by ECS1	MODBUS_HOLDING_REGISTER	2135	1		4	0	1	0
+Zone 18 affected by ECS1	MODBUS_HOLDING_REGISTER	2136	1		4	0	1	0
+Zone 19 affected by ECS1	MODBUS_HOLDING_REGISTER	2137	1		4	0	1	0
+Zone 20 affected by ECS1	MODBUS_HOLDING_REGISTER	2138	1		4	0	1	0
+Zone 21 affected by ECS1	MODBUS_HOLDING_REGISTER	2139	1		4	0	1	0
+Zone 22 affected by ECS1	MODBUS_HOLDING_REGISTER	2140	1		4	0	1	0
+Zone 23 affected by ECS1	MODBUS_HOLDING_REGISTER	2141	1		4	0	1	0
+Zone 24 affected by ECS1	MODBUS_HOLDING_REGISTER	2142	1		4	0	1	0
+Zone 25 affected by ECS1	MODBUS_HOLDING_REGISTER	2143	1		4	0	1	0
+Zone 26 affected by ECS1	MODBUS_HOLDING_REGISTER	2144	1		4	0	1	0
+Zone 27 affected by ECS1	MODBUS_HOLDING_REGISTER	2145	1		4	0	1	0
+Zone 28 affected by ECS1	MODBUS_HOLDING_REGISTER	2146	1		4	0	1	0
+Zone 29 affected by ECS1	MODBUS_HOLDING_REGISTER	2147	1		4	0	1	0
+Zone 30 affected by ECS1	MODBUS_HOLDING_REGISTER	2148	1		4	0	1	0
+Zone 31 affected by ECS1	MODBUS_HOLDING_REGISTER	2149	1		4	0	1	0
+Zone 32 affected by ECS1	MODBUS_HOLDING_REGISTER	2150	1		4	0	1	0
+Zone 33 affected by ECS1	MODBUS_HOLDING_REGISTER	2151	1		4	0	1	0
+Zone 34 affected by ECS1	MODBUS_HOLDING_REGISTER	2152	1		4	0	1	0
+Zone 35 affected by ECS1	MODBUS_HOLDING_REGISTER	2153	1		4	0	1	0
+Zone 36 affected by ECS1	MODBUS_HOLDING_REGISTER	2154	1		4	0	1	0
+Zone 37 affected by ECS1	MODBUS_HOLDING_REGISTER	2155	1		4	0	1	0
+Zone 38 affected by ECS1	MODBUS_HOLDING_REGISTER	2156	1		4	0	1	0
+Zone 39 affected by ECS1	MODBUS_HOLDING_REGISTER	2157	1		4	0	1	0
+Zone 40 affected by ECS1	MODBUS_HOLDING_REGISTER	2158	1		4	0	1	0
+Input on ECS1 affects ECS1	MODBUS_HOLDING_REGISTER	2439	1		4	0	1	0
+Input on ECS1 affects ECS2	MODBUS_HOLDING_REGISTER	2440	1		4	0	1	0
+Input on ECS1 affects ECS3	MODBUS_HOLDING_REGISTER	2441	1		4	0	1	0
+Input on ECS1 affects ECS4	MODBUS_HOLDING_REGISTER	2442	1		4	0	1	0
+Input on ECS1 affects ECS5	MODBUS_HOLDING_REGISTER	2443	1		4	0	1	0
+Input on ECS1 affects ECS6	MODBUS_HOLDING_REGISTER	2444	1		4	0	1	0
+Input on ECS1 affects ECS7	MODBUS_HOLDING_REGISTER	2445	1		4	0	1	0
+Input on ECS1 affects ECS8	MODBUS_HOLDING_REGISTER	2446	1		4	0	1	0
+External setting for adjustment migrated	MODBUS_HOLDING_REGISTER	2503	1		4	0	1	0
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2676	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2677	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2678	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2679	1		4	1	24	3
+id:21077	MODBUS_HOLDING_REGISTER	3020	1		4	0	0	0
+id:21078	MODBUS_HOLDING_REGISTER	3021	1		4	0	0	0
+id:21079	MODBUS_HOLDING_REGISTER	3022	1		4	0	0	0
+id:21080	MODBUS_HOLDING_REGISTER	3023	1		4	0	0	0
+id:21081	MODBUS_HOLDING_REGISTER	3024	1		4	0	0	0
+id:21082	MODBUS_HOLDING_REGISTER	3025	1		4	0	0	0
+id:21083	MODBUS_HOLDING_REGISTER	3026	1		4	0	0	0
+id:21084	MODBUS_HOLDING_REGISTER	3027	1		4	0	0	0
+Return time fan 4	MODBUS_HOLDING_REGISTER	2700	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2701	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2702	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2703	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2704	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2705	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2706	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2707	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2708	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2709	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2710	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2711	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2712	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2713	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2714	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2715	1	h	4	1	24	4
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2728	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2729	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2730	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2731	1		4	1	24	3
+AUX from Modbus	MODBUS_HOLDING_REGISTER	2740	1		4	0	59	0
+AUX from Modbus	MODBUS_HOLDING_REGISTER	2741	1		2	0	0	0
+ERS 2	MODBUS_HOLDING_REGISTER	2820	1		4	0	1	0
+ERS 3	MODBUS_HOLDING_REGISTER	2821	1		4	0	1	0
+ERS 4	MODBUS_HOLDING_REGISTER	2822	1		4	0	1	0
+ERS 4	MODBUS_HOLDING_REGISTER	2823	1		4	0	1	0
+ERS 4	MODBUS_HOLDING_REGISTER	2824	1		4	0	1	1
+ERS 4	MODBUS_HOLDING_REGISTER	2825	1		4	0	1	1
+ERS 4	MODBUS_HOLDING_REGISTER	2826	1		4	0	1	1
+ERS 4	MODBUS_HOLDING_REGISTER	2827	1		4	0	1	1
+Min. vent temp. (ERS 4)	MODBUS_HOLDING_REGISTER	2857	1	°C	4	0	10	3
+Min. vent temp. (ERS 4)	MODBUS_HOLDING_REGISTER	2858	1	°C	4	0	10	3
+Min. vent temp. (ERS 4)	MODBUS_HOLDING_REGISTER	2859	1	°C	4	0	10	3
+Min. vent temp. (ERS 4)	MODBUS_HOLDING_REGISTER	2860	1	°C	4	0	10	3
+Blocking actions (ERS 4)	MODBUS_HOLDING_REGISTER	2828	1		4	0	2	2
+Blocking actions (ERS 4)	MODBUS_HOLDING_REGISTER	2829	1		4	0	2	2
+Blocking actions (ERS 4)	MODBUS_HOLDING_REGISTER	2830	1		4	0	2	2
+Blocking actions (ERS 4)	MODBUS_HOLDING_REGISTER	2831	1		4	0	2	2
+id:23145	MODBUS_HOLDING_REGISTER	2921	1		4	0	1	0
+id:23146	MODBUS_HOLDING_REGISTER	2922	1		4	0	1	0
+id:23147	MODBUS_HOLDING_REGISTER	2923	1		4	0	1	0
+id:23148	MODBUS_HOLDING_REGISTER	2924	1		4	0	1	0
+id:23149	MODBUS_HOLDING_REGISTER	2836	10	°C	2	-200	410	190
+id:23150	MODBUS_HOLDING_REGISTER	2837	10	°C	2	-200	410	190
+id:23151	MODBUS_HOLDING_REGISTER	2838	10	°C	2	-200	410	190
+id:23152	MODBUS_HOLDING_REGISTER	2839	10	°C	2	-200	410	190
+id:23153	MODBUS_HOLDING_REGISTER	2832	10	°C	2	30	100	30
+id:23154	MODBUS_HOLDING_REGISTER	2833	10	°C	2	30	100	30
+id:23155	MODBUS_HOLDING_REGISTER	2834	10	°C	2	30	100	30
+id:23156	MODBUS_HOLDING_REGISTER	2835	10	°C	2	30	100	30
+Fan mode 5	MODBUS_INPUT_REGISTER	2168	1	%	4	0	0	0
+Fan mode 6	MODBUS_INPUT_REGISTER	2169	1	%	4	0	0	0
+Fan mode 7	MODBUS_INPUT_REGISTER	2170	1	%	4	0	0	0
+Fan mode 8	MODBUS_INPUT_REGISTER	2171	1	%	4	0	0	0
+Disable emergency restart GP1	MODBUS_HOLDING_REGISTER	4204	1		4	0	1	0
+Disable emergency restart GP1	MODBUS_HOLDING_REGISTER	5025	1		4	0	1	0
+id:24483	MODBUS_HOLDING_REGISTER	5008	1		4	0	1	0
+id:24484	MODBUS_HOLDING_REGISTER	5009	10	°C	2	50	800	450
+id:24485	MODBUS_HOLDING_REGISTER	5010	10	°C	2	50	800	450
+id:24486	MODBUS_HOLDING_REGISTER	5011	10	°C	2	50	800	450
+id:24487	MODBUS_HOLDING_REGISTER	5012	10	°C	2	50	800	450
+id:24488	MODBUS_HOLDING_REGISTER	5013	10	°C	2	50	800	450
+id:24489	MODBUS_HOLDING_REGISTER	5014	10	°C	2	50	800	450
+id:24490	MODBUS_HOLDING_REGISTER	5015	10	°C	2	50	800	450
+id:24491	MODBUS_HOLDING_REGISTER	5016	10	°C	2	50	800	450
+id:24492	MODBUS_HOLDING_REGISTER	5017	10	°C	2	-50	300	250
+id:24493	MODBUS_HOLDING_REGISTER	5018	10	°C	2	-50	300	250
+id:24494	MODBUS_HOLDING_REGISTER	5019	10	°C	2	-50	300	250
+id:24495	MODBUS_HOLDING_REGISTER	5020	10	°C	2	-50	300	250
+id:24496	MODBUS_HOLDING_REGISTER	5021	10	°C	2	-50	300	250
+id:24497	MODBUS_HOLDING_REGISTER	5022	10	°C	2	-50	300	250
+id:24498	MODBUS_HOLDING_REGISTER	5023	10	°C	2	-50	300	250
+id:24499	MODBUS_HOLDING_REGISTER	5024	10	°C	2	-50	300	250
+id:55035	MODBUS_HOLDING_REGISTER	1555	1		4	0	40	0
+id:55036	MODBUS_HOLDING_REGISTER	1556	1		4	0	40	0
+id:55037	MODBUS_HOLDING_REGISTER	1557	1		4	0	40	0
+id:55076	MODBUS_HOLDING_REGISTER	2877	1		4	0	1	0
+id:55077	MODBUS_HOLDING_REGISTER	2878	1		4	0	1	0
+id:55078	MODBUS_HOLDING_REGISTER	2879	1		4	0	1	0
+id:55079	MODBUS_HOLDING_REGISTER	2880	1		4	0	1	0
+id:55080	MODBUS_HOLDING_REGISTER	2881	1		4	0	1	0
+id:55081	MODBUS_HOLDING_REGISTER	2882	1		4	0	1	0
+id:55082	MODBUS_HOLDING_REGISTER	2883	1		4	0	1	0
+id:55083	MODBUS_HOLDING_REGISTER	2884	1		4	0	1	0
+Immersion heater power, emergency mode	MODBUS_HOLDING_REGISTER	3028	100	kW	2	0	4500	600
+Disable emergency restart GP1	MODBUS_HOLDING_REGISTER	3986	1		4	0	1	0
+Return line (AZ2-BT69)	MODBUS_INPUT_REGISTER	2190	10	°C	2	0	0	0
+Supply line (AZ2-BT68)	MODBUS_INPUT_REGISTER	2191	10	°C	2	0	0	0
+id:55100	MODBUS_INPUT_REGISTER	2192	10	°C	2	0	0	0
+id:55101	MODBUS_INPUT_REGISTER	2193	10	°C	2	0	0	0
+id:55102	MODBUS_INPUT_REGISTER	2194	10	°C	2	0	0	0

--- a/nibe/data/s320.json
+++ b/nibe/data/s320.json
@@ -27,6 +27,20 @@
     "size": "s16",
     "name": "supply-line-ep21-bt2-30005"
   },
+  "30006": {
+    "title": "Supply line (BT2)",
+    "factor": 10,
+    "unit": "\u00b0C",
+    "size": "s16",
+    "name": "supply-line-bt2-30006"
+  },
+  "30008": {
+    "title": "Return line (BT3)",
+    "factor": 10,
+    "unit": "\u00b0C",
+    "size": "s16",
+    "name": "return-line-bt3-30008"
+  },
   "30009": {
     "title": "Hot water top (BT7)",
     "factor": 10,
@@ -48,13 +62,6 @@
     "size": "s16",
     "name": "roomsensor-1-1-30027"
   },
-  "30032": {
-    "title": "Return line (EQ1-BT65)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "return-line-eq1-bt65-30032"
-  },
   "30037": {
     "title": "Temperature limiter (EB100-FD1)",
     "factor": 1,
@@ -75,12 +82,12 @@
     "size": "s16",
     "name": "boiler-temperature-bt52-30039"
   },
-  "30040": {
-    "title": "External supply line (BT25)",
+  "30041": {
+    "title": "Flow sensor (BF1)",
     "factor": 10,
-    "unit": "\u00b0C",
+    "unit": "l/m",
     "size": "s16",
-    "name": "external-supply-line-bt25-30040"
+    "name": "flow-sensor-bf1-30041"
   },
   "30042": {
     "title": "Electrical anode (EB100-FR1)",
@@ -109,12 +116,12 @@
     "size": "u32",
     "name": "current-be1-30051"
   },
-  "30060": {
-    "title": "Pool (CL12-BT51)",
+  "30073": {
+    "title": "Additional heat (BT63)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "pool-cl12-bt51-30060"
+    "name": "additional-heat-bt63-30073"
   },
   "30076": {
     "title": "Return line (EP23-BT3)",
@@ -150,27 +157,6 @@
     "unit": "\u00b0C",
     "size": "s16",
     "name": "outgoing-hot-water-bt70-30088"
-  },
-  "30089": {
-    "title": "Return line (BT71)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "return-line-bt71-30089"
-  },
-  "30091": {
-    "title": "Collector (EQ1-BT57)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "collector-eq1-bt57-30091"
-  },
-  "30092": {
-    "title": "Heating dump (EQ1-BT75)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "heating-dump-eq1-bt75-30092"
   },
   "30095": {
     "title": "Supply line (EP47-BT2)",
@@ -422,384 +408,6 @@
     "size": "s16",
     "name": "hot-water-comfort-heater-bt83-30176"
   },
-  "30178": {
-    "title": "Compressor, total time cooling, heat pump 8 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-8-ep15-30178"
-  },
-  "30180": {
-    "title": "Compressor, total time pool, heat pump 8 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-8-ep15-30180"
-  },
-  "30182": {
-    "title": "Compressor, total time pool 2, heat pump 8 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-8-ep15-30182"
-  },
-  "30184": {
-    "title": "Compressor, total time cooling, heat pump 8 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-8-ep14-30184"
-  },
-  "30186": {
-    "title": "Compressor, total time pool, heat pump 8 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-8-ep14-30186"
-  },
-  "30188": {
-    "title": "Compressor, total time pool 2, heat pump 8 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-8-ep14-30188"
-  },
-  "30190": {
-    "title": "Compressor, total time cooling, heat pump 7 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-7-ep15-30190"
-  },
-  "30192": {
-    "title": "Compressor, total time pool, heat pump 7 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-7-ep15-30192"
-  },
-  "30194": {
-    "title": "Compressor, total time pool 2, heat pump 7 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-7-ep15-30194"
-  },
-  "30196": {
-    "title": "Compressor, total time cooling, heat pump 7 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-7-ep14-30196"
-  },
-  "30198": {
-    "title": "Compressor, total time pool, heat pump 7 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-7-ep14-30198"
-  },
-  "30200": {
-    "title": "Compressor, total time pool 2, heat pump 7 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-7-ep14-30200"
-  },
-  "30202": {
-    "title": "Compressor, total time cooling, heat pump 6 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-6-ep15-30202"
-  },
-  "30204": {
-    "title": "Compressor, total time pool, heat pump 6 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-6-ep15-30204"
-  },
-  "30206": {
-    "title": "Compressor, total time pool 2, heat pump 6 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-6-ep15-30206"
-  },
-  "30208": {
-    "title": "Compressor, total time cooling, heat pump 6 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-6-ep14-30208"
-  },
-  "30210": {
-    "title": "Compressor, total time pool, heat pump 6 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-6-ep14-30210"
-  },
-  "30212": {
-    "title": "Compressor, total time pool 2, heat pump 6 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-6-ep14-30212"
-  },
-  "30214": {
-    "title": "Compressor, total time cooling, heat pump 5 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-5-ep15-30214"
-  },
-  "30216": {
-    "title": "Compressor, total time pool, heat pump 5 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-5-ep15-30216"
-  },
-  "30218": {
-    "title": "Compressor, total time pool 2, heat pump 5 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-5-ep15-30218"
-  },
-  "30220": {
-    "title": "Compressor, total time cooling, heat pump 5 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-5-ep14-30220"
-  },
-  "30222": {
-    "title": "Compressor, total time pool, heat pump 5 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-5-ep14-30222"
-  },
-  "30224": {
-    "title": "Compressor, total time pool 2, heat pump 5 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-5-ep14-30224"
-  },
-  "30226": {
-    "title": "Compressor, total time cooling, heat pump 4 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-4-ep15-30226"
-  },
-  "30228": {
-    "title": "Compressor, total time pool, heat pump 4 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-4-ep15-30228"
-  },
-  "30230": {
-    "title": "Compressor, total time pool 2, heat pump 4 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-4-ep15-30230"
-  },
-  "30232": {
-    "title": "Compressor, total time cooling, heat pump 4 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-4-ep14-30232"
-  },
-  "30234": {
-    "title": "Compressor, total time pool, heat pump 4 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-4-ep14-30234"
-  },
-  "30236": {
-    "title": "Compressor, total time pool 2, heat pump 4 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-4-ep14-30236"
-  },
-  "30238": {
-    "title": "Compressor, total time cooling, heat pump 3 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-3-ep15-30238"
-  },
-  "30240": {
-    "title": "Compressor, total time pool, heat pump 3 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-3-ep15-30240"
-  },
-  "30242": {
-    "title": "Compressor, total time pool 2, heat pump 3 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-3-ep15-30242"
-  },
-  "30244": {
-    "title": "Compressor, total time cooling, heat pump 3 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-3-ep14-30244"
-  },
-  "30246": {
-    "title": "Compressor, total time pool, heat pump 3 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-3-ep14-30246"
-  },
-  "30248": {
-    "title": "Compressor, total time pool 2, heat pump 3 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-3-ep14-30248"
-  },
-  "30250": {
-    "title": "Compressor, total time cooling, heat pump 2 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-2-ep15-30250"
-  },
-  "30252": {
-    "title": "Compressor, total time pool, heat pump 2 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-2-ep15-30252"
-  },
-  "30254": {
-    "title": "Compressor, total time pool 2, heat pump 2 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-2-ep15-30254"
-  },
-  "30256": {
-    "title": "Compressor, total time cooling, heat pump 2 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-cooling-heat-pump-2-ep14-30256"
-  },
-  "30258": {
-    "title": "Compressor, total time pool, heat pump 2 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-heat-pump-2-ep14-30258"
-  },
-  "30260": {
-    "title": "Compressor, total time pool 2, heat pump 2 (EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-total-time-pool-2-heat-pump-2-ep14-30260"
-  },
-  "30262": {
-    "title": "Compressor, total time cooling, heat pump 1 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-cooling-heat-pump-1-ep15-30262"
-  },
-  "30264": {
-    "title": "Compressor, total time pool, heat pump 1 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-heat-pump-1-ep15-30264"
-  },
-  "30266": {
-    "title": "Compressor, total time pool 2, heat pump 1 (EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-total-time-pool-2-heat-pump-1-ep15-30266"
-  },
   "30280": {
     "title": "Compressor, total time cooling, main unit (EP14)",
     "factor": 1,
@@ -830,65 +438,6 @@
     "default": 0.0,
     "name": "compressor-total-time-pool-2-main-unit-ep14-30284"
   },
-  "30286": {
-    "title": "Total run time external HW additional heat",
-    "factor": 10,
-    "unit": "h",
-    "size": "s32",
-    "min": 0.0,
-    "max": 9999999.0,
-    "default": 0.0,
-    "name": "total-run-time-external-hw-additional-heat-30286"
-  },
-  "30295": {
-    "title": "Heat pump 8 requested compressor frequency",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "heat-pump-8-requested-compressor-frequency-30295"
-  },
-  "30296": {
-    "title": "Heat pump 7 requested compressor frequency",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "heat-pump-7-requested-compressor-frequency-30296"
-  },
-  "30297": {
-    "title": "Heat pump 6 requested compressor frequency",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "heat-pump-6-requested-compressor-frequency-30297"
-  },
-  "30298": {
-    "title": "Heat pump 5 requested compressor frequency",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "heat-pump-5-requested-compressor-frequency-30298"
-  },
-  "30299": {
-    "title": "Heat pump 4 requested compressor frequency",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "heat-pump-4-requested-compressor-frequency-30299"
-  },
-  "30300": {
-    "title": "Heat pump 3 requested compressor frequency",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "heat-pump-3-requested-compressor-frequency-30300"
-  },
-  "30301": {
-    "title": "Heat pump 2 requested compressor frequency",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "heat-pump-2-requested-compressor-frequency-30301"
-  },
   "30302": {
     "title": "Heat pump 1 requested compressor frequency",
     "factor": 1,
@@ -896,47 +445,18 @@
     "size": "u8",
     "name": "heat-pump-1-requested-compressor-frequency-30302"
   },
-  "30304": {
-    "title": "Frost protection heat exchanger heat pump 8",
+  "30303": {
+    "title": "Main unit, requested compressor freq",
     "factor": 1,
+    "unit": "Hz",
     "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-8-30304"
+    "name": "main-unit-requested-compressor-freq-30303"
   },
-  "30305": {
-    "title": "Frost protection heat exchanger heat pump 7",
+  "30311": {
+    "title": "Frost protection heat exchanger, main unit",
     "factor": 1,
     "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-7-30305"
-  },
-  "30306": {
-    "title": "Frost protection heat exchanger heat pump 6",
-    "factor": 1,
-    "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-6-30306"
-  },
-  "30307": {
-    "title": "Frost protection heat exchanger heat pump 5",
-    "factor": 1,
-    "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-5-30307"
-  },
-  "30308": {
-    "title": "Frost protection heat exchanger heat pump 4",
-    "factor": 1,
-    "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-4-30308"
-  },
-  "30309": {
-    "title": "Frost protection heat exchanger heat pump 3",
-    "factor": 1,
-    "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-3-30309"
-  },
-  "30310": {
-    "title": "Frost protection heat exchanger heat pump 2",
-    "factor": 1,
-    "size": "u8",
-    "name": "frost-protection-heat-exchanger-heat-pump-2-30310"
+    "name": "frost-protection-heat-exchanger-main-unit-30311"
   },
   "30312": {
     "title": "Status (OPT)",
@@ -981,12 +501,6 @@
     "factor": 1,
     "size": "u8",
     "name": "available-compressors-pool-1-30320"
-  },
-  "30321": {
-    "title": "Available compressors pool 2",
-    "factor": 1,
-    "size": "u8",
-    "name": "available-compressors-pool-2-30321"
   },
   "30322": {
     "title": "Available compressors cooling",
@@ -1271,76 +785,17 @@
     "size": "u16",
     "name": "version-s135-30377"
   },
-  "30386": {
-    "title": "Seconds of blank time left, charge pump 8",
-    "factor": 1,
-    "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-8-30386"
-  },
-  "30387": {
-    "title": "Seconds of blank time left, charge pump 7",
-    "factor": 1,
-    "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-7-30387"
-  },
-  "30388": {
-    "title": "Seconds of blank time left, charge pump 6",
-    "factor": 1,
-    "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-6-30388"
-  },
-  "30389": {
-    "title": "Seconds of blank time left, charge pump 5",
-    "factor": 1,
-    "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-5-30389"
-  },
-  "30390": {
-    "title": "Seconds of blank time left, charge pump 4",
-    "factor": 1,
-    "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-4-30390"
-  },
-  "30391": {
-    "title": "Seconds of blank time left, charge pump 3",
-    "factor": 1,
-    "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-3-30391"
-  },
-  "30392": {
-    "title": "Seconds of blank time left, charge pump 2",
-    "factor": 1,
-    "size": "u8",
-    "name": "seconds-of-blank-time-left-charge-pump-2-30392"
-  },
   "30393": {
     "title": "Seconds of blank time left, charge pump 1",
     "factor": 1,
     "size": "u8",
     "name": "seconds-of-blank-time-left-charge-pump-1-30393"
   },
-  "30397": {
-    "title": "Pulse energy meter (BE6)",
-    "factor": 100,
-    "unit": "kWh",
-    "size": "u32",
-    "min": 0.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "pulse-energy-meter-be6-30397"
-  },
-  "30401": {
-    "title": "Alarm number from outdoor air heat pump (EB101)",
+  "30394": {
+    "title": "Seconds of blank time left, charge pump 0",
     "factor": 1,
     "size": "u8",
-    "name": "alarm-number-from-outdoor-air-heat-pump-eb101-30401"
-  },
-  "30402": {
-    "title": "Fan speed (EB101)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "fan-speed-eb101-30402"
+    "name": "seconds-of-blank-time-left-charge-pump-0-30394"
   },
   "30403": {
     "title": "Max fan speed (EB101)",
@@ -1355,20 +810,6 @@
     "unit": "rpm",
     "size": "u16",
     "name": "min-fan-speed-eb101-30404"
-  },
-  "30405": {
-    "title": "Max compressor speed (EB101)",
-    "factor": 10,
-    "unit": "Hz",
-    "size": "u16",
-    "name": "max-compressor-speed-eb101-30405"
-  },
-  "30406": {
-    "title": "Min compressor speed (EB101)",
-    "factor": 10,
-    "unit": "Hz",
-    "size": "u16",
-    "name": "min-compressor-speed-eb101-30406"
   },
   "30407": {
     "title": "Power (EB101)",
@@ -1500,335 +941,6 @@
     "size": "u16",
     "name": "degree-of-opening-evi-eb101-30425"
   },
-  "30439": {
-    "title": "Low press (EB108 BP8 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "low-press-eb108-bp8-dew-30439"
-  },
-  "30440": {
-    "title": "Hi press (EB108 BP9 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "hi-press-eb108-bp9-dew-30440"
-  },
-  "30441": {
-    "title": "Injection (EB108-BT81)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "injection-eb108-bt81-30441"
-  },
-  "30442": {
-    "title": "Pressure sensor, injection (EB108-BP11)",
-    "factor": 10,
-    "size": "s16",
-    "name": "pressure-sensor-injection-eb108-bp11-30442"
-  },
-  "30443": {
-    "title": "EVI pressure (EB108-EP14-BP11 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pressure-eb108-ep14-bp11-dew-30443"
-  },
-  "30445": {
-    "title": "Fan status (EB108-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "fan-status-eb108-ep14-30445"
-  },
-  "30446": {
-    "title": "Fan rpm (EB108-EP14)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "fan-rpm-eb108-ep14-30446"
-  },
-  "30455": {
-    "title": "Low press (EB107 BP8 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "low-press-eb107-bp8-dew-30455"
-  },
-  "30456": {
-    "title": "Hi press (EB107 BP9 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "hi-press-eb107-bp9-dew-30456"
-  },
-  "30457": {
-    "title": "Injection (EB107-BT81)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "injection-eb107-bt81-30457"
-  },
-  "30458": {
-    "title": "Pressure sensor, injection (EB107-BP11)",
-    "factor": 10,
-    "size": "s16",
-    "name": "pressure-sensor-injection-eb107-bp11-30458"
-  },
-  "30459": {
-    "title": "EVI pressure (EB107-EP14-BP11 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pressure-eb107-ep14-bp11-dew-30459"
-  },
-  "30461": {
-    "title": "Fan status (EB107-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "fan-status-eb107-ep14-30461"
-  },
-  "30462": {
-    "title": "Fan rpm (EB107-EP14)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "fan-rpm-eb107-ep14-30462"
-  },
-  "30471": {
-    "title": "Low press (EB106 BP8 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "low-press-eb106-bp8-dew-30471"
-  },
-  "30472": {
-    "title": "Hi press (EB106 BP9 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "hi-press-eb106-bp9-dew-30472"
-  },
-  "30473": {
-    "title": "Injection (EB106-BT81)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "injection-eb106-bt81-30473"
-  },
-  "30474": {
-    "title": "Pressure sensor, injection (EB106-BP11)",
-    "factor": 10,
-    "size": "s16",
-    "name": "pressure-sensor-injection-eb106-bp11-30474"
-  },
-  "30475": {
-    "title": "EVI pressure (EB106-EP14-BP11 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pressure-eb106-ep14-bp11-dew-30475"
-  },
-  "30477": {
-    "title": "Fan status (EB106-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "fan-status-eb106-ep14-30477"
-  },
-  "30478": {
-    "title": "Fan rpm (EB106-EP14)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "fan-rpm-eb106-ep14-30478"
-  },
-  "30487": {
-    "title": "Low press (EB105 BP8 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "low-press-eb105-bp8-dew-30487"
-  },
-  "30488": {
-    "title": "Hi press (EB105 BP9 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "hi-press-eb105-bp9-dew-30488"
-  },
-  "30489": {
-    "title": "Injection (EB105-BT81)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "injection-eb105-bt81-30489"
-  },
-  "30490": {
-    "title": "Pressure sensor, injection (EB105-BP11)",
-    "factor": 10,
-    "size": "s16",
-    "name": "pressure-sensor-injection-eb105-bp11-30490"
-  },
-  "30491": {
-    "title": "EVI pressure (EB105-EP14-BP11 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pressure-eb105-ep14-bp11-dew-30491"
-  },
-  "30493": {
-    "title": "Fan status (EB105-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "fan-status-eb105-ep14-30493"
-  },
-  "30494": {
-    "title": "Fan rpm (EB105-EP14)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "fan-rpm-eb105-ep14-30494"
-  },
-  "30503": {
-    "title": "Low press (EB104 BP8 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "low-press-eb104-bp8-dew-30503"
-  },
-  "30504": {
-    "title": "Hi press (EB104 BP9 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "hi-press-eb104-bp9-dew-30504"
-  },
-  "30505": {
-    "title": "Injection (EB104-BT81)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "injection-eb104-bt81-30505"
-  },
-  "30506": {
-    "title": "Pressure sensor, injection (EB104-BP11)",
-    "factor": 10,
-    "size": "s16",
-    "name": "pressure-sensor-injection-eb104-bp11-30506"
-  },
-  "30507": {
-    "title": "EVI pressure (EB104-EP14-BP11 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pressure-eb104-ep14-bp11-dew-30507"
-  },
-  "30509": {
-    "title": "Fan status (EB104-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "fan-status-eb104-ep14-30509"
-  },
-  "30510": {
-    "title": "Fan rpm (EB104-EP14)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "fan-rpm-eb104-ep14-30510"
-  },
-  "30519": {
-    "title": "Low press (EB103 BP8 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "low-press-eb103-bp8-dew-30519"
-  },
-  "30520": {
-    "title": "Hi press (EB103 BP9 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "hi-press-eb103-bp9-dew-30520"
-  },
-  "30521": {
-    "title": "Injection (EB103-BT81)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "injection-eb103-bt81-30521"
-  },
-  "30522": {
-    "title": "Pressure sensor, injection (EB103-BP11)",
-    "factor": 10,
-    "size": "s16",
-    "name": "pressure-sensor-injection-eb103-bp11-30522"
-  },
-  "30523": {
-    "title": "EVI pressure (EB103-EP14-BP11 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pressure-eb103-ep14-bp11-dew-30523"
-  },
-  "30525": {
-    "title": "Fan status (EB103-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "fan-status-eb103-ep14-30525"
-  },
-  "30526": {
-    "title": "Fan rpm (EB103-EP14)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "fan-rpm-eb103-ep14-30526"
-  },
-  "30535": {
-    "title": "Low press (EB102 BP8 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "low-press-eb102-bp8-dew-30535"
-  },
-  "30536": {
-    "title": "Hi press (EB102 BP9 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "hi-press-eb102-bp9-dew-30536"
-  },
-  "30537": {
-    "title": "Injection (EB102-BT81)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "injection-eb102-bt81-30537"
-  },
-  "30538": {
-    "title": "Pressure sensor, injection (EB102-EP14-BP11)",
-    "factor": 10,
-    "size": "s16",
-    "name": "pressure-sensor-injection-eb102-ep14-bp11-30538"
-  },
-  "30539": {
-    "title": "EVI pressure (EB102-EP14-BP11 dew)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pressure-eb102-ep14-bp11-dew-30539"
-  },
-  "30541": {
-    "title": "Fan status (EB102-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "fan-status-eb102-ep14-30541"
-  },
-  "30542": {
-    "title": "Fan rpm (EB102-EP14)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "fan-rpm-eb102-ep14-30542"
-  },
   "30551": {
     "title": "Low press (EB101 BP8 dew)",
     "factor": 10,
@@ -1862,13 +974,6 @@
     "unit": "\u00b0C",
     "size": "s16",
     "name": "evi-pressure-eb101-ep14-bp11-dew-30555"
-  },
-  "30556": {
-    "title": "Evaporator (EB101-BT84)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evaporator-eb101-bt84-30556"
   },
   "30557": {
     "title": "Fan status (EB101-EP14)",
@@ -2200,20 +1305,6 @@
     "size": "s32",
     "name": "smart-energy-source-dm-minimum-value-30738"
   },
-  "30744": {
-    "title": "Collector in (EP12-BT57)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "collector-in-ep12-bt57-30744"
-  },
-  "30745": {
-    "title": "Collector out (EP12-BT58)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "collector-out-ep12-bt58-30745"
-  },
   "30746": {
     "title": "External guide status",
     "factor": 1,
@@ -2238,32 +1329,17 @@
     "size": "u8",
     "name": "smart-energy-source-prio-opt10-for-hot-water-30758"
   },
+  "30759": {
+    "title": "Smart energy source, Permit OPT to produce hot water",
+    "factor": 1,
+    "size": "u8",
+    "name": "smart-energy-source-permit-opt-to-produce-hot-water-30759"
+  },
   "30760": {
     "title": "Wood boiler activated",
     "factor": 1,
     "size": "u8",
     "name": "wood-boiler-activated-30760"
-  },
-  "30763": {
-    "title": "Max fan speed (EB108-F21x0)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "max-fan-speed-eb108-f21x0-30763"
-  },
-  "30764": {
-    "title": "Min fan speed (EB108)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "min-fan-speed-eb108-30764"
-  },
-  "30767": {
-    "title": "Power (EB108-F21x0)",
-    "factor": 10,
-    "unit": "kW",
-    "size": "u16",
-    "name": "power-eb108-f21x0-30767"
   },
   "30768": {
     "title": "Time to defrosting (EB108)",
@@ -2272,279 +1348,12 @@
     "size": "u16",
     "name": "time-to-defrosting-eb108-30768"
   },
-  "30769": {
-    "title": "Defrosting index (EB108)",
-    "factor": 1,
-    "size": "u16",
-    "name": "defrosting-index-eb108-30769"
-  },
-  "30770": {
-    "title": "Superheat reference EEV (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-eev-eb108-30770"
-  },
-  "30771": {
-    "title": "Superheat EEV (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-eev-eb108-30771"
-  },
-  "30772": {
-    "title": "EEV-ssh-error (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-eb108-30772"
-  },
-  "30773": {
-    "title": "Superheat temp. reference EEV (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-eev-eb108-30773"
-  },
-  "30774": {
-    "title": "Set point value EEV (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-eev-eb108-30774"
-  },
-  "30775": {
-    "title": "EEV PV (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-pv-eb108-30775"
-  },
-  "30776": {
-    "title": "EEV-te-error average open (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-eb108-30776"
-  },
-  "30777": {
-    "title": "Degree of opening EEV (EB108)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-eev-eb108-30777"
-  },
-  "30778": {
-    "title": "Superheat reference EVI (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-evi-eb108-30778"
-  },
-  "30779": {
-    "title": "Superheat EVI (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-evi-eb108-30779"
-  },
-  "30780": {
-    "title": "EEV-ssh-error (EVI)(EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-evi-eb108-30780"
-  },
-  "30781": {
-    "title": "Superheat temp. reference EVI (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-evi-eb108-30781"
-  },
-  "30782": {
-    "title": "Set point value EVI (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-evi-eb108-30782"
-  },
-  "30783": {
-    "title": "EVI PV (EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pv-eb108-30783"
-  },
-  "30784": {
-    "title": "EEV-te-error average open (EVI)(EB108)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb108-30784"
-  },
-  "30785": {
-    "title": "Degree of opening EVI (EB108)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-evi-eb108-30785"
-  },
-  "30788": {
-    "title": "Max fan speed (EB107)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "max-fan-speed-eb107-30788"
-  },
-  "30789": {
-    "title": "Min fan speed (EB107)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "min-fan-speed-eb107-30789"
-  },
-  "30792": {
-    "title": "Power (EB107-F21x0)",
-    "factor": 10,
-    "unit": "kW",
-    "size": "u16",
-    "name": "power-eb107-f21x0-30792"
-  },
   "30793": {
     "title": "Time to defrosting (EB107)",
     "factor": 1,
     "unit": "min",
     "size": "u16",
     "name": "time-to-defrosting-eb107-30793"
-  },
-  "30794": {
-    "title": "Defrosting index (EB107)",
-    "factor": 1,
-    "size": "u16",
-    "name": "defrosting-index-eb107-30794"
-  },
-  "30795": {
-    "title": "Superheat reference EEV (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-eev-eb107-30795"
-  },
-  "30796": {
-    "title": "Superheat EEV (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-eev-eb107-30796"
-  },
-  "30797": {
-    "title": "EEV-ssh-error (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-eb107-30797"
-  },
-  "30798": {
-    "title": "Superheat temp. reference EEV (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-eev-eb107-30798"
-  },
-  "30799": {
-    "title": "Set point value EEV (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-eev-eb107-30799"
-  },
-  "30800": {
-    "title": "EEV PV (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-pv-eb107-30800"
-  },
-  "30801": {
-    "title": "EEV-te-error average open (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-eb107-30801"
-  },
-  "30802": {
-    "title": "Degree of opening EEV (EB107)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-eev-eb107-30802"
-  },
-  "30803": {
-    "title": "Superheat reference EVI (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-evi-eb107-30803"
-  },
-  "30804": {
-    "title": "Superheat EVI (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-evi-eb107-30804"
-  },
-  "30805": {
-    "title": "EEV-ssh-error (EVI)(EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-evi-eb107-30805"
-  },
-  "30806": {
-    "title": "Superheat temp. reference EVI (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-evi-eb107-30806"
-  },
-  "30807": {
-    "title": "Set point value EVI (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-evi-eb107-30807"
-  },
-  "30808": {
-    "title": "EVI PV (EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pv-eb107-30808"
-  },
-  "30809": {
-    "title": "EEV-te-error average open (EVI)(EB107)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb107-30809"
-  },
-  "30810": {
-    "title": "Degree of opening EVI (EB107)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-evi-eb107-30810"
-  },
-  "30813": {
-    "title": "Max fan speed (EB106)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "max-fan-speed-eb106-30813"
-  },
-  "30817": {
-    "title": "power (EB106)",
-    "factor": 10,
-    "unit": "kW",
-    "size": "u16",
-    "name": "power-eb106-30817"
   },
   "30818": {
     "title": "Time to defrosting (EB106)",
@@ -2553,286 +1362,12 @@
     "size": "u16",
     "name": "time-to-defrosting-eb106-30818"
   },
-  "30819": {
-    "title": "Defrosting index (EB106)",
-    "factor": 1,
-    "size": "u16",
-    "name": "defrosting-index-eb106-30819"
-  },
-  "30820": {
-    "title": "Superheat reference EEV (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-eev-eb106-30820"
-  },
-  "30821": {
-    "title": "Superheat EEV (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-eev-eb106-30821"
-  },
-  "30822": {
-    "title": "EEV-ssh-error (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-eb106-30822"
-  },
-  "30823": {
-    "title": "Superheat temp. reference EEV (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-eev-eb106-30823"
-  },
-  "30824": {
-    "title": "Set point value EEV (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-eev-eb106-30824"
-  },
-  "30825": {
-    "title": "EEV PV (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-pv-eb106-30825"
-  },
-  "30826": {
-    "title": "EEV-te-error average open (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-eb106-30826"
-  },
-  "30827": {
-    "title": "Degree of opening EEV (EB106)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-eev-eb106-30827"
-  },
-  "30828": {
-    "title": "Superheat reference EVI (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-evi-eb106-30828"
-  },
-  "30829": {
-    "title": "Superheat EVI (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-evi-eb106-30829"
-  },
-  "30830": {
-    "title": "EEV-ssh-error (EVI)(EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-evi-eb106-30830"
-  },
-  "30831": {
-    "title": "Superheat temp. reference EVI (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-evi-eb106-30831"
-  },
-  "30832": {
-    "title": "Set point value EVI (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-evi-eb106-30832"
-  },
-  "30833": {
-    "title": "EVI PV (EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pv-eb106-30833"
-  },
-  "30834": {
-    "title": "EEV-te-error average open (EVI)(EB106)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb106-30834"
-  },
-  "30835": {
-    "title": "Degree of opening EVI (EB106)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-evi-eb106-30835"
-  },
-  "30838": {
-    "title": "Max fan speed (EB105)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "max-fan-speed-eb105-30838"
-  },
-  "30839": {
-    "title": "Min fan speed (EB105)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "min-fan-speed-eb105-30839"
-  },
-  "30842": {
-    "title": "Power (EB105)",
-    "factor": 10,
-    "unit": "kW",
-    "size": "u16",
-    "name": "power-eb105-30842"
-  },
   "30843": {
     "title": "Time to defrosting (EB105)",
     "factor": 1,
     "unit": "min",
     "size": "u16",
     "name": "time-to-defrosting-eb105-30843"
-  },
-  "30844": {
-    "title": "Defrosting index (EB105)",
-    "factor": 1,
-    "size": "u16",
-    "name": "defrosting-index-eb105-30844"
-  },
-  "30845": {
-    "title": "Superheat reference EEV (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-eev-eb105-30845"
-  },
-  "30846": {
-    "title": "Superheat EEV (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-eev-eb105-30846"
-  },
-  "30847": {
-    "title": "EEV-ssh-error (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-eb105-30847"
-  },
-  "30848": {
-    "title": "Superheat temp. reference EEV (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-eev-eb105-30848"
-  },
-  "30849": {
-    "title": "Set point value EEV (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-eev-eb105-30849"
-  },
-  "30850": {
-    "title": "EEV PV (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-pv-eb105-30850"
-  },
-  "30851": {
-    "title": "EEV-te-error average open (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-eb105-30851"
-  },
-  "30852": {
-    "title": "Degree of opening EEV (EB105)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-eev-eb105-30852"
-  },
-  "30853": {
-    "title": "Superheat reference EVI (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-evi-eb105-30853"
-  },
-  "30854": {
-    "title": "Superheat EVI (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-evi-eb105-30854"
-  },
-  "30855": {
-    "title": "EEV-ssh-error (EVI)(EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-evi-eb105-30855"
-  },
-  "30856": {
-    "title": "Superheat temp. reference EVI (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-evi-eb105-30856"
-  },
-  "30857": {
-    "title": "Set point value EVI (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-evi-eb105-30857"
-  },
-  "30858": {
-    "title": "EVI PV (EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pv-eb105-30858"
-  },
-  "30859": {
-    "title": "EEV-te-error average open (EVI)(EB105)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb105-30859"
-  },
-  "30860": {
-    "title": "Degree of opening EVI (EB105)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-evi-eb105-30860"
-  },
-  "30863": {
-    "title": "Max fan speed (EB104)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "max-fan-speed-eb104-30863"
-  },
-  "30864": {
-    "title": "Min fan speed (EB104)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "min-fan-speed-eb104-30864"
-  },
-  "30867": {
-    "title": "Power (EB104)",
-    "factor": 10,
-    "unit": "kW",
-    "size": "u16",
-    "name": "power-eb104-30867"
   },
   "30868": {
     "title": "Time to defrosting (EB104)",
@@ -2841,293 +1376,12 @@
     "size": "u16",
     "name": "time-to-defrosting-eb104-30868"
   },
-  "30869": {
-    "title": "Defrosting index (EB104)",
-    "factor": 1,
-    "size": "u16",
-    "name": "defrosting-index-eb104-30869"
-  },
-  "30870": {
-    "title": "Superheat reference EEV (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-eev-eb104-30870"
-  },
-  "30871": {
-    "title": "Superheat EEV (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-eev-eb104-30871"
-  },
-  "30872": {
-    "title": "EEV-ssh-error (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-eb104-30872"
-  },
-  "30873": {
-    "title": "Superheat temp. reference EEV (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-eev-eb104-30873"
-  },
-  "30874": {
-    "title": "Set point value EEV (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-eev-eb104-30874"
-  },
-  "30875": {
-    "title": "EEV PV (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-pv-eb104-30875"
-  },
-  "30876": {
-    "title": "EEV-te-error average open (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-eb104-30876"
-  },
-  "30877": {
-    "title": "Degree of opening EEV (EB104)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-eev-eb104-30877"
-  },
-  "30878": {
-    "title": "Superheat reference EVI (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-evi-eb104-30878"
-  },
-  "30879": {
-    "title": "Superheat EVI (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-evi-eb104-30879"
-  },
-  "30880": {
-    "title": "EEV-ssh-error (EVI)(EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-evi-eb104-30880"
-  },
-  "30881": {
-    "title": "Superheat temp. reference EVI (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-evi-eb104-30881"
-  },
-  "30882": {
-    "title": "Set point value EVI (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-evi-eb104-30882"
-  },
-  "30883": {
-    "title": "EVI PV (EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pv-eb104-30883"
-  },
-  "30884": {
-    "title": "EEV-te-error average open (EVI)(EB104)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb104-30884"
-  },
-  "30885": {
-    "title": "Degree of opening EVI (EB104)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-evi-eb104-30885"
-  },
-  "30888": {
-    "title": "Max fan speed (EB103)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "max-fan-speed-eb103-30888"
-  },
-  "30889": {
-    "title": "Min fan speed (EB103)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "min-fan-speed-eb103-30889"
-  },
-  "30892": {
-    "title": "Power (EB103)",
-    "factor": 10,
-    "unit": "kW",
-    "size": "u16",
-    "name": "power-eb103-30892"
-  },
   "30893": {
     "title": "Time to defrosting (EB103)",
     "factor": 1,
     "unit": "min",
     "size": "u16",
     "name": "time-to-defrosting-eb103-30893"
-  },
-  "30894": {
-    "title": "Defrosting index (EB103)",
-    "factor": 1,
-    "size": "u16",
-    "name": "defrosting-index-eb103-30894"
-  },
-  "30895": {
-    "title": "Superheat reference EEV (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-eev-eb103-30895"
-  },
-  "30896": {
-    "title": "Superheat EEV (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-eev-eb103-30896"
-  },
-  "30897": {
-    "title": "EEV-ssh-error (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-eb103-30897"
-  },
-  "30898": {
-    "title": "Superheat temp. reference EEV (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-eev-eb103-30898"
-  },
-  "30899": {
-    "title": "Set point value EEV (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-eev-eb103-30899"
-  },
-  "30900": {
-    "title": "EEV PV (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-pv-eb103-30900"
-  },
-  "30901": {
-    "title": "EEV-te-error average open (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-eb103-30901"
-  },
-  "30902": {
-    "title": "Degree of opening EEV (EB103)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-eev-eb103-30902"
-  },
-  "30903": {
-    "title": "Superheat reference EVI (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-reference-evi-eb103-30903"
-  },
-  "30904": {
-    "title": "Superheat EVI (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-evi-eb103-30904"
-  },
-  "30905": {
-    "title": "EEV-ssh-error (EVI)(EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-ssh-error-evi-eb103-30905"
-  },
-  "30906": {
-    "title": "Superheat temp. reference EVI (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "superheat-temp-reference-evi-eb103-30906"
-  },
-  "30907": {
-    "title": "Set point value EVI (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "set-point-value-evi-eb103-30907"
-  },
-  "30908": {
-    "title": "EVI PV (EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evi-pv-eb103-30908"
-  },
-  "30909": {
-    "title": "EEV-te-error average open (EVI)(EB103)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb103-30909"
-  },
-  "30910": {
-    "title": "Degree of opening EVI (EB103)",
-    "factor": 1,
-    "size": "u16",
-    "name": "degree-of-opening-evi-eb103-30910"
-  },
-  "30912": {
-    "title": "Fan speed (EB102)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "fan-speed-eb102-30912"
-  },
-  "30913": {
-    "title": "Max fan speed (EB102)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "max-fan-speed-eb102-30913"
-  },
-  "30914": {
-    "title": "Min fan speed (EB102)",
-    "factor": 1,
-    "unit": "rpm",
-    "size": "u16",
-    "name": "min-fan-speed-eb102-30914"
-  },
-  "30917": {
-    "title": "Power (EB102)",
-    "factor": 10,
-    "unit": "kW",
-    "size": "u16",
-    "name": "power-eb102-30917"
   },
   "30918": {
     "title": "Time to defrosting (EB102)",
@@ -3136,121 +1390,203 @@
     "size": "u16",
     "name": "time-to-defrosting-eb102-30918"
   },
-  "30919": {
-    "title": "Defrosting index (EB102)",
+  "30936": {
+    "title": "Alarm number (EB100)",
+    "factor": 1,
+    "size": "u8",
+    "name": "alarm-number-eb100-30936"
+  },
+  "30937": {
+    "title": "Fan speed (EB100)",
+    "factor": 1,
+    "unit": "rpm",
+    "size": "u16",
+    "name": "fan-speed-eb100-30937"
+  },
+  "30938": {
+    "title": "Max fan speed (EB100)",
+    "factor": 1,
+    "unit": "rpm",
+    "size": "u16",
+    "name": "max-fan-speed-eb100-30938"
+  },
+  "30939": {
+    "title": "Min fan speed (EB100)",
+    "factor": 1,
+    "unit": "rpm",
+    "size": "u16",
+    "name": "min-fan-speed-eb100-30939"
+  },
+  "30940": {
+    "title": "Max compressor speed (EB100)",
+    "factor": 10,
+    "unit": "Hz",
+    "size": "u16",
+    "name": "max-compressor-speed-eb100-30940"
+  },
+  "30941": {
+    "title": "Min compressor speed (EB100)",
+    "factor": 10,
+    "unit": "Hz",
+    "size": "u16",
+    "name": "min-compressor-speed-eb100-30941"
+  },
+  "30942": {
+    "title": "Power (EB100)",
+    "factor": 10,
+    "unit": "kW",
+    "size": "u16",
+    "name": "power-eb100-30942"
+  },
+  "30943": {
+    "title": "Time to defrosting (EB100)",
+    "factor": 1,
+    "unit": "min",
+    "size": "u16",
+    "name": "time-to-defrosting-eb100-30943"
+  },
+  "30944": {
+    "title": "Defrosting index (EB100)",
     "factor": 1,
     "size": "u16",
-    "name": "defrosting-index-eb102-30919"
+    "name": "defrosting-index-eb100-30944"
   },
-  "30920": {
-    "title": "Superheat reference EEV (EB102)",
+  "30945": {
+    "title": "Superheat reference (EEV)(EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-eev-eb102-30920"
+    "name": "superheat-reference-eev-eb100-30945"
   },
-  "30921": {
-    "title": "Superheat EEV (EB102)",
+  "30946": {
+    "title": "Superheat EEV (EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-eev-eb102-30921"
+    "name": "superheat-eev-eb100-30946"
   },
-  "30922": {
-    "title": "EEV-ssh-error (EB102)",
+  "30947": {
+    "title": "EEV-ssh-error EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-eb102-30922"
+    "name": "eev-ssh-error-eb100-30947"
   },
-  "30923": {
-    "title": "Superheat temp. reference EEV (EB101)",
+  "30948": {
+    "title": "Superheat temp. reference (EEV)(EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-eev-eb101-30923"
+    "name": "superheat-temp-reference-eev-eb100-30948"
   },
-  "30924": {
-    "title": "Set point value EEV (EB102)",
+  "30949": {
+    "title": "Set point value EEV (EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-eev-eb102-30924"
+    "name": "set-point-value-eev-eb100-30949"
   },
-  "30925": {
-    "title": "EEV PV (EB102)",
+  "30950": {
+    "title": "EEV PV (EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-pv-eb102-30925"
+    "name": "eev-pv-eb100-30950"
   },
-  "30926": {
-    "title": "EEV-te-error average open (EB102)",
+  "30951": {
+    "title": "EEV-te-error average open (EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-eb102-30926"
+    "name": "eev-te-error-average-open-eb100-30951"
   },
-  "30927": {
-    "title": "Degree of opening EEV (EB102)",
+  "30952": {
+    "title": "Opening degree EEV (EB100)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-eev-eb102-30927"
+    "name": "opening-degree-eev-eb100-30952"
   },
-  "30928": {
-    "title": "Superheat reference EVI (EB102)",
+  "30953": {
+    "title": "Superheat reference EVI (EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-reference-evi-eb102-30928"
+    "name": "superheat-reference-evi-eb100-30953"
   },
-  "30929": {
-    "title": "Superheat EVI (EB102)",
+  "30954": {
+    "title": "Superheat EVI (EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-evi-eb102-30929"
+    "name": "superheat-evi-eb100-30954"
   },
-  "30930": {
-    "title": "EEV-ssh-error (EVI)(EB102)",
+  "30955": {
+    "title": "EEV-ssh-error (EVI)(EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-ssh-error-evi-eb102-30930"
+    "name": "eev-ssh-error-evi-eb100-30955"
   },
-  "30931": {
-    "title": "Superheat temp. reference EVI (EB102)",
+  "30956": {
+    "title": "Superheat temp. reference (EVI)(EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "superheat-temp-reference-evi-eb102-30931"
+    "name": "superheat-temp-reference-evi-eb100-30956"
   },
-  "30932": {
-    "title": "Set point value EVI (EB102)",
+  "30957": {
+    "title": "Set point value EVI (EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "set-point-value-evi-eb102-30932"
+    "name": "set-point-value-evi-eb100-30957"
   },
-  "30933": {
-    "title": "EVI PV (EB102)",
+  "30958": {
+    "title": "EVI PV (EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "evi-pv-eb102-30933"
+    "name": "evi-pv-eb100-30958"
   },
-  "30934": {
-    "title": "EEV-te-error average open (EVI)(EB102)",
+  "30959": {
+    "title": "EEV-te-error average open (EVI)(EB100)",
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "name": "eev-te-error-average-open-evi-eb102-30934"
+    "name": "eev-te-error-average-open-evi-eb100-30959"
   },
-  "30935": {
-    "title": "Degree of opening EVI (EB102)",
+  "30960": {
+    "title": "Opening degree EVI EB100)",
     "factor": 1,
     "size": "u16",
-    "name": "degree-of-opening-evi-eb102-30935"
+    "name": "opening-degree-evi-eb100-30960"
+  },
+  "30961": {
+    "title": "Wind speed, weather forecast",
+    "factor": 10,
+    "size": "u16",
+    "name": "wind-speed-weather-forecast-30961"
+  },
+  "30962": {
+    "title": "Humidity, weather forecast",
+    "factor": 10,
+    "unit": "%",
+    "size": "u16",
+    "name": "humidity-weather-forecast-30962"
+  },
+  "30963": {
+    "title": "Temperature, weather forecast",
+    "factor": 10,
+    "unit": "\u00b0C",
+    "size": "s16",
+    "name": "temperature-weather-forecast-30963"
+  },
+  "30964": {
+    "title": "Temperature, weather data (forecast)",
+    "factor": 10,
+    "unit": "\u00b0C",
+    "size": "s16",
+    "name": "temperature-weather-data-forecast-30964"
   },
   "30992": {
     "title": "Smart energy source, priority select. in hot water",
@@ -3270,17 +1606,17 @@
     "size": "u8",
     "name": "outd-air-heat-pump-inverter-speed-reducing-30994"
   },
-  "31009": {
-    "title": "Has one phase (EB101)",
+  "31012": {
+    "title": "Serial index (EB100)",
     "factor": 1,
     "size": "u8",
-    "name": "has-one-phase-eb101-31009"
+    "name": "serial-index-eb100-31012"
   },
-  "31010": {
-    "title": "Serial index (EB101)",
+  "31013": {
+    "title": "Alarm incompatible (heat pump)",
     "factor": 1,
-    "size": "u8",
-    "name": "serial-index-eb101-31010"
+    "size": "u16",
+    "name": "alarm-incompatible-heat-pump-31013"
   },
   "40019": {
     "title": "Limit DM",
@@ -3327,6 +1663,13 @@
     "max": 1000000.0,
     "default": 0.0,
     "name": "total-run-time-additional-heat-31026"
+  },
+  "31028": {
+    "title": "Power internal additional heat",
+    "factor": 100,
+    "unit": "kW",
+    "size": "s16",
+    "name": "power-internal-additional-heat-31028"
   },
   "31029": {
     "title": "Priority",
@@ -3419,35 +1762,11 @@
     "size": "u8",
     "name": "external-blocking-31059"
   },
-  "31060": {
-    "title": "Blocked",
-    "factor": 1,
-    "size": "u8",
-    "name": "blocked-31060"
-  },
-  "31061": {
-    "title": "External blocking, active cooling (HPAC)",
-    "factor": 1,
-    "size": "u8",
-    "name": "external-blocking-active-cooling-hpac-31061"
-  },
-  "31062": {
-    "title": "External blocking, passive cooling (HPAC)",
-    "factor": 1,
-    "size": "u8",
-    "name": "external-blocking-passive-cooling-hpac-31062"
-  },
   "31063": {
     "title": "Step controlled add. heat blocking",
     "factor": 1,
     "size": "u8",
     "name": "step-controlled-add-heat-blocking-31063"
-  },
-  "31067": {
-    "title": "External heating medium pump (GP10) status",
-    "factor": 1,
-    "size": "u8",
-    "name": "external-heating-medium-pump-gp10-status-31067"
   },
   "31068": {
     "title": "Energy meter",
@@ -3475,18 +1794,19 @@
     "size": "u8",
     "name": "more-hot-water-status-31079"
   },
-  "31080": {
-    "title": "Relay status (HPAC)",
-    "factor": 1,
-    "size": "u8",
-    "name": "relay-status-hpac-31080"
-  },
   "40020": {
     "title": "Holiday function status",
     "factor": 1,
     "size": "s8",
     "name": "holiday-function-status-40020",
     "write": true
+  },
+  "31103": {
+    "title": "Heating medium pump speed (GP1)",
+    "factor": 1,
+    "unit": "%",
+    "size": "u8",
+    "name": "heating-medium-pump-speed-gp1-31103"
   },
   "31109": {
     "title": "Docked compressors heating",
@@ -3511,6 +1831,12 @@
     "factor": 1,
     "size": "u8",
     "name": "reversing-valve-hot-water-qn10-32197"
+  },
+  "31116": {
+    "title": "Operating mode step controlled additional heat",
+    "factor": 1,
+    "size": "u8",
+    "name": "operating-mode-step-controlled-additional-heat-31116"
   },
   "31118": {
     "title": "Relay status, base board (EB100-EP14)",
@@ -3560,155 +1886,17 @@
     "size": "u8",
     "name": "operating-mode-hw-comfort-additional-heat-31131"
   },
-  "31132": {
-    "title": "Blocked",
-    "factor": 1,
-    "size": "u8",
-    "name": "blocked-31132"
-  },
   "31133": {
     "title": "Blocked",
     "factor": 1,
     "size": "u8",
     "name": "blocked-31133"
   },
-  "31134": {
-    "title": "Pool 2 (QN19)",
-    "factor": 1,
-    "size": "u8",
-    "name": "pool-2-qn19-31134"
-  },
   "31135": {
     "title": "Pool 1 (QN19)",
     "factor": 1,
     "size": "u8",
     "name": "pool-1-qn19-31135"
-  },
-  "31136": {
-    "title": "Docked compressors pool 2",
-    "factor": 1,
-    "size": "u8",
-    "name": "docked-compressors-pool-2-31136"
-  },
-  "31452": {
-    "title": "Version (EB101)",
-    "factor": 1,
-    "size": "u16",
-    "name": "version-eb101-31452"
-  },
-  "31453": {
-    "title": "Heat pump type (EB101)",
-    "factor": 1,
-    "size": "u8",
-    "name": "heat-pump-type-eb101-31453"
-  },
-  "31454": {
-    "title": "Compressor size (EB101)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-size-eb101-31454"
-  },
-  "31476": {
-    "title": "Return line (EB101-BT3)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "return-line-eb101-bt3-31476"
-  },
-  "31479": {
-    "title": "Supply line (EB101-BT12)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "supply-line-eb101-bt12-31479"
-  },
-  "31480": {
-    "title": "Discharge (EB101-BT14)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "discharge-eb101-bt14-31480"
-  },
-  "31481": {
-    "title": "Liquid line (EB101-BT15)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "liquid-line-eb101-bt15-31481"
-  },
-  "31482": {
-    "title": "Suction gas (EB101-BT17)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "suction-gas-eb101-bt17-31482"
-  },
-  "31483": {
-    "title": "Compressor sensor (EB101-BT29)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "compressor-sensor-eb101-bt29-31483"
-  },
-  "31485": {
-    "title": "Compressor status (EB101)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-status-eb101-31485"
-  },
-  "31486": {
-    "title": "Compressor, time to start (EB101-EP14)",
-    "factor": 1,
-    "unit": "min",
-    "size": "u8",
-    "name": "compressor-time-to-start-eb101-ep14-31486"
-  },
-  "31487": {
-    "title": "Relay status (EB101-EP14)",
-    "factor": 1,
-    "size": "u16",
-    "name": "relay-status-eb101-ep14-31487"
-  },
-  "31490": {
-    "title": "Compressor, number of starts (EB101-EP14)",
-    "factor": 1,
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-number-of-starts-eb101-ep14-31490"
-  },
-  "31492": {
-    "title": "Compressor, oper. time, total (EB101-EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-oper-time-total-eb101-ep14-31492"
-  },
-  "31494": {
-    "title": "Compressor, oper. time, hot water (EB101-EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "min": -2147483648.0,
-    "max": 2147483647.0,
-    "default": 0.0,
-    "name": "compressor-oper-time-hot-water-eb101-ep14-31494"
-  },
-  "31496": {
-    "title": "Alarm number (EB101-EP14)",
-    "factor": 1,
-    "size": "u16",
-    "name": "alarm-number-eb101-ep14-31496"
-  },
-  "31497": {
-    "title": "Version (EB100)",
-    "factor": 1,
-    "size": "u16",
-    "name": "version-eb100-31497"
   },
   "31498": {
     "title": "Heat pump type (EB100)",
@@ -3721,178 +1909,6 @@
     "factor": 1,
     "size": "u8",
     "name": "compressor-size-eb100-31499"
-  },
-  "31516": {
-    "title": "Compressor, oper. time, total (EB100-EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-oper-time-total-eb100-ep15-31516"
-  },
-  "31518": {
-    "title": "Compressor, oper. time, hot water (EB100-EP15)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-oper-time-hot-water-eb100-ep15-31518"
-  },
-  "31521": {
-    "title": "Return line (EB100-BT3)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "return-line-eb100-bt3-31521"
-  },
-  "31522": {
-    "title": "Brine sensor in (EB100-BT10)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "brine-sensor-in-eb100-bt10-31522"
-  },
-  "31523": {
-    "title": "Brine sensor out (EB100-BT11)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "brine-sensor-out-eb100-bt11-31523"
-  },
-  "31524": {
-    "title": "Condenser (EB100-BT2)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "condenser-eb100-bt2-31524"
-  },
-  "31525": {
-    "title": "Discharge sensor (EB100-BT14)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "discharge-sensor-eb100-bt14-31525"
-  },
-  "31526": {
-    "title": "Liquid line sensor (EB100-BT15)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "liquid-line-sensor-eb100-bt15-31526"
-  },
-  "31527": {
-    "title": "Suction gas sensor (EB100-BT17)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "suction-gas-sensor-eb100-bt17-31527"
-  },
-  "31528": {
-    "title": "Compressor sensor (EB100-BT29)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "compressor-sensor-eb100-bt29-31528"
-  },
-  "31529": {
-    "title": "Low press (EB100-BP8)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "low-press-eb100-bp8-31529"
-  },
-  "31530": {
-    "title": "Compressor status (EB100)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-status-eb100-31530"
-  },
-  "31531": {
-    "title": "Compressor, time to start (EB100-EP14)",
-    "factor": 1,
-    "unit": "min",
-    "size": "u8",
-    "name": "compressor-time-to-start-eb100-ep14-31531"
-  },
-  "31532": {
-    "title": "Relay status (EB100-EP14)",
-    "factor": 1,
-    "size": "u16",
-    "name": "relay-status-eb100-ep14-31532"
-  },
-  "31533": {
-    "title": "Heating medium pump (EB100)",
-    "factor": 1,
-    "unit": "%",
-    "size": "u8",
-    "name": "heating-medium-pump-eb100-31533"
-  },
-  "31534": {
-    "title": "Brine pump (EB100)",
-    "factor": 1,
-    "unit": "%",
-    "size": "u8",
-    "name": "brine-pump-eb100-31534"
-  },
-  "31535": {
-    "title": "Compressor, number of starts (EB100-EP14)",
-    "factor": 1,
-    "size": "u32",
-    "name": "compressor-number-of-starts-eb100-ep14-31535"
-  },
-  "31537": {
-    "title": "Compressor, oper. time, total (EB100-EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-oper-time-total-eb100-ep14-31537"
-  },
-  "31539": {
-    "title": "Compressor, oper. time, hot water (EB100-EP14)",
-    "factor": 1,
-    "unit": "h",
-    "size": "u32",
-    "name": "compressor-oper-time-hot-water-eb100-ep14-31539"
-  },
-  "31543": {
-    "title": "Compressor, requested (EB108-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-requested-eb108-ep14-31543"
-  },
-  "31545": {
-    "title": "Compressor, requested (EB107-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-requested-eb107-ep14-31545"
-  },
-  "31547": {
-    "title": "Compressor, requested (EB106-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-requested-eb106-ep14-31547"
-  },
-  "31549": {
-    "title": "Compressor, requested (EB105-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-requested-eb105-ep14-31549"
-  },
-  "31551": {
-    "title": "Compressor, requested (EB104-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-requested-eb104-ep14-31551"
-  },
-  "31553": {
-    "title": "Compressor, requested (EB103-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-requested-eb103-ep14-31553"
-  },
-  "31555": {
-    "title": "Compressor, requested (EB102-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-requested-eb102-ep14-31555"
   },
   "31557": {
     "title": "Compressor, requested (EB101-EP14)",
@@ -3929,48 +1945,6 @@
     "name": "cooling-degree-minutes-40021",
     "write": true
   },
-  "31569": {
-    "title": "Status (ACS)",
-    "factor": 1,
-    "size": "u8",
-    "name": "status-acs-31569"
-  },
-  "31570": {
-    "title": "Status, heating dumping (ACS)",
-    "factor": 1,
-    "size": "u8",
-    "name": "status-heating-dumping-acs-31570"
-  },
-  "31571": {
-    "title": "Status, cooling dumping (ACS)",
-    "factor": 1,
-    "size": "u8",
-    "name": "status-cooling-dumping-acs-31571"
-  },
-  "31572": {
-    "title": "Used compressors hot water",
-    "factor": 1,
-    "size": "u8",
-    "name": "used-compressors-hot-water-31572"
-  },
-  "31573": {
-    "title": "Used compressors heating",
-    "factor": 1,
-    "size": "u8",
-    "name": "used-compressors-heating-31573"
-  },
-  "31574": {
-    "title": "Used compressors pool 1",
-    "factor": 1,
-    "size": "u8",
-    "name": "used-compressors-pool-1-31574"
-  },
-  "31575": {
-    "title": "Used compressors pool 2",
-    "factor": 1,
-    "size": "u8",
-    "name": "used-compressors-pool-2-31575"
-  },
   "31576": {
     "title": "Hot water, including int. add. heat",
     "factor": 10,
@@ -3980,6 +1954,16 @@
     "max": 9999999.0,
     "default": 0.0,
     "name": "hot-water-including-int-add-heat-31576"
+  },
+  "31578": {
+    "title": "Heating, including int. add. heat",
+    "factor": 10,
+    "unit": "kWh",
+    "size": "u32",
+    "min": 0.0,
+    "max": 9999999.0,
+    "default": 0.0,
+    "name": "heating-including-int-add-heat-31578"
   },
   "31584": {
     "title": "Hot water, compressor only",
@@ -4001,12 +1985,6 @@
     "default": 0.0,
     "name": "heating-compressor-only-31586"
   },
-  "31589": {
-    "title": "Used compressors cooling",
-    "factor": 1,
-    "size": "u8",
-    "name": "used-compressors-cooling-31589"
-  },
   "31590": {
     "title": "Speed (GP12)",
     "factor": 1,
@@ -4014,99 +1992,11 @@
     "size": "u8",
     "name": "speed-gp12-31590"
   },
-  "31622": {
-    "title": "Outdoor temperature (EB101-BT28)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "outdoor-temperature-eb101-bt28-31622"
-  },
-  "31623": {
-    "title": "Evaporator (EB101-BT16)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evaporator-eb101-bt16-31623"
-  },
-  "31624": {
-    "title": "(EB100-EP15-BT28)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eb100-ep15-bt28-31624"
-  },
-  "31625": {
-    "title": "(EB100-EP15-BT16)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eb100-ep15-bt16-31625"
-  },
-  "31626": {
-    "title": "(EB100-EP14-BT28)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eb100-ep14-bt28-31626"
-  },
-  "31627": {
-    "title": "(EB100-EP14-BT16)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "eb100-ep14-bt16-31627"
-  },
-  "31637": {
-    "title": "Heating medium pump speed (GP1)",
-    "factor": 1,
-    "unit": "%",
-    "size": "u8",
-    "name": "heating-medium-pump-speed-gp1-31637"
-  },
   "31639": {
     "title": "Frost protection heat exchanger heat pump 1",
     "factor": 1,
     "size": "u8",
     "name": "frost-protection-heat-exchanger-heat-pump-1-31639"
-  },
-  "31688": {
-    "title": "Bit register (EB100)",
-    "factor": 1,
-    "size": "u8",
-    "name": "bit-register-eb100-31688"
-  },
-  "31689": {
-    "title": "Controlling hot water sensor (EB100-BT6)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "controlling-hot-water-sensor-eb100-bt6-31689"
-  },
-  "31690": {
-    "title": "Display hot water sensor (EB100-BT7)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "display-hot-water-sensor-eb100-bt7-31690"
-  },
-  "31691": {
-    "title": "Supply temperature sensor (EB100-BT2)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "supply-temperature-sensor-eb100-bt2-31691"
-  },
-  "31692": {
-    "title": "Compressor status (EB100-EP15)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-status-eb100-ep15-31692"
-  },
-  "31693": {
-    "title": "Compressor status (EB100-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "compressor-status-eb100-ep14-31693"
   },
   "31694": {
     "title": "Operating mode extra additional heat",
@@ -4120,349 +2010,11 @@
     "size": "u8",
     "name": "docked-compressors-cooling-31695"
   },
-  "31696": {
-    "title": "BP4, unprocessed (EB108-EP15)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb108-ep15-31696"
-  },
-  "31698": {
-    "title": "Low pressure (EB108-EP15--BP8)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "low-pressure-eb108-ep15-bp8-31698"
-  },
-  "31700": {
-    "title": "Prot. status (EB108-EP15)",
-    "factor": 1,
-    "size": "u16",
-    "name": "prot-status-eb108-ep15-31700"
-  },
-  "31701": {
-    "title": "Defrosting (EB108-EP15)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb108-ep15-31701"
-  },
-  "31703": {
-    "title": "BP4, unprocessed (EB108-EP14)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb108-ep14-31703"
-  },
-  "31708": {
-    "title": "Defrosting (EB108)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb108-31708"
-  },
-  "31710": {
-    "title": "BP4, unprocessed (EB107-EP15)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb107-ep15-31710"
-  },
-  "31712": {
-    "title": "Low pressure (EB107-EP15--BP8)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "low-pressure-eb107-ep15-bp8-31712"
-  },
-  "31714": {
-    "title": "Prot. status (EB107-EP15)",
-    "factor": 1,
-    "size": "u16",
-    "name": "prot-status-eb107-ep15-31714"
-  },
-  "31715": {
-    "title": "Defrosting (EB107-EP15)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb107-ep15-31715"
-  },
-  "31716": {
-    "title": "Power (EB107-EP15)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb107-ep15-31716"
-  },
-  "31717": {
-    "title": "BP4, unprocessed (EB107-EP14)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb107-ep14-31717"
-  },
-  "31722": {
-    "title": "Defrosting (EB107)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb107-31722"
-  },
-  "31723": {
-    "title": "Power (EB107-EP14)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb107-ep14-31723"
-  },
-  "31724": {
-    "title": "BP4, unprocessed (EB106-EP15)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb106-ep15-31724"
-  },
-  "31726": {
-    "title": "Low pressure (EB106-EP15--BP8)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "low-pressure-eb106-ep15-bp8-31726"
-  },
-  "31728": {
-    "title": "Prot. status (EB106-EP15)",
-    "factor": 1,
-    "size": "u16",
-    "name": "prot-status-eb106-ep15-31728"
-  },
-  "31729": {
-    "title": "Defrosting (EB106-EP15)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb106-ep15-31729"
-  },
-  "31730": {
-    "title": "Power (EB106-EP15)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb106-ep15-31730"
-  },
-  "31731": {
-    "title": "BP4, unprocessed (EB106-EP14)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb106-ep14-31731"
-  },
-  "31736": {
-    "title": "Defrosting (EB106)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb106-31736"
-  },
-  "31737": {
-    "title": "Power (EB106-EP14)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb106-ep14-31737"
-  },
-  "31738": {
-    "title": "BP4, unprocessed (EB105-EP15)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb105-ep15-31738"
-  },
-  "31740": {
-    "title": "Low pressure (EB105-EP15--BP8)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "low-pressure-eb105-ep15-bp8-31740"
-  },
-  "31742": {
-    "title": "Prot. status (EB105-EP15)",
-    "factor": 1,
-    "size": "u16",
-    "name": "prot-status-eb105-ep15-31742"
-  },
-  "31743": {
-    "title": "Defrosting (EB105-EP15)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb105-ep15-31743"
-  },
-  "31744": {
-    "title": "Power (EB105-EP15)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb105-ep15-31744"
-  },
-  "31745": {
-    "title": "BP4, unprocessed (EB105-EP14)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb105-ep14-31745"
-  },
-  "31750": {
-    "title": "Defrosting (EB105)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb105-31750"
-  },
-  "31751": {
-    "title": "Power (EB105-EP15)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb105-ep15-31751"
-  },
-  "31752": {
-    "title": "BP4, unprocessed (EB104-EP15)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb104-ep15-31752"
-  },
-  "31754": {
-    "title": "Low pressure (EB104-EP15--BP8)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "low-pressure-eb104-ep15-bp8-31754"
-  },
-  "31756": {
-    "title": "Prot. status (EB104-EP15)",
-    "factor": 1,
-    "size": "u16",
-    "name": "prot-status-eb104-ep15-31756"
-  },
-  "31768": {
-    "title": "Low pressure (EB103-EP15--BP8)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "low-pressure-eb103-ep15-bp8-31768"
-  },
-  "31773": {
-    "title": "BP4, unprocessed (EB103-EP14)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb103-ep14-31773"
-  },
-  "31778": {
-    "title": "Defrosting (EB103)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb103-31778"
-  },
-  "31779": {
-    "title": "Power (EB103-EP14)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb103-ep14-31779"
-  },
-  "31780": {
-    "title": "BP4, unprocessed (EB102-EP15)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb102-ep15-31780"
-  },
-  "31782": {
-    "title": "Low pressure (EB102-EP15--BP8)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "low-pressure-eb102-ep15-bp8-31782"
-  },
-  "31784": {
-    "title": "Prot. status (EB102-EP15)",
-    "factor": 1,
-    "size": "u16",
-    "name": "prot-status-eb102-ep15-31784"
-  },
-  "31785": {
-    "title": "Defrosting (EB102-EP15)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb102-ep15-31785"
-  },
-  "31786": {
-    "title": "Power (EB102-EP15)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb102-ep15-31786"
-  },
-  "31787": {
-    "title": "BP4, unprocessed (EB102-EP14)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb102-ep14-31787"
-  },
-  "31792": {
-    "title": "Defrosting (EB102)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb102-31792"
-  },
-  "31793": {
-    "title": "Power (EB102-EP14)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb102-ep14-31793"
-  },
-  "31794": {
-    "title": "BP4, unprocessed (EB101-EP15)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb101-ep15-31794"
-  },
-  "31796": {
-    "title": "Low pressure (EB101-EP15-BP8)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "low-pressure-eb101-ep15-bp8-31796"
-  },
-  "31798": {
-    "title": "Prot. status (EB101-EP15)",
-    "factor": 1,
-    "size": "u16",
-    "name": "prot-status-eb101-ep15-31798"
-  },
-  "31799": {
-    "title": "Defrosting (EB101-EP15)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb101-ep15-31799"
-  },
-  "31800": {
-    "title": "Power (EB101-EP15)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb101-ep15-31800"
-  },
   "31801": {
     "title": "BP4, unprocessed (EB101-EP14)",
     "factor": 1,
     "size": "s16",
     "name": "bp4-unprocessed-eb101-ep14-31801"
-  },
-  "31803": {
-    "title": "Low pressure (EB101-BP8)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "low-pressure-eb101-bp8-31803"
-  },
-  "31804": {
-    "title": "Current compressor frequency (EB101)",
-    "factor": 10,
-    "unit": "Hz",
-    "size": "s16",
-    "name": "current-compressor-frequency-eb101-31804"
-  },
-  "31805": {
-    "title": "Protection mode (EB101)",
-    "factor": 1,
-    "size": "u16",
-    "name": "protection-mode-eb101-31805"
   },
   "31806": {
     "title": "Defrosting (EB101)",
@@ -4477,83 +2029,11 @@
     "size": "u8",
     "name": "power-eb101-ep14-31807"
   },
-  "31808": {
-    "title": "BP4, unprocessed (EB100-EP15)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb100-ep15-31808"
-  },
-  "31809": {
-    "title": "Pressure sensor, condenser (EB100-EP15-BP4)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "pressure-sensor-condenser-eb100-ep15-bp4-31809"
-  },
-  "31810": {
-    "title": "Low pressure (EB100-EP15-BP8)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "low-pressure-eb100-ep15-bp8-31810"
-  },
-  "31812": {
-    "title": "Prot. status (EB100-EP15)",
-    "factor": 1,
-    "size": "u16",
-    "name": "prot-status-eb100-ep15-31812"
-  },
-  "31813": {
-    "title": "Defrosting (EB100-EP15)",
+  "31823": {
+    "title": "Internal charge pump (GP12)",
     "factor": 1,
     "size": "u8",
-    "name": "defrosting-eb100-ep15-31813"
-  },
-  "31814": {
-    "title": "Power (EB100-EP15)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb100-ep15-31814"
-  },
-  "31815": {
-    "title": "BP4, unprocessed (EB100-EP14)",
-    "factor": 1,
-    "size": "s16",
-    "name": "bp4-unprocessed-eb100-ep14-31815"
-  },
-  "31816": {
-    "title": "Pressure sensor, condenser (EB100-EP14-BP4)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "pressure-sensor-condenser-eb100-ep14-bp4-31816"
-  },
-  "31817": {
-    "title": "Low pressure (EB100-EP14-BP8)",
-    "factor": 10,
-    "unit": "bar",
-    "size": "s16",
-    "name": "low-pressure-eb100-ep14-bp8-31817"
-  },
-  "31819": {
-    "title": "Prot. status (EB100-EP14)",
-    "factor": 1,
-    "size": "u16",
-    "name": "prot-status-eb100-ep14-31819"
-  },
-  "31820": {
-    "title": "Defrosting (EB100-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "defrosting-eb100-ep14-31820"
-  },
-  "31821": {
-    "title": "Power (EB100-EP14)",
-    "factor": 1,
-    "unit": "kW",
-    "size": "u8",
-    "name": "power-eb100-ep14-31821"
+    "name": "internal-charge-pump-gp12-31823"
   },
   "31824": {
     "title": "Climate system 4",
@@ -4579,157 +2059,11 @@
     "size": "u8",
     "name": "climate-system-1-hmp-31827"
   },
-  "31828": {
-    "title": "Pool 2 pump status",
-    "factor": 1,
-    "size": "u8",
-    "name": "pool-2-pump-status-31828"
-  },
   "31829": {
     "title": "Pool 1 pump status",
     "factor": 1,
     "size": "u8",
     "name": "pool-1-pump-status-31829"
-  },
-  "31831": {
-    "title": "ACS EQ1-QN12",
-    "factor": 1,
-    "size": "u8",
-    "name": "acs-eq1-qn12-31831"
-  },
-  "31832": {
-    "title": "ACS EQ1-GP20",
-    "factor": 1,
-    "size": "u8",
-    "name": "acs-eq1-gp20-31832"
-  },
-  "31838": {
-    "title": "Alarm number (EB100-EP15)",
-    "factor": 1,
-    "size": "u16",
-    "name": "alarm-number-eb100-ep15-31838"
-  },
-  "31839": {
-    "title": "Alarm number (EB100-EP14)",
-    "factor": 1,
-    "size": "u16",
-    "name": "alarm-number-eb100-ep14-31839"
-  },
-  "31840": {
-    "title": "Requested compressor frequency (EB108-EP15)",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "requested-compressor-frequency-eb108-ep15-31840"
-  },
-  "31842": {
-    "title": "Requested compressor frequency (EB107-EP15)",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "requested-compressor-frequency-eb107-ep15-31842"
-  },
-  "31844": {
-    "title": "Requested compressor frequency (EB106-EP15)",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "requested-compressor-frequency-eb106-ep15-31844"
-  },
-  "31846": {
-    "title": "Requested compressor frequency (EB105-EP15)",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "requested-compressor-frequency-eb105-ep15-31846"
-  },
-  "31848": {
-    "title": "Requested compressor frequency (EB104-EP15)",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "requested-compressor-frequency-eb104-ep15-31848"
-  },
-  "31850": {
-    "title": "Requested compressor frequency (EB103-EP15)",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "requested-compressor-frequency-eb103-ep15-31850"
-  },
-  "31852": {
-    "title": "Requested compressor frequency (EB102-EP15)",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "requested-compressor-frequency-eb102-ep15-31852"
-  },
-  "31854": {
-    "title": "Requested compressor frequency (EB101-EP15)",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "requested-compressor-frequency-eb101-ep15-31854"
-  },
-  "31855": {
-    "title": "Requested compressor frequency (EB101)",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "requested-compressor-frequency-eb101-31855"
-  },
-  "31856": {
-    "title": "Requested compressor frequency (EP15)",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "requested-compressor-frequency-ep15-31856"
-  },
-  "31857": {
-    "title": "Requested compressor frequency",
-    "factor": 1,
-    "unit": "Hz",
-    "size": "u8",
-    "name": "requested-compressor-frequency-31857"
-  },
-  "31903": {
-    "title": "Low press. sensor, unprocessed (EB101-EP14)",
-    "factor": 1,
-    "size": "s16",
-    "name": "low-press-sensor-unprocessed-eb101-ep14-31903"
-  },
-  "31904": {
-    "title": "Current sensor (EB101-EP14)",
-    "factor": 10,
-    "unit": "A",
-    "size": "s16",
-    "name": "current-sensor-eb101-ep14-31904"
-  },
-  "31906": {
-    "title": "Low press. sensor, unprocessed (EB100-EP15)",
-    "factor": 1,
-    "size": "s16",
-    "name": "low-press-sensor-unprocessed-eb100-ep15-31906"
-  },
-  "31907": {
-    "title": "Current sensor (EB100-EP15)",
-    "factor": 10,
-    "unit": "A",
-    "size": "s16",
-    "name": "current-sensor-eb100-ep15-31907"
-  },
-  "31909": {
-    "title": "Low press. sensor, unprocessed (EB100-EP14)",
-    "factor": 1,
-    "size": "s16",
-    "name": "low-press-sensor-unprocessed-eb100-ep14-31909"
-  },
-  "31910": {
-    "title": "Current sensor (EB100-EP14)",
-    "factor": 10,
-    "unit": "A",
-    "size": "s16",
-    "name": "current-sensor-eb100-ep14-31910"
   },
   "31912": {
     "title": "Operating mode (SG Ready)",
@@ -4778,26 +2112,6 @@
     "factor": 1,
     "size": "u8",
     "name": "operating-mode-smart-price-adaption-31919"
-  },
-  "31967": {
-    "title": "Evaporator 2 (EB101-EP14-BT16)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "evaporator-2-eb101-ep14-bt16-31967"
-  },
-  "31968": {
-    "title": "Temperature, inverter (EB101-EP14)",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s16",
-    "name": "temperature-inverter-eb101-ep14-31968"
-  },
-  "31969": {
-    "title": "fan speed (EB101-EP14)",
-    "factor": 1,
-    "size": "u8",
-    "name": "fan-speed-eb101-ep14-31969"
   },
   "31970": {
     "title": "Evaporator 2 (EB100-EP15-BT16)",
@@ -5037,7 +2351,7 @@
     "size": "s16",
     "min": 50.0,
     "max": 700.0,
-    "default": 490.0,
+    "default": 470.0,
     "name": "start-temperature-hw-high-temperature-40059",
     "write": true
   },
@@ -5047,8 +2361,8 @@
     "unit": "\u00b0C",
     "size": "s16",
     "min": 50.0,
-    "max": 600.0,
-    "default": 460.0,
+    "max": 700.0,
+    "default": 440.0,
     "name": "start-temperature-hw-normal-temperature-40060",
     "write": true
   },
@@ -5058,8 +2372,8 @@
     "unit": "\u00b0C",
     "size": "s16",
     "min": 50.0,
-    "max": 550.0,
-    "default": 420.0,
+    "max": 700.0,
+    "default": 400.0,
     "name": "start-temperature-hw-low-temperature-40061",
     "write": true
   },
@@ -5081,7 +2395,7 @@
     "size": "s16",
     "min": 50.0,
     "max": 700.0,
-    "default": 530.0,
+    "default": 510.0,
     "name": "stop-temperature-hw-high-temperature-40063",
     "write": true
   },
@@ -5091,8 +2405,8 @@
     "unit": "\u00b0C",
     "size": "s16",
     "min": 50.0,
-    "max": 650.0,
-    "default": 500.0,
+    "max": 700.0,
+    "default": 480.0,
     "name": "stop-temperature-hw-normal-temperature-40064",
     "write": true
   },
@@ -5102,8 +2416,8 @@
     "unit": "\u00b0C",
     "size": "s16",
     "min": 50.0,
-    "max": 600.0,
-    "default": 480.0,
+    "max": 700.0,
+    "default": 440.0,
     "name": "stop-temperature-hw-low-temperature-40065",
     "write": true
   },
@@ -5194,6 +2508,17 @@
     "name": "activate-force-control-45001",
     "write": true
   },
+  "40103": {
+    "title": "Max. internal additional heat",
+    "factor": 100,
+    "unit": "kW",
+    "size": "s16",
+    "min": 0.0,
+    "max": 4500.0,
+    "default": 900.0,
+    "name": "max-internal-additional-heat-40103",
+    "write": true
+  },
   "40104": {
     "title": "Fuse",
     "factor": 1,
@@ -5201,7 +2526,7 @@
     "size": "u16",
     "min": 1.0,
     "max": 400.0,
-    "default": 32.0,
+    "default": 16.0,
     "name": "fuse-40104",
     "write": true
   },
@@ -5472,16 +2797,6 @@
     "name": "dm-start-step-controlled-additional-heat-40160",
     "write": true
   },
-  "40163": {
-    "title": "Ground water pump accessory",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "ground-water-pump-accessory-40163",
-    "write": true
-  },
   "40166": {
     "title": "Waiting time cooling/heating",
     "factor": 1,
@@ -5515,17 +2830,6 @@
     "name": "cooling-start-at-over-temp-40168",
     "write": true
   },
-  "40170": {
-    "title": "Cooling shunt waiting time",
-    "factor": 1,
-    "unit": "s",
-    "size": "s16",
-    "min": 10.0,
-    "max": 300.0,
-    "default": 30.0,
-    "name": "cooling-shunt-waiting-time-40170",
-    "write": true
-  },
   "40171": {
     "title": "Cooling with room sensors",
     "factor": 10,
@@ -5534,17 +2838,6 @@
     "max": 41.0,
     "default": 0.0,
     "name": "cooling-with-room-sensors-40171",
-    "write": true
-  },
-  "40173": {
-    "title": "Start passive cooling DM",
-    "factor": 1,
-    "unit": "DM",
-    "size": "s16",
-    "min": 10.0,
-    "max": 500.0,
-    "default": 30.0,
-    "name": "start-passive-cooling-dm-40173",
     "write": true
   },
   "40174": {
@@ -5556,16 +2849,6 @@
     "max": 300.0,
     "default": 30.0,
     "name": "start-active-cooling-dm-40174",
-    "write": true
-  },
-  "42745": {
-    "title": "Changes have been made",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "changes-have-been-made-42745",
     "write": true
   },
   "40181": {
@@ -5603,7 +2886,7 @@
     "factor": 10,
     "unit": "\u00b0C",
     "size": "s16",
-    "min": 0.0,
+    "min": 150.0,
     "max": 400.0,
     "default": 250.0,
     "name": "auto-mode-start-temperature-for-cooling-40184",
@@ -5674,16 +2957,6 @@
     "name": "time-format-40195",
     "write": true
   },
-  "40196": {
-    "title": "Hot water permitted",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "hot-water-permitted-40196",
-    "write": true
-  },
   "40197": {
     "title": "Alarm action, lower room temperature",
     "factor": 1,
@@ -5700,7 +2973,7 @@
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
-    "default": 0.0,
+    "default": 1.0,
     "name": "alarm-action-lower-hw-temperature-40198",
     "write": true
   },
@@ -5919,26 +3192,6 @@
     "name": "oper-mode-40238",
     "write": true
   },
-  "40239": {
-    "title": "Max. step internal additional heat",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 7.0,
-    "default": 3.0,
-    "name": "max-step-internal-additional-heat-40239",
-    "write": true
-  },
-  "40240": {
-    "title": "Internal additional heat stepping mode",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "internal-additional-heat-stepping-mode-40240",
-    "write": true
-  },
   "40682": {
     "title": "Cooling heat sensor set point value",
     "factor": 10,
@@ -5947,27 +3200,6 @@
     "max": 400.0,
     "default": 210.0,
     "name": "cooling-heat-sensor-set-point-value-40682",
-    "write": true
-  },
-  "40683": {
-    "title": "Heating medium pump manual speed",
-    "factor": 1,
-    "unit": "%",
-    "size": "s8",
-    "min": 1.0,
-    "max": 100.0,
-    "default": 70.0,
-    "name": "heating-medium-pump-manual-speed-40683",
-    "write": true
-  },
-  "40685": {
-    "title": "Pool 2 accessory",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "pool-2-accessory-40685",
     "write": true
   },
   "40686": {
@@ -5988,17 +3220,6 @@
     "max": 1.0,
     "default": 0.0,
     "name": "hot-water-comfort-40695",
-    "write": true
-  },
-  "40696": {
-    "title": "Manual heating medium pump speed",
-    "factor": 1,
-    "unit": "%",
-    "size": "s8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "manual-heating-medium-pump-speed-40696",
     "write": true
   },
   "40698": {
@@ -6039,31 +3260,11 @@
     "name": "external-cooling-accessory-40710",
     "write": true
   },
-  "40711": {
-    "title": "HW comfort additional heat",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "hw-comfort-additional-heat-40711",
-    "write": true
-  },
   "40727": {
     "title": "Cooling connected, climate system 1",
     "factor": 1,
     "size": "u8",
     "name": "cooling-connected-climate-system-1-40727",
-    "write": true
-  },
-  "40732": {
-    "title": "ACS",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "acs-40732",
     "write": true
   },
   "40749": {
@@ -6072,7 +3273,7 @@
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
-    "default": 0.0,
+    "default": 1.0,
     "name": "operating-mode-charge-pump-climate-system-1-40749",
     "write": true
   },
@@ -6085,36 +3286,6 @@
     "max": 30.0,
     "default": 20.0,
     "name": "shunted-brine-max-temp-44068",
-    "write": true
-  },
-  "40756": {
-    "title": "Hot water compressors step diff.",
-    "factor": 100,
-    "size": "s16",
-    "min": 0.0,
-    "max": 400.0,
-    "default": 100.0,
-    "name": "hot-water-compressors-step-diff-40756",
-    "write": true
-  },
-  "40759": {
-    "title": "Additional heat after reversing valve",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 1.0,
-    "name": "additional-heat-after-reversing-valve-40759",
-    "write": true
-  },
-  "40760": {
-    "title": "Hot water additional heat in tank",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "hot-water-additional-heat-in-tank-40760",
     "write": true
   },
   "40761": {
@@ -6145,76 +3316,6 @@
     "max": 1.0,
     "default": 1.0,
     "name": "operating-mode-circulation-pump-heating-heat-pump-1-40784",
-    "write": true
-  },
-  "40793": {
-    "title": "Operating mode circulation pump hot water heat pump 8",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 1.0,
-    "name": "operating-mode-circulation-pump-hot-water-heat-pump-8-40793",
-    "write": true
-  },
-  "40794": {
-    "title": "Operating mode circulation pump hot water heat pump 7",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 1.0,
-    "name": "operating-mode-circulation-pump-hot-water-heat-pump-7-40794",
-    "write": true
-  },
-  "40795": {
-    "title": "Operating mode circulation pump hot water heat pump 6",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 1.0,
-    "name": "operating-mode-circulation-pump-hot-water-heat-pump-6-40795",
-    "write": true
-  },
-  "40796": {
-    "title": "Operating mode circulation pump hot water heat pump 5",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 1.0,
-    "name": "operating-mode-circulation-pump-hot-water-heat-pump-5-40796",
-    "write": true
-  },
-  "40797": {
-    "title": "Operating mode circulation pump hot water heat pump 4",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 1.0,
-    "name": "operating-mode-circulation-pump-hot-water-heat-pump-4-40797",
-    "write": true
-  },
-  "40798": {
-    "title": "Operating mode circulation pump hot water heat pump 3",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 1.0,
-    "name": "operating-mode-circulation-pump-hot-water-heat-pump-3-40798",
-    "write": true
-  },
-  "40799": {
-    "title": "Operating mode circulation pump hot water heat pump 2",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 1.0,
-    "name": "operating-mode-circulation-pump-hot-water-heat-pump-2-40799",
     "write": true
   },
   "40800": {
@@ -6277,16 +3378,6 @@
     "max": 254.0,
     "default": 23.0,
     "name": "spa-area-40852",
-    "write": true
-  },
-  "40858": {
-    "title": "Internal shunt controlled additional heat",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "internal-shunt-controlled-additional-heat-40858",
     "write": true
   },
   "40868": {
@@ -6442,36 +3533,6 @@
     "max": 1.0,
     "default": 0.0,
     "name": "ers-1-40934",
-    "write": true
-  },
-  "40940": {
-    "title": "EB103/104-GP12",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "eb103-104-gp12-40940",
-    "write": true
-  },
-  "40941": {
-    "title": "EB105/106-GP12",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "eb105-106-gp12-40941",
-    "write": true
-  },
-  "40942": {
-    "title": "EB107/108-GP12",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "eb107-108-gp12-40942",
     "write": true
   },
   "40949": {
@@ -6873,39 +3934,6 @@
     "name": "exhaust-air-fan-speed-normal-ers-1-41026",
     "write": true
   },
-  "41028": {
-    "title": "Filtering time (BT64)",
-    "factor": 1,
-    "unit": "min",
-    "size": "u8",
-    "min": 5.0,
-    "max": 30.0,
-    "default": 5.0,
-    "name": "filtering-time-bt64-41028",
-    "write": true
-  },
-  "41029": {
-    "title": "(ACS) - Thermostat, hysteresis between compressors",
-    "factor": 1,
-    "unit": "\u00b0C",
-    "size": "s8",
-    "min": 1.0,
-    "max": 10.0,
-    "default": 2.0,
-    "name": "acs-thermostat-hysteresis-between-compressors-41029",
-    "write": true
-  },
-  "41030": {
-    "title": "Start temperature (BT64)",
-    "factor": 1,
-    "unit": "\u00b0C",
-    "size": "s8",
-    "min": -8.0,
-    "max": 30.0,
-    "default": 10.0,
-    "name": "start-temperature-bt64-41030",
-    "write": true
-  },
   "41032": {
     "title": "Flow sensor activated X21",
     "factor": 1,
@@ -6948,6 +3976,16 @@
     "name": "bypass-temp-ers-1-41045",
     "write": true
   },
+  "41046": {
+    "title": "Pool pump type",
+    "factor": 1,
+    "size": "u8",
+    "min": 0.0,
+    "max": 1.0,
+    "default": 1.0,
+    "name": "pool-pump-type-41046",
+    "write": true
+  },
   "41047": {
     "title": "External cooling accessory pump type",
     "factor": 1,
@@ -6968,16 +4006,6 @@
     "name": "flow-sensor-activated-x22-41050",
     "write": true
   },
-  "41051": {
-    "title": "Flow sensor activated X21",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "flow-sensor-activated-x21-41051",
-    "write": true
-  },
   "41053": {
     "title": "Max. internal additional heat SG Ready",
     "factor": 100,
@@ -6985,7 +4013,7 @@
     "size": "s16",
     "min": 0.0,
     "max": 900.0,
-    "default": 700.0,
+    "default": 900.0,
     "name": "max-internal-additional-heat-sg-ready-41053",
     "write": true
   },
@@ -7573,25 +4601,14 @@
     "name": "end-month-tariff-ext-step-add-heat-smart-energy-source-41284",
     "write": true
   },
-  "41317": {
-    "title": "Ground water pump temperature alarm",
+  "41321": {
+    "title": "Prioritise additional heat (AXC40)",
     "factor": 1,
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
     "default": 0.0,
-    "name": "ground-water-pump-temperature-alarm-41317",
-    "write": true
-  },
-  "41318": {
-    "title": "Ground water pump temperature alarm level",
-    "factor": 1,
-    "unit": "\u00b0C",
-    "size": "s8",
-    "min": -15.0,
-    "max": 20.0,
-    "default": 3.0,
-    "name": "ground-water-pump-temperature-alarm-level-41318",
+    "name": "prioritise-additional-heat-axc40-41321",
     "write": true
   },
   "41327": {
@@ -7657,16 +4674,6 @@
     "size": "s32",
     "name": "total-energy-eme-20-32181"
   },
-  "44019": {
-    "title": "External energy meter 2 pulse per kWh",
-    "factor": 1,
-    "size": "u16",
-    "min": 1.0,
-    "max": 10000.0,
-    "default": 500.0,
-    "name": "external-energy-meter-2-pulse-per-kwh-44019",
-    "write": true
-  },
   "44077": {
     "title": "ERS 2",
     "factor": 1,
@@ -7695,16 +4702,6 @@
     "max": 1.0,
     "default": 0.0,
     "name": "ers-4-44079",
-    "write": true
-  },
-  "44204": {
-    "title": "Hot water additional heat used in heating mode",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "hot-water-additional-heat-used-in-heating-mode-44204",
     "write": true
   },
   "41982": {
@@ -8005,6 +5002,38 @@
     "name": "blocking-actions-ers-4-44102",
     "write": true
   },
+  "42956": {
+    "title": "Night cooling 1",
+    "factor": 1,
+    "size": "u8",
+    "min": 0.0,
+    "max": 1.0,
+    "default": 0.0,
+    "name": "night-cooling-1-42956",
+    "write": true
+  },
+  "42943": {
+    "title": "Start temperature night cooling 1",
+    "factor": 1,
+    "unit": "\u00b0C",
+    "size": "u8",
+    "min": 20.0,
+    "max": 30.0,
+    "default": 25.0,
+    "name": "start-temperature-night-cooling-1-42943",
+    "write": true
+  },
+  "42944": {
+    "title": "Night cooling diff",
+    "factor": 1,
+    "unit": "\u00b0C",
+    "size": "u8",
+    "min": 3.0,
+    "max": 10.0,
+    "default": 6.0,
+    "name": "night-cooling-diff-42944",
+    "write": true
+  },
   "43244": {
     "title": "Minimum permitted speed (EB101 GP12)",
     "factor": 1,
@@ -8014,16 +5043,6 @@
     "max": 50.0,
     "default": 1.0,
     "name": "minimum-permitted-speed-eb101-gp12-43244",
-    "write": true
-  },
-  "43252": {
-    "title": "Start fan de-icing (EB101)",
-    "factor": 1,
-    "size": "s8",
-    "min": 0.0,
-    "max": 1.0,
-    "default": 0.0,
-    "name": "start-fan-de-icing-eb101-43252",
     "write": true
   },
   "40177": {
@@ -8136,27 +5155,6 @@
     "name": "sound-when-pressing-button-43234",
     "write": true
   },
-  "43235": {
-    "title": "BT12 offset, heat pump 1",
-    "factor": 10,
-    "unit": "\u00b0C",
-    "size": "s8",
-    "min": -50.0,
-    "max": 50.0,
-    "default": 0.0,
-    "name": "bt12-offset-heat-pump-1-43235",
-    "write": true
-  },
-  "43059": {
-    "title": "Additional heat step, emergency mode",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 7.0,
-    "default": 0.0,
-    "name": "additional-heat-step-emergency-mode-43059",
-    "write": true
-  },
   "43060": {
     "title": "Heating, auto",
     "factor": 1,
@@ -8176,6 +5174,12 @@
     "default": 5.0,
     "name": "factor-43034",
     "write": true
+  },
+  "32129": {
+    "title": "Pump: Heating medium (GP6)",
+    "factor": 1,
+    "size": "u8",
+    "name": "pump-heating-medium-gp6-32129"
   },
   "43089": {
     "title": "Period",
@@ -8290,16 +5294,6 @@
     "factor": 1,
     "size": "u16",
     "name": "stop-time-43076",
-    "write": true
-  },
-  "40225": {
-    "title": "AUX relay (X11)",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 25.0,
-    "default": 5.0,
-    "name": "aux-relay-x11-40225",
     "write": true
   },
   "42668": {
@@ -8964,22 +5958,6 @@
     "name": "external-setting-for-adjustment-migrated-42504",
     "write": true
   },
-  "42505": {
-    "title": "Max. step internal additional heat",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 7.0,
-    "default": 3.0,
-    "name": "max-step-internal-additional-heat-42505",
-    "write": true
-  },
-  "32148": {
-    "title": "Version, inverter (EB101)",
-    "factor": 1,
-    "size": "u8",
-    "name": "version-inverter-eb101-32148"
-  },
   "42677": {
     "title": "Time between filter replacement",
     "factor": 1,
@@ -9019,26 +5997,6 @@
     "default": 3.0,
     "name": "time-between-filter-replacement-42680",
     "write": true
-  },
-  "32183": {
-    "title": "Total oper. time ext. add. heat, heating",
-    "factor": 10,
-    "unit": "h",
-    "size": "s32",
-    "min": 0.0,
-    "max": 9999999.0,
-    "default": 0.0,
-    "name": "total-oper-time-ext-add-heat-heating-32183"
-  },
-  "32185": {
-    "title": "Total HW run time additional heat",
-    "factor": 10,
-    "unit": "h",
-    "size": "s32",
-    "min": 0.0,
-    "max": 9999999.0,
-    "default": 0.0,
-    "name": "total-hw-run-time-additional-heat-32185"
   },
   "42701": {
     "title": "Return time fan 4",
@@ -9273,15 +6231,6 @@
     "name": "aux-from-modbus-42742",
     "write": true
   },
-  "32159": {
-    "title": "Last defrost, heat pump 1",
-    "factor": 1,
-    "size": "u8",
-    "min": 0.0,
-    "max": 255.0,
-    "default": 255.0,
-    "name": "last-defrost-heat-pump-1-32159"
-  },
   "42821": {
     "title": "ERS 2",
     "factor": 1,
@@ -9501,7 +6450,7 @@
     "size": "s16",
     "min": 0.0,
     "max": 4500.0,
-    "default": 940.0,
+    "default": 600.0,
     "name": "immersion-heater-power-emergency-mode-43029",
     "write": true
   },

--- a/nibe/data/smos40.csv
+++ b/nibe/data/smos40.csv
@@ -1,21 +1,27 @@
 Title	Register type	Register	Division factor	Unit	Size of variable	Min value	Max value	Default value
-Current outdoor temper­ature (BT1)	MODBUS_INPUT_REGISTER	1	10	°C	2	0	0	0
+Current outdoor temperature (BT1)	MODBUS_INPUT_REGISTER	1	10	°C	2	0	0	0
 Supply line (EP23-BT2)	MODBUS_INPUT_REGISTER	2	10	°C	2	0	0	0
 Supply line (EP22-BT2)	MODBUS_INPUT_REGISTER	3	10	°C	2	0	0	0
 Supply line (EP21-BT2)	MODBUS_INPUT_REGISTER	4	10	°C	2	0	0	0
 Hot water top (BT7)	MODBUS_INPUT_REGISTER	8	10	°C	2	0	0	0
-Hot water char­ging (BT6)	MODBUS_INPUT_REGISTER	9	10	°C	2	0	0	0
+Hot water charging (BT6)	MODBUS_INPUT_REGISTER	9	10	°C	2	0	0	0
 Roomsensor 1-1	MODBUS_INPUT_REGISTER	26	10	°C	2	0	0	0
 Return line (EQ1-BT65)	MODBUS_INPUT_REGISTER	31	10	°C	2	0	0	0
-Temper­ature limiter (EB100-FD1)	MODBUS_INPUT_REGISTER	36	1		2	0	0	0
-Average temper­ature (BT1)	MODBUS_INPUT_REGISTER	37	10	°C	2	0	0	0
-Boiler temp­erature (BT52)	MODBUS_INPUT_REGISTER	38	10	°C	2	0	0	0
-Exter­nal supply line (BT25)	MODBUS_INPUT_REGISTER	39	10	°C	2	0	0	0
+Temperature limiter (EB100-FD1)	MODBUS_INPUT_REGISTER	36	1		2	0	0	0
+Average temperature (BT1)	MODBUS_INPUT_REGISTER	37	10	°C	2	0	0	0
+Boiler temperature (BT52)	MODBUS_INPUT_REGISTER	38	10	°C	2	0	0	0
+External supply line (BT25)	MODBUS_INPUT_REGISTER	39	10	°C	2	0	0	0
 Electrical anode (EB100-FR1)	MODBUS_INPUT_REGISTER	41	1		2	0	0	0
 Current (BE3)	MODBUS_INPUT_REGISTER	46	10	A	6	0	0	0
 Current (BE2)	MODBUS_INPUT_REGISTER	48	10	A	6	0	0	0
 Current (BE1)	MODBUS_INPUT_REGISTER	50	10	A	6	0	0	0
 Pool (CL12-BT51)	MODBUS_INPUT_REGISTER	59	10	°C	2	0	0	0
+-	MODBUS_INPUT_REGISTER	60	10	°C	2	0	0	0
+-	MODBUS_INPUT_REGISTER	61	10	°C	2	0	0	0
+-	MODBUS_INPUT_REGISTER	62	10	°C	2	0	0	0
+-	MODBUS_INPUT_REGISTER	63	10	°C	2	0	0	0
+-	MODBUS_INPUT_REGISTER	64	10	°C	2	0	0	0
+-	MODBUS_INPUT_REGISTER	65	10	°C	2	0	0	0
 Return line (EP23-BT3)	MODBUS_INPUT_REGISTER	75	10	°C	2	0	0	0
 Return line (EP22-BT3)	MODBUS_INPUT_REGISTER	76	10	°C	2	0	0	0
 Return line (EP21-BT3)	MODBUS_INPUT_REGISTER	77	10	°C	2	0	0	0
@@ -41,7 +47,7 @@ Room average temp. clim. system 4 (BT50)	MODBUS_INPUT_REGISTER	113	10	°C	2	0	0	
 Room average temp. clim. system 3 (BT50)	MODBUS_INPUT_REGISTER	114	10	°C	2	0	0	0
 Room average temp. clim. system 2 (BT50)	MODBUS_INPUT_REGISTER	115	10	°C	2	0	0	0
 Room average temp. clim. system 1 (BT50)	MODBUS_INPUT_REGISTER	116	10	°C	2	0	0	0
-Exter­nal cooling supply temper­ature (BT25)	MODBUS_INPUT_REGISTER	119	10	°C	2	0	0	0
+External cooling supply temperature (BT25)	MODBUS_INPUT_REGISTER	119	10	°C	2	0	0	0
 id:193	MODBUS_INPUT_REGISTER	128	1		4	0	0	0
 Oper. mode shunt climate system 8	MODBUS_INPUT_REGISTER	129	1		4	0	0	0
 Oper. mode shunt climate system 7	MODBUS_INPUT_REGISTER	130	1		4	0	0	0
@@ -51,128 +57,128 @@ id:246	MODBUS_INPUT_REGISTER	133	1		4	0	0	0
 Relay status (ERS 1)	MODBUS_INPUT_REGISTER	134	1		4	0	0	0
 Fan speed (AZ30-GQ2)	MODBUS_INPUT_REGISTER	135	1	%	4	0	0	0
 Fan speed (AZ30-GQ3)	MODBUS_INPUT_REGISTER	136	1	%	4	0	0	0
-Current hot water mode con­trolled by	MODBUS_INPUT_REGISTER	137	1		1	0	0	0
-Max. compres­sor freq­uency, heating	MODBUS_INPUT_REGISTER	141	100	Hz	5	0	0	0
-Invert­er alarm code	MODBUS_INPUT_REGISTER	142	1		5	0	0	0
-Invert­er alarm code	MODBUS_INPUT_REGISTER	143	1		5	0	0	0
-Exter­nal adjust­ment climate system 8	MODBUS_INPUT_REGISTER	151	1		4	0	0	0
-Exter­nal adjust­ment climate system 7	MODBUS_INPUT_REGISTER	152	1		4	0	0	0
-Exter­nal adjust­ment climate system 6	MODBUS_INPUT_REGISTER	153	1		4	0	0	0
-Exter­nal adjust­ment climate system 5	MODBUS_INPUT_REGISTER	154	1		4	0	0	0
+Current hot water mode controlled by	MODBUS_INPUT_REGISTER	137	1		1	0	0	0
+Max. compressor frequency, heating	MODBUS_INPUT_REGISTER	141	100	Hz	5	0	0	0
+Inverter alarm code	MODBUS_INPUT_REGISTER	142	1		5	0	0	0
+Inverter alarm code	MODBUS_INPUT_REGISTER	143	1		5	0	0	0
+External adjustment climate system 8	MODBUS_INPUT_REGISTER	151	1		4	0	0	0
+External adjustment climate system 7	MODBUS_INPUT_REGISTER	152	1		4	0	0	0
+External adjustment climate system 6	MODBUS_INPUT_REGISTER	153	1		4	0	0	0
+External adjustment climate system 5	MODBUS_INPUT_REGISTER	154	1		4	0	0	0
 Climate system 8	MODBUS_INPUT_REGISTER	156	1		4	0	0	0
 Climate system 7	MODBUS_INPUT_REGISTER	157	1		4	0	0	0
 Climate system 6	MODBUS_INPUT_REGISTER	158	1		4	0	0	0
 Climate system 5	MODBUS_INPUT_REGISTER	159	1		4	0	0	0
 Hot water comfort return (BT82)	MODBUS_INPUT_REGISTER	174	10	°C	2	0	0	0
 Hot water comfort heater (BT83)	MODBUS_INPUT_REGISTER	175	10	°C	2	0	0	0
-Com­pressor, total time cooling, heat pump 8 (EP15)	MODBUS_INPUT_REGISTER	177	1	h	6	0	0	0
-Com­pressor, total time pool, heat pump 8 (EP15)	MODBUS_INPUT_REGISTER	179	1	h	6	0	0	0
-Com­pressor, total time pool 2, heat pump 8 (EP15)	MODBUS_INPUT_REGISTER	181	1	h	6	0	0	0
-Com­pressor, total time cooling, heat pump 8 (EP14)	MODBUS_INPUT_REGISTER	183	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool, heat pump 8 (EP14)	MODBUS_INPUT_REGISTER	185	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool 2, heat pump 8 (EP14)	MODBUS_INPUT_REGISTER	187	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time cooling, heat pump 7 (EP15)	MODBUS_INPUT_REGISTER	189	1	h	6	0	0	0
-Com­pressor, total time pool, heat pump 7 (EP15)	MODBUS_INPUT_REGISTER	191	1	h	6	0	0	0
-Com­pressor, total time pool 2, heat pump 7 (EP15)	MODBUS_INPUT_REGISTER	193	1	h	6	0	0	0
-Com­pressor, total time cooling, heat pump 7 (EP14)	MODBUS_INPUT_REGISTER	195	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool, heat pump 7 (EP14)	MODBUS_INPUT_REGISTER	197	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool 2, heat pump 7 (EP14)	MODBUS_INPUT_REGISTER	199	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time cooling, heat pump 6 (EP15)	MODBUS_INPUT_REGISTER	201	1	h	6	0	0	0
-Com­pressor, total time pool, heat pump 6 (EP15)	MODBUS_INPUT_REGISTER	203	1	h	6	0	0	0
-Com­pressor, total time pool 2, heat pump 6 (EP15)	MODBUS_INPUT_REGISTER	205	1	h	6	0	0	0
-Com­pressor, total time cooling, heat pump 6 (EP14)	MODBUS_INPUT_REGISTER	207	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool, heat pump 6 (EP14)	MODBUS_INPUT_REGISTER	209	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool 2, heat pump 6 (EP14)	MODBUS_INPUT_REGISTER	211	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time cooling, heat pump 5 (EP15)	MODBUS_INPUT_REGISTER	213	1	h	6	0	0	0
-Com­pressor, total time pool, heat pump 5 (EP15)	MODBUS_INPUT_REGISTER	215	1	h	6	0	0	0
-Com­pressor, total time pool 2, heat pump 5 (EP15)	MODBUS_INPUT_REGISTER	217	1	h	6	0	0	0
-Com­pressor, total time cooling, heat pump 5 (EP14)	MODBUS_INPUT_REGISTER	219	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool, heat pump 5 (EP14)	MODBUS_INPUT_REGISTER	221	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool 2, heat pump 5 (EP14)	MODBUS_INPUT_REGISTER	223	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time cooling, heat pump 4 (EP15)	MODBUS_INPUT_REGISTER	225	1	h	6	0	0	0
-Com­pressor, total time pool, heat pump 4 (EP15)	MODBUS_INPUT_REGISTER	227	1	h	6	0	0	0
-Com­pressor, total time pool 2, heat pump 4 (EP15)	MODBUS_INPUT_REGISTER	229	1	h	6	0	0	0
-Com­pressor, total time cooling, heat pump 4 (EP14)	MODBUS_INPUT_REGISTER	231	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool, heat pump 4 (EP14)	MODBUS_INPUT_REGISTER	233	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool 2, heat pump 4 (EP14)	MODBUS_INPUT_REGISTER	235	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time cooling, heat pump 3 (EP15)	MODBUS_INPUT_REGISTER	237	1	h	6	0	0	0
-Com­pressor, total time pool, heat pump 3 (EP15)	MODBUS_INPUT_REGISTER	239	1	h	6	0	0	0
-Com­pressor, total time pool 2, heat pump 3 (EP15)	MODBUS_INPUT_REGISTER	241	1	h	6	0	0	0
-Com­pressor, total time cooling, heat pump 3 (EP14)	MODBUS_INPUT_REGISTER	243	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool, heat pump 3 (EP14)	MODBUS_INPUT_REGISTER	245	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool 2, heat pump 3 (EP14)	MODBUS_INPUT_REGISTER	247	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time cooling, heat pump 2 (EP15)	MODBUS_INPUT_REGISTER	249	1	h	6	0	0	0
-Com­pressor, total time pool, heat pump 2 (EP15)	MODBUS_INPUT_REGISTER	251	1	h	6	0	0	0
-Com­pressor, total time pool 2, heat pump 2 (EP15)	MODBUS_INPUT_REGISTER	253	1	h	6	0	0	0
-Com­pressor, total time cooling, heat pump 2 (EP14)	MODBUS_INPUT_REGISTER	255	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool, heat pump 2 (EP14)	MODBUS_INPUT_REGISTER	257	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool 2, heat pump 2 (EP14)	MODBUS_INPUT_REGISTER	259	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time cooling, heat pump 1 (EP15)	MODBUS_INPUT_REGISTER	261	1	h	6	0	0	0
-Com­pressor, total time pool, heat pump 1 (EP15)	MODBUS_INPUT_REGISTER	263	1	h	6	0	0	0
-Com­pressor, total time pool 2, heat pump 1 (EP15)	MODBUS_INPUT_REGISTER	265	1	h	6	0	0	0
+Compressor, total time cooling, heat pump 8 (EP15)	MODBUS_INPUT_REGISTER	177	1	h	6	0	0	0
+Compressor, total time pool, heat pump 8 (EP15)	MODBUS_INPUT_REGISTER	179	1	h	6	0	0	0
+Compressor, total time pool 2, heat pump 8 (EP15)	MODBUS_INPUT_REGISTER	181	1	h	6	0	0	0
+Compressor, total time cooling, heat pump 8 (EP14)	MODBUS_INPUT_REGISTER	183	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool, heat pump 8 (EP14)	MODBUS_INPUT_REGISTER	185	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool 2, heat pump 8 (EP14)	MODBUS_INPUT_REGISTER	187	1	h	6	-2147483648	2147483647	0
+Compressor, total time cooling, heat pump 7 (EP15)	MODBUS_INPUT_REGISTER	189	1	h	6	0	0	0
+Compressor, total time pool, heat pump 7 (EP15)	MODBUS_INPUT_REGISTER	191	1	h	6	0	0	0
+Compressor, total time pool 2, heat pump 7 (EP15)	MODBUS_INPUT_REGISTER	193	1	h	6	0	0	0
+Compressor, total time cooling, heat pump 7 (EP14)	MODBUS_INPUT_REGISTER	195	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool, heat pump 7 (EP14)	MODBUS_INPUT_REGISTER	197	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool 2, heat pump 7 (EP14)	MODBUS_INPUT_REGISTER	199	1	h	6	-2147483648	2147483647	0
+Compressor, total time cooling, heat pump 6 (EP15)	MODBUS_INPUT_REGISTER	201	1	h	6	0	0	0
+Compressor, total time pool, heat pump 6 (EP15)	MODBUS_INPUT_REGISTER	203	1	h	6	0	0	0
+Compressor, total time pool 2, heat pump 6 (EP15)	MODBUS_INPUT_REGISTER	205	1	h	6	0	0	0
+Compressor, total time cooling, heat pump 6 (EP14)	MODBUS_INPUT_REGISTER	207	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool, heat pump 6 (EP14)	MODBUS_INPUT_REGISTER	209	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool 2, heat pump 6 (EP14)	MODBUS_INPUT_REGISTER	211	1	h	6	-2147483648	2147483647	0
+Compressor, total time cooling, heat pump 5 (EP15)	MODBUS_INPUT_REGISTER	213	1	h	6	0	0	0
+Compressor, total time pool, heat pump 5 (EP15)	MODBUS_INPUT_REGISTER	215	1	h	6	0	0	0
+Compressor, total time pool 2, heat pump 5 (EP15)	MODBUS_INPUT_REGISTER	217	1	h	6	0	0	0
+Compressor, total time cooling, heat pump 5 (EP14)	MODBUS_INPUT_REGISTER	219	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool, heat pump 5 (EP14)	MODBUS_INPUT_REGISTER	221	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool 2, heat pump 5 (EP14)	MODBUS_INPUT_REGISTER	223	1	h	6	-2147483648	2147483647	0
+Compressor, total time cooling, heat pump 4 (EP15)	MODBUS_INPUT_REGISTER	225	1	h	6	0	0	0
+Compressor, total time pool, heat pump 4 (EP15)	MODBUS_INPUT_REGISTER	227	1	h	6	0	0	0
+Compressor, total time pool 2, heat pump 4 (EP15)	MODBUS_INPUT_REGISTER	229	1	h	6	0	0	0
+Compressor, total time cooling, heat pump 4 (EP14)	MODBUS_INPUT_REGISTER	231	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool, heat pump 4 (EP14)	MODBUS_INPUT_REGISTER	233	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool 2, heat pump 4 (EP14)	MODBUS_INPUT_REGISTER	235	1	h	6	-2147483648	2147483647	0
+Compressor, total time cooling, heat pump 3 (EP15)	MODBUS_INPUT_REGISTER	237	1	h	6	0	0	0
+Compressor, total time pool, heat pump 3 (EP15)	MODBUS_INPUT_REGISTER	239	1	h	6	0	0	0
+Compressor, total time pool 2, heat pump 3 (EP15)	MODBUS_INPUT_REGISTER	241	1	h	6	0	0	0
+Compressor, total time cooling, heat pump 3 (EP14)	MODBUS_INPUT_REGISTER	243	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool, heat pump 3 (EP14)	MODBUS_INPUT_REGISTER	245	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool 2, heat pump 3 (EP14)	MODBUS_INPUT_REGISTER	247	1	h	6	-2147483648	2147483647	0
+Compressor, total time cooling, heat pump 2 (EP15)	MODBUS_INPUT_REGISTER	249	1	h	6	0	0	0
+Compressor, total time pool, heat pump 2 (EP15)	MODBUS_INPUT_REGISTER	251	1	h	6	0	0	0
+Compressor, total time pool 2, heat pump 2 (EP15)	MODBUS_INPUT_REGISTER	253	1	h	6	0	0	0
+Compressor, total time cooling, heat pump 2 (EP14)	MODBUS_INPUT_REGISTER	255	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool, heat pump 2 (EP14)	MODBUS_INPUT_REGISTER	257	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool 2, heat pump 2 (EP14)	MODBUS_INPUT_REGISTER	259	1	h	6	-2147483648	2147483647	0
+Compressor, total time cooling, heat pump 1 (EP15)	MODBUS_INPUT_REGISTER	261	1	h	6	0	0	0
+Compressor, total time pool, heat pump 1 (EP15)	MODBUS_INPUT_REGISTER	263	1	h	6	0	0	0
+Compressor, total time pool 2, heat pump 1 (EP15)	MODBUS_INPUT_REGISTER	265	1	h	6	0	0	0
 id:599	MODBUS_INPUT_REGISTER	267	1	h	6	-2147483648	2147483647	0
 id:600	MODBUS_INPUT_REGISTER	269	1	h	6	-2147483648	2147483647	0
 id:601	MODBUS_INPUT_REGISTER	271	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time cooling, main unit (EP14)	MODBUS_INPUT_REGISTER	279	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool, main unit (EP14)	MODBUS_INPUT_REGISTER	281	1	h	6	-2147483648	2147483647	0
-Com­pressor, total time pool 2, main unit (EP14)	MODBUS_INPUT_REGISTER	283	1	h	6	-2147483648	2147483647	0
-Total run time exter­nal HW addi­tional heat	MODBUS_INPUT_REGISTER	285	10	h	3	0	9999999	0
-Heat pump 8 re­quested com­pressor fre­quency	MODBUS_INPUT_REGISTER	294	1	Hz	4	0	0	0
-Heat pump 7 re­quested com­pressor fre­quency	MODBUS_INPUT_REGISTER	295	1	Hz	4	0	0	0
-Heat pump 6 re­quested com­pressor fre­quency	MODBUS_INPUT_REGISTER	296	1	Hz	4	0	0	0
-Heat pump 5 re­quested com­pressor fre­quency	MODBUS_INPUT_REGISTER	297	1	Hz	4	0	0	0
-Heat pump 4 re­quested com­pressor fre­quency	MODBUS_INPUT_REGISTER	298	1	Hz	4	0	0	0
-Heat pump 3 re­quested com­pressor fre­quency	MODBUS_INPUT_REGISTER	299	1	Hz	4	0	0	0
-Heat pump 2 re­quested com­pressor fre­quency	MODBUS_INPUT_REGISTER	300	1	Hz	4	0	0	0
-Heat pump 1 re­quested com­pressor fre­quency	MODBUS_INPUT_REGISTER	301	1	Hz	4	0	0	0
-Frost protec­tion heat ex­changer heat pump 8	MODBUS_INPUT_REGISTER	303	1		4	0	0	0
-Frost protec­tion heat ex­changer heat pump 7	MODBUS_INPUT_REGISTER	304	1		4	0	0	0
-Frost protec­tion heat ex­changer heat pump 6	MODBUS_INPUT_REGISTER	305	1		4	0	0	0
-Frost protec­tion heat ex­changer heat pump 5	MODBUS_INPUT_REGISTER	306	1		4	0	0	0
-Frost protec­tion heat ex­changer heat pump 4	MODBUS_INPUT_REGISTER	307	1		4	0	0	0
-Frost protec­tion heat ex­changer heat pump 3	MODBUS_INPUT_REGISTER	308	1		4	0	0	0
-Frost protec­tion heat ex­changer heat pump 2	MODBUS_INPUT_REGISTER	309	1		4	0	0	0
+Compressor, total time cooling, main unit (EP14)	MODBUS_INPUT_REGISTER	279	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool, main unit (EP14)	MODBUS_INPUT_REGISTER	281	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool 2, main unit (EP14)	MODBUS_INPUT_REGISTER	283	1	h	6	-2147483648	2147483647	0
+Total run time external HW additional heat	MODBUS_INPUT_REGISTER	285	10	h	3	0	9999999	0
+Heat pump 8 requested compressor frequency	MODBUS_INPUT_REGISTER	294	1	Hz	4	0	0	0
+Heat pump 7 requested compressor frequency	MODBUS_INPUT_REGISTER	295	1	Hz	4	0	0	0
+Heat pump 6 requested compressor frequency	MODBUS_INPUT_REGISTER	296	1	Hz	4	0	0	0
+Heat pump 5 requested compressor frequency	MODBUS_INPUT_REGISTER	297	1	Hz	4	0	0	0
+Heat pump 4 requested compressor frequency	MODBUS_INPUT_REGISTER	298	1	Hz	4	0	0	0
+Heat pump 3 requested compressor frequency	MODBUS_INPUT_REGISTER	299	1	Hz	4	0	0	0
+Heat pump 2 requested compressor frequency	MODBUS_INPUT_REGISTER	300	1	Hz	4	0	0	0
+Heat pump 1 requested compressor frequency	MODBUS_INPUT_REGISTER	301	1	Hz	4	0	0	0
+Frost protection heat exchanger heat pump 8	MODBUS_INPUT_REGISTER	303	1		4	0	0	0
+Frost protection heat exchanger heat pump 7	MODBUS_INPUT_REGISTER	304	1		4	0	0	0
+Frost protection heat exchanger heat pump 6	MODBUS_INPUT_REGISTER	305	1		4	0	0	0
+Frost protection heat exchanger heat pump 5	MODBUS_INPUT_REGISTER	306	1		4	0	0	0
+Frost protection heat exchanger heat pump 4	MODBUS_INPUT_REGISTER	307	1		4	0	0	0
+Frost protection heat exchanger heat pump 3	MODBUS_INPUT_REGISTER	308	1		4	0	0	0
+Frost protection heat exchanger heat pump 2	MODBUS_INPUT_REGISTER	309	1		4	0	0	0
 Status (OPT)	MODBUS_INPUT_REGISTER	311	1		4	0	0	0
 Version (OPT)	MODBUS_INPUT_REGISTER	312	1		5	0	0	0
-OPT relay, modu­lation level	MODBUS_INPUT_REGISTER	313	10	%	2	0	0	0
-OPT oper­ating time	MODBUS_INPUT_REGISTER	315	1	h	5	0	0	0
-Avail­able compres­sors heating	MODBUS_INPUT_REGISTER	317	1		4	0	0	0
-Avail­able compres­sors hot water	MODBUS_INPUT_REGISTER	318	1		4	0	0	0
-Avail­able compres­sors pool 1	MODBUS_INPUT_REGISTER	319	1		4	0	0	0
-Avail­able compres­sors pool 2	MODBUS_INPUT_REGISTER	320	1		4	0	0	0
-Avail­able compres­sors cooling	MODBUS_INPUT_REGISTER	321	1		4	0	0	0
+OPT relay, modulation level	MODBUS_INPUT_REGISTER	313	10	%	2	0	0	0
+OPT operating time	MODBUS_INPUT_REGISTER	315	1	h	5	0	0	0
+Available compressors heating	MODBUS_INPUT_REGISTER	317	1		4	0	0	0
+Available compressors hot water	MODBUS_INPUT_REGISTER	318	1		4	0	0	0
+Available compressors pool 1	MODBUS_INPUT_REGISTER	319	1		4	0	0	0
+Available compressors pool 2	MODBUS_INPUT_REGISTER	320	1		4	0	0	0
+Available compressors cooling	MODBUS_INPUT_REGISTER	321	1		4	0	0	0
 +Adjust, port	MODBUS_INPUT_REGISTER	327	1		4	0	0	0
-+Adjust, oper­ating mode	MODBUS_INPUT_REGISTER	328	1		4	0	0	0
++Adjust, operating mode	MODBUS_INPUT_REGISTER	328	1		4	0	0	0
 +Adjust, comfort	MODBUS_INPUT_REGISTER	329	1		4	0	0	0
-+Adjust, paral­lel adjust­ment	MODBUS_INPUT_REGISTER	330	1		1	0	0	0
-+Adjust, humid­ity	MODBUS_INPUT_REGISTER	331	10	%RH	2	0	0	0
-+Adjust, indoor temp­erature	MODBUS_INPUT_REGISTER	332	10	°C	2	0	0	0
-+Adjust, outdoor temp­erature	MODBUS_INPUT_REGISTER	333	10	°C	2	0	0	0
++Adjust, parallel adjustment	MODBUS_INPUT_REGISTER	330	1		1	0	0	0
++Adjust, humidity	MODBUS_INPUT_REGISTER	331	10	%RH	2	0	0	0
++Adjust, indoor temperature	MODBUS_INPUT_REGISTER	332	10	°C	2	0	0	0
++Adjust, outdoor temperature	MODBUS_INPUT_REGISTER	333	10	°C	2	0	0	0
 +Adjust, version	MODBUS_INPUT_REGISTER	334	1		5	0	0	0
 +Adjust, active	MODBUS_INPUT_REGISTER	335	1		4	0	0	0
 +Adjust, demand	MODBUS_INPUT_REGISTER	336	1		4	0	0	0
-+Adjust, paral­lel factor	MODBUS_HOLDING_REGISTER	1	1		1	1	10	5
-+Adjust, Paral­lel (min-max)	MODBUS_HOLDING_REGISTER	2	1		1	1	100	100
-Supply temper­ature (BT64)	MODBUS_INPUT_REGISTER	337	10	°C	2	0	0	0
-Heat pump func­tional­ity 2	MODBUS_INPUT_REGISTER	338	1		6	0	0	0
++Adjust, parallel factor	MODBUS_HOLDING_REGISTER	1	1		1	1	10	5
++Adjust, Parallel (min-max)	MODBUS_HOLDING_REGISTER	2	1		1	1	100	100
+Supply temperature (BT64)	MODBUS_INPUT_REGISTER	337	10	°C	2	0	0	0
+Heat pump functionality 2	MODBUS_INPUT_REGISTER	338	1		6	0	0	0
 Status (S135)	MODBUS_INPUT_REGISTER	344	1		4	0	0	0
 Status, demand, pump speed (S135)	MODBUS_INPUT_REGISTER	345	1		4	0	0	0
 Status, demand, fan speed (S135)	MODBUS_INPUT_REGISTER	346	1		4	0	0	0
-Status, sole­noid (S135)	MODBUS_INPUT_REGISTER	347	1		4	0	0	0
-Status, com­pressor, heater(S135)	MODBUS_INPUT_REGISTER	348	1		4	0	0	0
-Status, com­pressor, demand (S135)	MODBUS_INPUT_REGISTER	350	1		4	0	0	0
+Status, solenoid (S135)	MODBUS_INPUT_REGISTER	347	1		4	0	0	0
+Status, compressor, heater(S135)	MODBUS_INPUT_REGISTER	348	1		4	0	0	0
+Status, compressor, demand (S135)	MODBUS_INPUT_REGISTER	350	1		4	0	0	0
 No. of starts (S135)	MODBUS_INPUT_REGISTER	351	1		6	0	9999999	0
-Oper­ating time (S135)	MODBUS_INPUT_REGISTER	353	1	h	6	0	9999999	0
+Operating time (S135)	MODBUS_INPUT_REGISTER	353	1	h	6	0	9999999	0
 Degree minutes	MODBUS_HOLDING_REGISTER	11	10	DM	3	-30000	30000	0
 Blocking (ERS 1)	MODBUS_INPUT_REGISTER	358	1		4	0	0	0
 AZ30-EB17	MODBUS_INPUT_REGISTER	359	1		4	0	0	0
 Supply line (S135-BT12)	MODBUS_INPUT_REGISTER	360	10	°C	2	0	0	0
 Return line (S135-BT13)	MODBUS_INPUT_REGISTER	361	10	°C	2	0	0	0
-Evap­orator (S135-BT16)	MODBUS_INPUT_REGISTER	362	10	°C	2	0	0	0
-Defrost­ing sensor (S135-BT76)	MODBUS_INPUT_REGISTER	363	10	°C	2	0	0	0
-Incom­ing air (S135-BT77)	MODBUS_INPUT_REGISTER	364	10	°C	2	0	0	0
+Evaporator (S135-BT16)	MODBUS_INPUT_REGISTER	362	10	°C	2	0	0	0
+Defrosting sensor (S135-BT76)	MODBUS_INPUT_REGISTER	363	10	°C	2	0	0	0
+Incoming air (S135-BT77)	MODBUS_INPUT_REGISTER	364	10	°C	2	0	0	0
 Alarm number (S135)	MODBUS_INPUT_REGISTER	365	1		5	0	0	0
-Defrost­ing (S135)	MODBUS_INPUT_REGISTER	366	1		4	0	0	0
+Defrosting (S135)	MODBUS_INPUT_REGISTER	366	1		4	0	0	0
 Status, relay 5 (S135)	MODBUS_INPUT_REGISTER	367	1		4	0	0	0
 Status, relay 4 (S135)	MODBUS_INPUT_REGISTER	368	1		4	0	0	0
 Status, relay 3 (S135)	MODBUS_INPUT_REGISTER	369	1		4	0	0	0
@@ -180,7 +186,7 @@ Status, relay 2 (S135)	MODBUS_INPUT_REGISTER	370	1		4	0	0	0
 Status, relay 1 (S135)	MODBUS_INPUT_REGISTER	371	1		4	0	0	0
 Status, relay 0 (S135)	MODBUS_INPUT_REGISTER	372	1		4	0	0	0
 Pump speed (S135)	MODBUS_INPUT_REGISTER	373	1	%	4	0	0	0
-Sel­ected fan speed	MODBUS_INPUT_REGISTER	374	1	%	4	0	0	0
+Selected fan speed	MODBUS_INPUT_REGISTER	374	1	%	4	0	0	0
 Version (S135)	MODBUS_INPUT_REGISTER	376	1		5	0	0	0
 id:803	MODBUS_INPUT_REGISTER	377	1		6	0	2147483647	0
 id:804	MODBUS_INPUT_REGISTER	379	1		6	0	0	0
@@ -199,23 +205,23 @@ Alarm number from outdoor air heat pump (EB101)	MODBUS_INPUT_REGISTER	400	1		4	0
 Fan speed (EB101)	MODBUS_INPUT_REGISTER	401	1	rpm	5	0	0	0
 Max fan speed (EB101)	MODBUS_INPUT_REGISTER	402	1	rpm	5	0	0	0
 Min fan speed (EB101)	MODBUS_INPUT_REGISTER	403	1	rpm	5	0	0	0
-Max com­pressor speed (EB101)	MODBUS_INPUT_REGISTER	404	10	Hz	5	0	0	0
-Min com­pressor speed (EB101)	MODBUS_INPUT_REGISTER	405	10	Hz	5	0	0	0
+Max compressor speed (EB101)	MODBUS_INPUT_REGISTER	404	10	Hz	5	0	0	0
+Min compressor speed (EB101)	MODBUS_INPUT_REGISTER	405	10	Hz	5	0	0	0
 Power (EB101)	MODBUS_INPUT_REGISTER	406	10	kW	5	0	0	0
-Time to defrost­ing (EB101)	MODBUS_INPUT_REGISTER	407	1	min	5	0	0	0
-Defrost­ing index (EB101)	MODBUS_INPUT_REGISTER	408	1		5	0	0	0
-Super­heat refer­ence EEV (EB101)	MODBUS_INPUT_REGISTER	409	10	°C	2	0	0	0
-Super­heat EEV (EB101)	MODBUS_INPUT_REGISTER	410	10	°C	2	0	0	0
+Time to defrosting (EB101)	MODBUS_INPUT_REGISTER	407	1	min	5	0	0	0
+Defrosting index (EB101)	MODBUS_INPUT_REGISTER	408	1		5	0	0	0
+Superheat reference EEV (EB101)	MODBUS_INPUT_REGISTER	409	10	°C	2	0	0	0
+Superheat EEV (EB101)	MODBUS_INPUT_REGISTER	410	10	°C	2	0	0	0
 EEV-ssh-error (EB101)	MODBUS_INPUT_REGISTER	411	10	°C	2	0	0	0
-Super­heat temp. refer­ence EEV (EB101)	MODBUS_INPUT_REGISTER	412	10	°C	2	0	0	0
+Superheat temp. reference EEV (EB101)	MODBUS_INPUT_REGISTER	412	10	°C	2	0	0	0
 Set point value EEV (EB101)	MODBUS_INPUT_REGISTER	413	10	°C	2	0	0	0
 EEV PV (EB101)	MODBUS_INPUT_REGISTER	414	10	°C	2	0	0	0
 EEV-te-error average open (EB101)	MODBUS_INPUT_REGISTER	415	10	°C	2	0	0	0
 Degree of opening EEV (EB101)	MODBUS_INPUT_REGISTER	416	1		5	0	0	0
-Super­heat refer­ence EVI (EB101)	MODBUS_INPUT_REGISTER	417	10	°C	2	0	0	0
-Super­heat EVI (EB101)	MODBUS_INPUT_REGISTER	418	10	°C	2	0	0	0
+Superheat reference EVI (EB101)	MODBUS_INPUT_REGISTER	417	10	°C	2	0	0	0
+Superheat EVI (EB101)	MODBUS_INPUT_REGISTER	418	10	°C	2	0	0	0
 EEV-ssh-error (EVI)(EB101)	MODBUS_INPUT_REGISTER	419	10	°C	2	0	0	0
-Super­heat temp. refer­ence EVI (EB101)	MODBUS_INPUT_REGISTER	420	10	°C	2	0	0	0
+Superheat temp. reference EVI (EB101)	MODBUS_INPUT_REGISTER	420	10	°C	2	0	0	0
 Set point value EVI (EB101)	MODBUS_INPUT_REGISTER	421	10	°C	2	0	0	0
 EVI PV (EB101)	MODBUS_INPUT_REGISTER	422	10	°C	2	0	0	0
 EEV-te-error average open in (EVI)(EB101)	MODBUS_INPUT_REGISTER	423	10	°C	2	0	0	0
@@ -225,80 +231,80 @@ id:861	MODBUS_INPUT_REGISTER	427	1		6	0	0	0
 id:862	MODBUS_INPUT_REGISTER	429	1		5	0	0	0
 Low press (EB108 BP8 dew)	MODBUS_INPUT_REGISTER	438	10	°C	2	0	0	0
 Hi press (EB108 BP9 dew)	MODBUS_INPUT_REGISTER	439	10	°C	2	0	0	0
-Injec­tion (EB108-BT81)	MODBUS_INPUT_REGISTER	440	10	°C	2	0	0	0
-Pres­sure sensor, injec­tion (EB108-BP11)	MODBUS_INPUT_REGISTER	441	10		2	0	0	0
-EVI pres­sure (EB108-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	442	10	°C	2	0	0	0
+Injection (EB108-BT81)	MODBUS_INPUT_REGISTER	440	10	°C	2	0	0	0
+Pressure sensor, injection (EB108-BP11)	MODBUS_INPUT_REGISTER	441	10		2	0	0	0
+EVI pressure (EB108-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	442	10	°C	2	0	0	0
 Fan status (EB108-EP14)	MODBUS_INPUT_REGISTER	444	1		4	0	0	0
 Fan rpm (EB108-EP14)	MODBUS_INPUT_REGISTER	445	1	rpm	5	0	0	0
 Low press (EB107 BP8 dew)	MODBUS_INPUT_REGISTER	454	10	°C	2	0	0	0
 Hi press (EB107 BP9 dew)	MODBUS_INPUT_REGISTER	455	10	°C	2	0	0	0
-Injec­tion (EB107-BT81)	MODBUS_INPUT_REGISTER	456	10	°C	2	0	0	0
-Pres­sure sensor, injec­tion (EB107-BP11)	MODBUS_INPUT_REGISTER	457	10		2	0	0	0
-EVI pres­sure (EB107-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	458	10	°C	2	0	0	0
+Injection (EB107-BT81)	MODBUS_INPUT_REGISTER	456	10	°C	2	0	0	0
+Pressure sensor, injection (EB107-BP11)	MODBUS_INPUT_REGISTER	457	10		2	0	0	0
+EVI pressure (EB107-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	458	10	°C	2	0	0	0
 Fan status (EB107-EP14)	MODBUS_INPUT_REGISTER	460	1		4	0	0	0
 Fan rpm (EB107-EP14)	MODBUS_INPUT_REGISTER	461	1	rpm	5	0	0	0
 Low press (EB106 BP8 dew)	MODBUS_INPUT_REGISTER	470	10	°C	2	0	0	0
 Hi press (EB106 BP9 dew)	MODBUS_INPUT_REGISTER	471	10	°C	2	0	0	0
-Injec­tion (EB106-BT81)	MODBUS_INPUT_REGISTER	472	10	°C	2	0	0	0
-Pres­sure sensor, injec­tion (EB106-BP11)	MODBUS_INPUT_REGISTER	473	10		2	0	0	0
-EVI pres­sure (EB106-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	474	10	°C	2	0	0	0
+Injection (EB106-BT81)	MODBUS_INPUT_REGISTER	472	10	°C	2	0	0	0
+Pressure sensor, injection (EB106-BP11)	MODBUS_INPUT_REGISTER	473	10		2	0	0	0
+EVI pressure (EB106-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	474	10	°C	2	0	0	0
 Fan status (EB106-EP14)	MODBUS_INPUT_REGISTER	476	1		4	0	0	0
 Fan rpm (EB106-EP14)	MODBUS_INPUT_REGISTER	477	1	rpm	5	0	0	0
 Low press (EB105 BP8 dew)	MODBUS_INPUT_REGISTER	486	10	°C	2	0	0	0
 Hi press (EB105 BP9 dew)	MODBUS_INPUT_REGISTER	487	10	°C	2	0	0	0
-Injec­tion (EB105-BT81)	MODBUS_INPUT_REGISTER	488	10	°C	2	0	0	0
-Pres­sure sensor, injec­tion (EB105-BP11)	MODBUS_INPUT_REGISTER	489	10		2	0	0	0
-EVI pres­sure (EB105-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	490	10	°C	2	0	0	0
+Injection (EB105-BT81)	MODBUS_INPUT_REGISTER	488	10	°C	2	0	0	0
+Pressure sensor, injection (EB105-BP11)	MODBUS_INPUT_REGISTER	489	10		2	0	0	0
+EVI pressure (EB105-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	490	10	°C	2	0	0	0
 Fan status (EB105-EP14)	MODBUS_INPUT_REGISTER	492	1		4	0	0	0
 Fan rpm (EB105-EP14)	MODBUS_INPUT_REGISTER	493	1	rpm	5	0	0	0
 Low press (EB104 BP8 dew)	MODBUS_INPUT_REGISTER	502	10	°C	2	0	0	0
 Hi press (EB104 BP9 dew)	MODBUS_INPUT_REGISTER	503	10	°C	2	0	0	0
-Injec­tion (EB104-BT81)	MODBUS_INPUT_REGISTER	504	10	°C	2	0	0	0
-Pres­sure sensor, injec­tion (EB104-BP11)	MODBUS_INPUT_REGISTER	505	10		2	0	0	0
-EVI pres­sure (EB104-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	506	10	°C	2	0	0	0
+Injection (EB104-BT81)	MODBUS_INPUT_REGISTER	504	10	°C	2	0	0	0
+Pressure sensor, injection (EB104-BP11)	MODBUS_INPUT_REGISTER	505	10		2	0	0	0
+EVI pressure (EB104-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	506	10	°C	2	0	0	0
 Fan status (EB104-EP14)	MODBUS_INPUT_REGISTER	508	1		4	0	0	0
 Fan rpm (EB104-EP14)	MODBUS_INPUT_REGISTER	509	1	rpm	5	0	0	0
 Low press (EB103 BP8 dew)	MODBUS_INPUT_REGISTER	518	10	°C	2	0	0	0
 Hi press (EB103 BP9 dew)	MODBUS_INPUT_REGISTER	519	10	°C	2	0	0	0
-Injec­tion (EB103-BT81)	MODBUS_INPUT_REGISTER	520	10	°C	2	0	0	0
-Pres­sure sensor, injec­tion (EB103-BP11)	MODBUS_INPUT_REGISTER	521	10		2	0	0	0
-EVI pres­sure (EB103-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	522	10	°C	2	0	0	0
+Injection (EB103-BT81)	MODBUS_INPUT_REGISTER	520	10	°C	2	0	0	0
+Pressure sensor, injection (EB103-BP11)	MODBUS_INPUT_REGISTER	521	10		2	0	0	0
+EVI pressure (EB103-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	522	10	°C	2	0	0	0
 Fan status (EB103-EP14)	MODBUS_INPUT_REGISTER	524	1		4	0	0	0
 Fan rpm (EB103-EP14)	MODBUS_INPUT_REGISTER	525	1	rpm	5	0	0	0
 Low press (EB102 BP8 dew)	MODBUS_INPUT_REGISTER	534	10	°C	2	0	0	0
 Hi press (EB102 BP9 dew)	MODBUS_INPUT_REGISTER	535	10	°C	2	0	0	0
-Injec­tion (EB102-BT81)	MODBUS_INPUT_REGISTER	536	10	°C	2	0	0	0
-Pres­sure sensor, injec­tion (EB102-EP14-BP11)	MODBUS_INPUT_REGISTER	537	10		2	0	0	0
-EVI pres­sure (EB102-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	538	10	°C	2	0	0	0
+Injection (EB102-BT81)	MODBUS_INPUT_REGISTER	536	10	°C	2	0	0	0
+Pressure sensor, injection (EB102-EP14-BP11)	MODBUS_INPUT_REGISTER	537	10		2	0	0	0
+EVI pressure (EB102-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	538	10	°C	2	0	0	0
 Fan status (EB102-EP14)	MODBUS_INPUT_REGISTER	540	1		4	0	0	0
 Fan rpm (EB102-EP14)	MODBUS_INPUT_REGISTER	541	1	rpm	5	0	0	0
 Low press (EB101 BP8 dew)	MODBUS_INPUT_REGISTER	550	10	°C	2	0	0	0
 Hi press (EB101 BP9 dew)	MODBUS_INPUT_REGISTER	551	10	°C	2	0	0	0
-Injec­tion (EB101-BT81)	MODBUS_INPUT_REGISTER	552	10	°C	2	0	0	0
-Pres­sure sensor, injec­tion (EB101-BP11)	MODBUS_INPUT_REGISTER	553	10		2	0	0	0
-EVI pres­sure (EB101-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	554	10	°C	2	0	0	0
-Evap­orator (EB101-BT84)	MODBUS_INPUT_REGISTER	555	10	°C	2	0	0	0
+Injection (EB101-BT81)	MODBUS_INPUT_REGISTER	552	10	°C	2	0	0	0
+Pressure sensor, injection (EB101-BP11)	MODBUS_INPUT_REGISTER	553	10		2	0	0	0
+EVI pressure (EB101-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	554	10	°C	2	0	0	0
+Evaporator (EB101-BT84)	MODBUS_INPUT_REGISTER	555	10	°C	2	0	0	0
 Fan status (EB101-EP14)	MODBUS_INPUT_REGISTER	556	1		4	0	0	0
 Fan rpm (EB101-EP14)	MODBUS_INPUT_REGISTER	557	1	rpm	5	0	0	0
-High con­denser out alarm (S135)	MODBUS_INPUT_REGISTER	575	1		5	0	0	0
-High con­denser in alarm (S135)	MODBUS_INPUT_REGISTER	576	1		5	0	0	0
+High condenser out alarm (S135)	MODBUS_INPUT_REGISTER	575	1		5	0	0	0
+High condenser in alarm (S135)	MODBUS_INPUT_REGISTER	576	1		5	0	0	0
 Average current (EME 10)	MODBUS_INPUT_REGISTER	578	10	A	2	0	0	0
-Oper­ating mode PV panels	MODBUS_INPUT_REGISTER	579	1		4	0	0	0
+Operating mode PV panels	MODBUS_INPUT_REGISTER	579	1		4	0	0	0
 EME lux mode without EME	MODBUS_INPUT_REGISTER	581	1		4	0	0	0
 Timer (EME)	MODBUS_INPUT_REGISTER	582	60	min	5	0	0	0
 Fan mode 4	MODBUS_INPUT_REGISTER	590	1	%	4	0	0	0
 Fan mode 3	MODBUS_INPUT_REGISTER	591	1	%	4	0	0	0
 Fan mode 2	MODBUS_INPUT_REGISTER	592	1	%	4	0	0	0
-Is the com­pressor acces­sible	MODBUS_INPUT_REGISTER	593	1		4	0	0	0
+Is the compressor accessible	MODBUS_INPUT_REGISTER	593	1		4	0	0	0
 Prio, hot water (OPT)	MODBUS_INPUT_REGISTER	604	1		4	0	0	0
-Permit (un­defined)	MODBUS_INPUT_REGISTER	683	1		4	0	0	0
-Permit (un­defined)	MODBUS_INPUT_REGISTER	684	1		4	0	0	0
-Permit (un­defined)	MODBUS_INPUT_REGISTER	685	1		4	0	0	0
-Permit (OPT 10) addi­tional heat	MODBUS_INPUT_REGISTER	686	1		4	0	0	0
+Permit (undefined)	MODBUS_INPUT_REGISTER	683	1		4	0	0	0
+Permit (undefined)	MODBUS_INPUT_REGISTER	684	1		4	0	0	0
+Permit (undefined)	MODBUS_INPUT_REGISTER	685	1		4	0	0	0
+Permit (OPT 10) additional heat	MODBUS_INPUT_REGISTER	686	1		4	0	0	0
 Permit ext. imm. heater step	MODBUS_INPUT_REGISTER	687	1		4	0	0	0
 Permit int. imm. heater step	MODBUS_INPUT_REGISTER	688	1		4	0	0	0
-Permit shunted addi­tional heat	MODBUS_INPUT_REGISTER	689	1		4	0	0	0
-Permit prior­itised addi­tional heat	MODBUS_INPUT_REGISTER	690	1		4	0	0	0
+Permit shunted additional heat	MODBUS_INPUT_REGISTER	689	1		4	0	0	0
+Permit prioritised additional heat	MODBUS_INPUT_REGISTER	690	1		4	0	0	0
 Permit (EB108-EP15)	MODBUS_INPUT_REGISTER	691	1		4	0	0	0
 Permit (EB107-EP15)	MODBUS_INPUT_REGISTER	692	1		4	0	0	0
 Permit (EB106-EP15)	MODBUS_INPUT_REGISTER	693	1		4	0	0	0
@@ -317,24 +323,24 @@ Permit (EB103-EP14)	MODBUS_INPUT_REGISTER	705	1		4	0	0	0
 Permit (EB102-EP14)	MODBUS_INPUT_REGISTER	706	1		4	0	0	0
 Permit (EB101-EP14)	MODBUS_INPUT_REGISTER	707	1		4	0	0	0
 Permit (EB100-EP14)	MODBUS_INPUT_REGISTER	708	1		4	0	0	0
-Smart energy source, prior­ity 7, start DM	MODBUS_INPUT_REGISTER	709	1		3	0	0	0
-Smart energy source, prior­ity 6, start DM	MODBUS_INPUT_REGISTER	711	1		3	0	0	0
-Smart energy source, prior­ity 5, start DM	MODBUS_INPUT_REGISTER	713	1		3	0	0	0
-Smart energy source, prior­ity 4, start DM	MODBUS_INPUT_REGISTER	715	1		3	0	0	0
-Smart energy source, prior­ity 3, start DM	MODBUS_INPUT_REGISTER	717	1		3	0	0	0
-Smart energy source, prior­ity 2, start DM	MODBUS_INPUT_REGISTER	719	1		3	0	0	0
-Smart energy source, prior­ity 1, start DM	MODBUS_INPUT_REGISTER	721	1		3	0	0	0
-Smart energy source, prior­ity 7, stop DM	MODBUS_INPUT_REGISTER	723	1		3	0	0	0
-Smart energy source, prior­ity 6, stop DM	MODBUS_INPUT_REGISTER	725	1		3	0	0	0
-Smart energy source, prior­ity 5, stop DM	MODBUS_INPUT_REGISTER	727	1		3	0	0	0
-Smart energy source, prior­ity 4, stop DM	MODBUS_INPUT_REGISTER	729	1		3	0	0	0
-Smart energy source, prior­ity 3, stop DM	MODBUS_INPUT_REGISTER	731	1		3	0	0	0
-Smart energy source, prior­ity 2, stop DM	MODBUS_INPUT_REGISTER	733	1		3	0	0	0
-Smart energy source, prior­ity 1, stop DM	MODBUS_INPUT_REGISTER	735	1		3	0	0	0
+Smart energy source, priority 7, start DM	MODBUS_INPUT_REGISTER	709	1		3	0	0	0
+Smart energy source, priority 6, start DM	MODBUS_INPUT_REGISTER	711	1		3	0	0	0
+Smart energy source, priority 5, start DM	MODBUS_INPUT_REGISTER	713	1		3	0	0	0
+Smart energy source, priority 4, start DM	MODBUS_INPUT_REGISTER	715	1		3	0	0	0
+Smart energy source, priority 3, start DM	MODBUS_INPUT_REGISTER	717	1		3	0	0	0
+Smart energy source, priority 2, start DM	MODBUS_INPUT_REGISTER	719	1		3	0	0	0
+Smart energy source, priority 1, start DM	MODBUS_INPUT_REGISTER	721	1		3	0	0	0
+Smart energy source, priority 7, stop DM	MODBUS_INPUT_REGISTER	723	1		3	0	0	0
+Smart energy source, priority 6, stop DM	MODBUS_INPUT_REGISTER	725	1		3	0	0	0
+Smart energy source, priority 5, stop DM	MODBUS_INPUT_REGISTER	727	1		3	0	0	0
+Smart energy source, priority 4, stop DM	MODBUS_INPUT_REGISTER	729	1		3	0	0	0
+Smart energy source, priority 3, stop DM	MODBUS_INPUT_REGISTER	731	1		3	0	0	0
+Smart energy source, priority 2, stop DM	MODBUS_INPUT_REGISTER	733	1		3	0	0	0
+Smart energy source, priority 1, stop DM	MODBUS_INPUT_REGISTER	735	1		3	0	0	0
 Smart energy source, DM minimum value	MODBUS_INPUT_REGISTER	737	1		3	0	0	0
 Collector in (EP12-BT57)	MODBUS_INPUT_REGISTER	743	10	°C	2	0	0	0
 Collector out (EP12-BT58)	MODBUS_INPUT_REGISTER	744	10	°C	2	0	0	0
-Exter­nal guide status	MODBUS_INPUT_REGISTER	745	1		4	0	0	0
+External guide status	MODBUS_INPUT_REGISTER	745	1		4	0	0	0
 Test guide value	MODBUS_INPUT_REGISTER	746	1		5	0	0	0
 Temp. lux forces start of hot water demand	MODBUS_INPUT_REGISTER	747	1		4	0	0	0
 Smart energy source, prio OPT10 for hot water	MODBUS_INPUT_REGISTER	757	1		4	0	0	0
@@ -342,20 +348,20 @@ Wood boiler activated	MODBUS_INPUT_REGISTER	759	1		4	0	0	0
 Max fan speed (EB108-F21x0)	MODBUS_INPUT_REGISTER	762	1	rpm	5	0	0	0
 Min fan speed (EB108)	MODBUS_INPUT_REGISTER	763	1	rpm	5	0	0	0
 Power (EB108-F21x0)	MODBUS_INPUT_REGISTER	766	10	kW	5	0	0	0
-Time to defrost­ing (EB108)	MODBUS_INPUT_REGISTER	767	1	min	5	0	0	0
-Defrost­ing index (EB108)	MODBUS_INPUT_REGISTER	768	1		5	0	0	0
-Super­heat refer­ence EEV (EB108)	MODBUS_INPUT_REGISTER	769	10	°C	2	0	0	0
-Super­heat EEV (EB108)	MODBUS_INPUT_REGISTER	770	10	°C	2	0	0	0
+Time to defrosting (EB108)	MODBUS_INPUT_REGISTER	767	1	min	5	0	0	0
+Defrosting index (EB108)	MODBUS_INPUT_REGISTER	768	1		5	0	0	0
+Superheat reference EEV (EB108)	MODBUS_INPUT_REGISTER	769	10	°C	2	0	0	0
+Superheat EEV (EB108)	MODBUS_INPUT_REGISTER	770	10	°C	2	0	0	0
 EEV-ssh-error (EB108)	MODBUS_INPUT_REGISTER	771	10	°C	2	0	0	0
-Super­heat temp. refer­ence EEV (EB108)	MODBUS_INPUT_REGISTER	772	10	°C	2	0	0	0
+Superheat temp. reference EEV (EB108)	MODBUS_INPUT_REGISTER	772	10	°C	2	0	0	0
 Set point value EEV (EB108)	MODBUS_INPUT_REGISTER	773	10	°C	2	0	0	0
 EEV PV (EB108)	MODBUS_INPUT_REGISTER	774	10	°C	2	0	0	0
 EEV-te-error average open (EB108)	MODBUS_INPUT_REGISTER	775	10	°C	2	0	0	0
 Degree of opening EEV (EB108)	MODBUS_INPUT_REGISTER	776	1		5	0	0	0
-Super­heat refer­ence EVI (EB108)	MODBUS_INPUT_REGISTER	777	10	°C	2	0	0	0
-Super­heat EVI (EB108)	MODBUS_INPUT_REGISTER	778	10	°C	2	0	0	0
+Superheat reference EVI (EB108)	MODBUS_INPUT_REGISTER	777	10	°C	2	0	0	0
+Superheat EVI (EB108)	MODBUS_INPUT_REGISTER	778	10	°C	2	0	0	0
 EEV-ssh-error (EVI)(EB108)	MODBUS_INPUT_REGISTER	779	10	°C	2	0	0	0
-Super­heat temp. refer­ence EVI (EB108)	MODBUS_INPUT_REGISTER	780	10	°C	2	0	0	0
+Superheat temp. reference EVI (EB108)	MODBUS_INPUT_REGISTER	780	10	°C	2	0	0	0
 Set point value EVI (EB108)	MODBUS_INPUT_REGISTER	781	10	°C	2	0	0	0
 EVI PV (EB108)	MODBUS_INPUT_REGISTER	782	10	°C	2	0	0	0
 EEV-te-error average open (EVI)(EB108)	MODBUS_INPUT_REGISTER	783	10	°C	2	0	0	0
@@ -363,20 +369,20 @@ Degree of opening EVI (EB108)	MODBUS_INPUT_REGISTER	784	1		5	0	0	0
 Max fan speed (EB107)	MODBUS_INPUT_REGISTER	787	1	rpm	5	0	0	0
 Min fan speed (EB107)	MODBUS_INPUT_REGISTER	788	1	rpm	5	0	0	0
 Power (EB107-F21x0)	MODBUS_INPUT_REGISTER	791	10	kW	5	0	0	0
-Time to defrost­ing (EB107)	MODBUS_INPUT_REGISTER	792	1	min	5	0	0	0
-Defrost­ing index (EB107)	MODBUS_INPUT_REGISTER	793	1		5	0	0	0
-Super­heat refer­ence EEV (EB107)	MODBUS_INPUT_REGISTER	794	10	°C	2	0	0	0
-Super­heat EEV (EB107)	MODBUS_INPUT_REGISTER	795	10	°C	2	0	0	0
+Time to defrosting (EB107)	MODBUS_INPUT_REGISTER	792	1	min	5	0	0	0
+Defrosting index (EB107)	MODBUS_INPUT_REGISTER	793	1		5	0	0	0
+Superheat reference EEV (EB107)	MODBUS_INPUT_REGISTER	794	10	°C	2	0	0	0
+Superheat EEV (EB107)	MODBUS_INPUT_REGISTER	795	10	°C	2	0	0	0
 EEV-ssh-error (EB107)	MODBUS_INPUT_REGISTER	796	10	°C	2	0	0	0
-Super­heat temp. refer­ence EEV (EB107)	MODBUS_INPUT_REGISTER	797	10	°C	2	0	0	0
+Superheat temp. reference EEV (EB107)	MODBUS_INPUT_REGISTER	797	10	°C	2	0	0	0
 Set point value EEV (EB107)	MODBUS_INPUT_REGISTER	798	10	°C	2	0	0	0
 EEV PV (EB107)	MODBUS_INPUT_REGISTER	799	10	°C	2	0	0	0
 EEV-te-error average open (EB107)	MODBUS_INPUT_REGISTER	800	10	°C	2	0	0	0
 Degree of opening EEV (EB107)	MODBUS_INPUT_REGISTER	801	1		5	0	0	0
-Super­heat refer­ence EVI (EB107)	MODBUS_INPUT_REGISTER	802	10	°C	2	0	0	0
-Super­heat EVI (EB107)	MODBUS_INPUT_REGISTER	803	10	°C	2	0	0	0
+Superheat reference EVI (EB107)	MODBUS_INPUT_REGISTER	802	10	°C	2	0	0	0
+Superheat EVI (EB107)	MODBUS_INPUT_REGISTER	803	10	°C	2	0	0	0
 EEV-ssh-error (EVI)(EB107)	MODBUS_INPUT_REGISTER	804	10	°C	2	0	0	0
-Super­heat temp. refer­ence EVI (EB107)	MODBUS_INPUT_REGISTER	805	10	°C	2	0	0	0
+Superheat temp. reference EVI (EB107)	MODBUS_INPUT_REGISTER	805	10	°C	2	0	0	0
 Set point value EVI (EB107)	MODBUS_INPUT_REGISTER	806	10	°C	2	0	0	0
 EVI PV (EB107)	MODBUS_INPUT_REGISTER	807	10	°C	2	0	0	0
 EEV-te-error average open (EVI)(EB107)	MODBUS_INPUT_REGISTER	808	10	°C	2	0	0	0
@@ -384,20 +390,20 @@ Degree of opening EVI (EB107)	MODBUS_INPUT_REGISTER	809	1		5	0	0	0
 Max fan speed (EB106)	MODBUS_INPUT_REGISTER	812	1	rpm	5	0	0	0
 id:1309	MODBUS_INPUT_REGISTER	813	1	rpm	5	0	0	0
 power (EB106)	MODBUS_INPUT_REGISTER	816	10	kW	5	0	0	0
-Time to defrost­ing (EB106)	MODBUS_INPUT_REGISTER	817	1	min	5	0	0	0
-Defrost­ing index (EB106)	MODBUS_INPUT_REGISTER	818	1		5	0	0	0
-Super­heat refer­ence EEV (EB106)	MODBUS_INPUT_REGISTER	819	10	°C	2	0	0	0
-Super­heat EEV (EB106)	MODBUS_INPUT_REGISTER	820	10	°C	2	0	0	0
+Time to defrosting (EB106)	MODBUS_INPUT_REGISTER	817	1	min	5	0	0	0
+Defrosting index (EB106)	MODBUS_INPUT_REGISTER	818	1		5	0	0	0
+Superheat reference EEV (EB106)	MODBUS_INPUT_REGISTER	819	10	°C	2	0	0	0
+Superheat EEV (EB106)	MODBUS_INPUT_REGISTER	820	10	°C	2	0	0	0
 EEV-ssh-error (EB106)	MODBUS_INPUT_REGISTER	821	10	°C	2	0	0	0
-Super­heat temp. refer­ence EEV (EB106)	MODBUS_INPUT_REGISTER	822	10	°C	2	0	0	0
+Superheat temp. reference EEV (EB106)	MODBUS_INPUT_REGISTER	822	10	°C	2	0	0	0
 Set point value EEV (EB106)	MODBUS_INPUT_REGISTER	823	10	°C	2	0	0	0
 EEV PV (EB106)	MODBUS_INPUT_REGISTER	824	10	°C	2	0	0	0
 EEV-te-error average open (EB106)	MODBUS_INPUT_REGISTER	825	10	°C	2	0	0	0
 Degree of opening EEV (EB106)	MODBUS_INPUT_REGISTER	826	1		5	0	0	0
-Super­heat refer­ence EVI (EB106)	MODBUS_INPUT_REGISTER	827	10	°C	2	0	0	0
-Super­heat EVI (EB106)	MODBUS_INPUT_REGISTER	828	10	°C	2	0	0	0
+Superheat reference EVI (EB106)	MODBUS_INPUT_REGISTER	827	10	°C	2	0	0	0
+Superheat EVI (EB106)	MODBUS_INPUT_REGISTER	828	10	°C	2	0	0	0
 EEV-ssh-error (EVI)(EB106)	MODBUS_INPUT_REGISTER	829	10	°C	2	0	0	0
-Super­heat temp. refer­ence EVI (EB106)	MODBUS_INPUT_REGISTER	830	10	°C	2	0	0	0
+Superheat temp. reference EVI (EB106)	MODBUS_INPUT_REGISTER	830	10	°C	2	0	0	0
 Set point value EVI (EB106)	MODBUS_INPUT_REGISTER	831	10	°C	2	0	0	0
 EVI PV (EB106)	MODBUS_INPUT_REGISTER	832	10	°C	2	0	0	0
 EEV-te-error average open (EVI)(EB106)	MODBUS_INPUT_REGISTER	833	10	°C	2	0	0	0
@@ -405,20 +411,20 @@ Degree of opening EVI (EB106)	MODBUS_INPUT_REGISTER	834	1		5	0	0	0
 Max fan speed (EB105)	MODBUS_INPUT_REGISTER	837	1	rpm	5	0	0	0
 Min fan speed (EB105)	MODBUS_INPUT_REGISTER	838	1	rpm	5	0	0	0
 Power (EB105)	MODBUS_INPUT_REGISTER	841	10	kW	5	0	0	0
-Time to defrost­ing (EB105)	MODBUS_INPUT_REGISTER	842	1	min	5	0	0	0
-Defrost­ing index (EB105)	MODBUS_INPUT_REGISTER	843	1		5	0	0	0
-Super­heat refer­ence EEV (EB105)	MODBUS_INPUT_REGISTER	844	10	°C	2	0	0	0
-Super­heat EEV (EB105)	MODBUS_INPUT_REGISTER	845	10	°C	2	0	0	0
+Time to defrosting (EB105)	MODBUS_INPUT_REGISTER	842	1	min	5	0	0	0
+Defrosting index (EB105)	MODBUS_INPUT_REGISTER	843	1		5	0	0	0
+Superheat reference EEV (EB105)	MODBUS_INPUT_REGISTER	844	10	°C	2	0	0	0
+Superheat EEV (EB105)	MODBUS_INPUT_REGISTER	845	10	°C	2	0	0	0
 EEV-ssh-error (EB105)	MODBUS_INPUT_REGISTER	846	10	°C	2	0	0	0
-Super­heat temp. refer­ence EEV (EB105)	MODBUS_INPUT_REGISTER	847	10	°C	2	0	0	0
+Superheat temp. reference EEV (EB105)	MODBUS_INPUT_REGISTER	847	10	°C	2	0	0	0
 Set point value EEV (EB105)	MODBUS_INPUT_REGISTER	848	10	°C	2	0	0	0
 EEV PV (EB105)	MODBUS_INPUT_REGISTER	849	10	°C	2	0	0	0
 EEV-te-error average open (EB105)	MODBUS_INPUT_REGISTER	850	10	°C	2	0	0	0
 Degree of opening EEV (EB105)	MODBUS_INPUT_REGISTER	851	1		5	0	0	0
-Super­heat refer­ence EVI (EB105)	MODBUS_INPUT_REGISTER	852	10	°C	2	0	0	0
-Super­heat EVI (EB105)	MODBUS_INPUT_REGISTER	853	10	°C	2	0	0	0
+Superheat reference EVI (EB105)	MODBUS_INPUT_REGISTER	852	10	°C	2	0	0	0
+Superheat EVI (EB105)	MODBUS_INPUT_REGISTER	853	10	°C	2	0	0	0
 EEV-ssh-error (EVI)(EB105)	MODBUS_INPUT_REGISTER	854	10	°C	2	0	0	0
-Super­heat temp. refer­ence EVI (EB105)	MODBUS_INPUT_REGISTER	855	10	°C	2	0	0	0
+Superheat temp. reference EVI (EB105)	MODBUS_INPUT_REGISTER	855	10	°C	2	0	0	0
 Set point value EVI (EB105)	MODBUS_INPUT_REGISTER	856	10	°C	2	0	0	0
 EVI PV (EB105)	MODBUS_INPUT_REGISTER	857	10	°C	2	0	0	0
 EEV-te-error average open (EVI)(EB105)	MODBUS_INPUT_REGISTER	858	10	°C	2	0	0	0
@@ -426,20 +432,20 @@ Degree of opening EVI (EB105)	MODBUS_INPUT_REGISTER	859	1		5	0	0	0
 Max fan speed (EB104)	MODBUS_INPUT_REGISTER	862	1	rpm	5	0	0	0
 Min fan speed (EB104)	MODBUS_INPUT_REGISTER	863	1	rpm	5	0	0	0
 Power (EB104)	MODBUS_INPUT_REGISTER	866	10	kW	5	0	0	0
-Time to defrost­ing (EB104)	MODBUS_INPUT_REGISTER	867	1	min	5	0	0	0
-Defrost­ing index (EB104)	MODBUS_INPUT_REGISTER	868	1		5	0	0	0
-Super­heat refer­ence EEV (EB104)	MODBUS_INPUT_REGISTER	869	10	°C	2	0	0	0
-Super­heat EEV (EB104)	MODBUS_INPUT_REGISTER	870	10	°C	2	0	0	0
+Time to defrosting (EB104)	MODBUS_INPUT_REGISTER	867	1	min	5	0	0	0
+Defrosting index (EB104)	MODBUS_INPUT_REGISTER	868	1		5	0	0	0
+Superheat reference EEV (EB104)	MODBUS_INPUT_REGISTER	869	10	°C	2	0	0	0
+Superheat EEV (EB104)	MODBUS_INPUT_REGISTER	870	10	°C	2	0	0	0
 EEV-ssh-error (EB104)	MODBUS_INPUT_REGISTER	871	10	°C	2	0	0	0
-Super­heat temp. refer­ence EEV (EB104)	MODBUS_INPUT_REGISTER	872	10	°C	2	0	0	0
+Superheat temp. reference EEV (EB104)	MODBUS_INPUT_REGISTER	872	10	°C	2	0	0	0
 Set point value EEV (EB104)	MODBUS_INPUT_REGISTER	873	10	°C	2	0	0	0
 EEV PV (EB104)	MODBUS_INPUT_REGISTER	874	10	°C	2	0	0	0
 EEV-te-error average open (EB104)	MODBUS_INPUT_REGISTER	875	10	°C	2	0	0	0
 Degree of opening EEV (EB104)	MODBUS_INPUT_REGISTER	876	1		5	0	0	0
-Super­heat refer­ence EVI (EB104)	MODBUS_INPUT_REGISTER	877	10	°C	2	0	0	0
-Super­heat EVI (EB104)	MODBUS_INPUT_REGISTER	878	10	°C	2	0	0	0
+Superheat reference EVI (EB104)	MODBUS_INPUT_REGISTER	877	10	°C	2	0	0	0
+Superheat EVI (EB104)	MODBUS_INPUT_REGISTER	878	10	°C	2	0	0	0
 EEV-ssh-error (EVI)(EB104)	MODBUS_INPUT_REGISTER	879	10	°C	2	0	0	0
-Super­heat temp. refer­ence EVI (EB104)	MODBUS_INPUT_REGISTER	880	10	°C	2	0	0	0
+Superheat temp. reference EVI (EB104)	MODBUS_INPUT_REGISTER	880	10	°C	2	0	0	0
 Set point value EVI (EB104)	MODBUS_INPUT_REGISTER	881	10	°C	2	0	0	0
 EVI PV (EB104)	MODBUS_INPUT_REGISTER	882	10	°C	2	0	0	0
 EEV-te-error average open (EVI)(EB104)	MODBUS_INPUT_REGISTER	883	10	°C	2	0	0	0
@@ -447,20 +453,20 @@ Degree of opening EVI (EB104)	MODBUS_INPUT_REGISTER	884	1		5	0	0	0
 Max fan speed (EB103)	MODBUS_INPUT_REGISTER	887	1	rpm	5	0	0	0
 Min fan speed (EB103)	MODBUS_INPUT_REGISTER	888	1	rpm	5	0	0	0
 Power (EB103)	MODBUS_INPUT_REGISTER	891	10	kW	5	0	0	0
-Time to defrost­ing (EB103)	MODBUS_INPUT_REGISTER	892	1	min	5	0	0	0
-Defrost­ing index (EB103)	MODBUS_INPUT_REGISTER	893	1		5	0	0	0
-Super­heat refer­ence EEV (EB103)	MODBUS_INPUT_REGISTER	894	10	°C	2	0	0	0
-Super­heat EEV (EB103)	MODBUS_INPUT_REGISTER	895	10	°C	2	0	0	0
+Time to defrosting (EB103)	MODBUS_INPUT_REGISTER	892	1	min	5	0	0	0
+Defrosting index (EB103)	MODBUS_INPUT_REGISTER	893	1		5	0	0	0
+Superheat reference EEV (EB103)	MODBUS_INPUT_REGISTER	894	10	°C	2	0	0	0
+Superheat EEV (EB103)	MODBUS_INPUT_REGISTER	895	10	°C	2	0	0	0
 EEV-ssh-error (EB103)	MODBUS_INPUT_REGISTER	896	10	°C	2	0	0	0
-Super­heat temp. refer­ence EEV (EB103)	MODBUS_INPUT_REGISTER	897	10	°C	2	0	0	0
+Superheat temp. reference EEV (EB103)	MODBUS_INPUT_REGISTER	897	10	°C	2	0	0	0
 Set point value EEV (EB103)	MODBUS_INPUT_REGISTER	898	10	°C	2	0	0	0
 EEV PV (EB103)	MODBUS_INPUT_REGISTER	899	10	°C	2	0	0	0
 EEV-te-error average open (EB103)	MODBUS_INPUT_REGISTER	900	10	°C	2	0	0	0
 Degree of opening EEV (EB103)	MODBUS_INPUT_REGISTER	901	1		5	0	0	0
-Super­heat refer­ence EVI (EB103)	MODBUS_INPUT_REGISTER	902	10	°C	2	0	0	0
-Super­heat EVI (EB103)	MODBUS_INPUT_REGISTER	903	10	°C	2	0	0	0
+Superheat reference EVI (EB103)	MODBUS_INPUT_REGISTER	902	10	°C	2	0	0	0
+Superheat EVI (EB103)	MODBUS_INPUT_REGISTER	903	10	°C	2	0	0	0
 EEV-ssh-error (EVI)(EB103)	MODBUS_INPUT_REGISTER	904	10	°C	2	0	0	0
-Super­heat temp. refer­ence EVI (EB103)	MODBUS_INPUT_REGISTER	905	10	°C	2	0	0	0
+Superheat temp. reference EVI (EB103)	MODBUS_INPUT_REGISTER	905	10	°C	2	0	0	0
 Set point value EVI (EB103)	MODBUS_INPUT_REGISTER	906	10	°C	2	0	0	0
 EVI PV (EB103)	MODBUS_INPUT_REGISTER	907	10	°C	2	0	0	0
 EEV-te-error average open (EVI)(EB103)	MODBUS_INPUT_REGISTER	908	10	°C	2	0	0	0
@@ -469,73 +475,73 @@ Fan speed (EB102)	MODBUS_INPUT_REGISTER	911	1	rpm	5	0	0	0
 Max fan speed (EB102)	MODBUS_INPUT_REGISTER	912	1	rpm	5	0	0	0
 Min fan speed (EB102)	MODBUS_INPUT_REGISTER	913	1	rpm	5	0	0	0
 Power (EB102)	MODBUS_INPUT_REGISTER	916	10	kW	5	0	0	0
-Time to defrost­ing (EB102)	MODBUS_INPUT_REGISTER	917	1	min	5	0	0	0
-Defrost­ing index (EB102)	MODBUS_INPUT_REGISTER	918	1		5	0	0	0
-Super­heat refer­ence EEV (EB102)	MODBUS_INPUT_REGISTER	919	10	°C	2	0	0	0
-Super­heat EEV (EB102)	MODBUS_INPUT_REGISTER	920	10	°C	2	0	0	0
+Time to defrosting (EB102)	MODBUS_INPUT_REGISTER	917	1	min	5	0	0	0
+Defrosting index (EB102)	MODBUS_INPUT_REGISTER	918	1		5	0	0	0
+Superheat reference EEV (EB102)	MODBUS_INPUT_REGISTER	919	10	°C	2	0	0	0
+Superheat EEV (EB102)	MODBUS_INPUT_REGISTER	920	10	°C	2	0	0	0
 EEV-ssh-error (EB102)	MODBUS_INPUT_REGISTER	921	10	°C	2	0	0	0
-Super­heat temp. refer­ence EEV (EB101)	MODBUS_INPUT_REGISTER	922	10	°C	2	0	0	0
+Superheat temp. reference EEV (EB101)	MODBUS_INPUT_REGISTER	922	10	°C	2	0	0	0
 Set point value EEV (EB102)	MODBUS_INPUT_REGISTER	923	10	°C	2	0	0	0
 EEV PV (EB102)	MODBUS_INPUT_REGISTER	924	10	°C	2	0	0	0
 EEV-te-error average open (EB102)	MODBUS_INPUT_REGISTER	925	10	°C	2	0	0	0
 Degree of opening EEV (EB102)	MODBUS_INPUT_REGISTER	926	1		5	0	0	0
-Super­heat refer­ence EVI (EB102)	MODBUS_INPUT_REGISTER	927	10	°C	2	0	0	0
-Super­heat EVI (EB102)	MODBUS_INPUT_REGISTER	928	10	°C	2	0	0	0
+Superheat reference EVI (EB102)	MODBUS_INPUT_REGISTER	927	10	°C	2	0	0	0
+Superheat EVI (EB102)	MODBUS_INPUT_REGISTER	928	10	°C	2	0	0	0
 EEV-ssh-error (EVI)(EB102)	MODBUS_INPUT_REGISTER	929	10	°C	2	0	0	0
-Super­heat temp. refer­ence EVI (EB102)	MODBUS_INPUT_REGISTER	930	10	°C	2	0	0	0
+Superheat temp. reference EVI (EB102)	MODBUS_INPUT_REGISTER	930	10	°C	2	0	0	0
 Set point value EVI (EB102)	MODBUS_INPUT_REGISTER	931	10	°C	2	0	0	0
 EVI PV (EB102)	MODBUS_INPUT_REGISTER	932	10	°C	2	0	0	0
 EEV-te-error average open (EVI)(EB102)	MODBUS_INPUT_REGISTER	933	10	°C	2	0	0	0
 Degree of opening EVI (EB102)	MODBUS_INPUT_REGISTER	934	1		5	0	0	0
-Smart energy source, prior­ity select. in hot water	MODBUS_INPUT_REGISTER	991	1		4	0	0	0
-Outd. air heat pump, inver­ter, limits	MODBUS_INPUT_REGISTER	992	1		4	0	0	0
-Outd. air heat pump, inver­ter, speed reduc­ing	MODBUS_INPUT_REGISTER	993	1		4	0	0	0
+Smart energy source, priority select. in hot water	MODBUS_INPUT_REGISTER	991	1		4	0	0	0
+Outd. air heat pump, inverter, limits	MODBUS_INPUT_REGISTER	992	1		4	0	0	0
+Outd. air heat pump, inverter, speed reducing	MODBUS_INPUT_REGISTER	993	1		4	0	0	0
 Has one phase (EB101)	MODBUS_INPUT_REGISTER	1008	1		4	0	0	0
 Serial index (EB101)	MODBUS_INPUT_REGISTER	1009	1		4	0	0	0
 Limit DM	MODBUS_HOLDING_REGISTER	18	10	DM	2	-30000	30000	0
-Calcu­lated supply climate system 1	MODBUS_INPUT_REGISTER	1017	10	°C	2	0	0	0
+Calculated supply climate system 1	MODBUS_INPUT_REGISTER	1017	10	°C	2	0	0	0
 Class 1 alarm	MODBUS_INPUT_REGISTER	2195	1		4	0	0	0
-Frost protec­tion status	MODBUS_INPUT_REGISTER	1018	1		5	0	0	0
+Frost protection status	MODBUS_INPUT_REGISTER	1018	1		5	0	0	0
 Cooling status	MODBUS_INPUT_REGISTER	1019	1		4	0	0	0
 id:1726	MODBUS_HOLDING_REGISTER	2757	1		2	0	30000	0
-Total run time addi­tional heat	MODBUS_INPUT_REGISTER	1025	10	h	3	0	1000000	0
+Total run time additional heat	MODBUS_INPUT_REGISTER	1025	10	h	3	0	1000000	0
 Priority	MODBUS_INPUT_REGISTER	1028	1		4	0	0	0
-Oper­ating mode internal add. heat	MODBUS_INPUT_REGISTER	1029	1		4	0	0	0
+Operating mode internal add. heat	MODBUS_INPUT_REGISTER	1029	1		4	0	0	0
 Oper. mode shunt climate system 4	MODBUS_INPUT_REGISTER	1030	1		4	0	0	0
 Oper. mode shunt climate system 3	MODBUS_INPUT_REGISTER	1031	1		4	0	0	0
 Oper. mode shunt climate system 2	MODBUS_INPUT_REGISTER	1032	1		4	0	0	0
 Oper. mode shunt climate system 1	MODBUS_INPUT_REGISTER	1033	1		4	0	0	0
-Oper­ating. mode shunt con­trolled addi­tional heat	MODBUS_INPUT_REGISTER	1034	1		4	0	0	0
+Operating. mode shunt controlled additional heat	MODBUS_INPUT_REGISTER	1034	1		4	0	0	0
 Fan mode 1	MODBUS_INPUT_REGISTER	1037	1	%	4	0	0	0
 Current hot water mode	MODBUS_INPUT_REGISTER	1038	1		1	0	0	0
 Blocking cooling	MODBUS_INPUT_REGISTER	1053	1		4	0	0	0
-Exter­nal adjust­ment climate system 4	MODBUS_INPUT_REGISTER	1054	1		4	0	0	0
-Exter­nal adjust­ment climate system 3	MODBUS_INPUT_REGISTER	1055	1		4	0	0	0
-Exter­nal adjust­ment climate system 2	MODBUS_INPUT_REGISTER	1056	1		4	0	0	0
-Exter­nal adjust­ment climate system 1	MODBUS_INPUT_REGISTER	1057	1		4	0	0	0
-Exter­nal block­ing	MODBUS_INPUT_REGISTER	1058	1		4	0	0	0
+External adjustment climate system 4	MODBUS_INPUT_REGISTER	1054	1		4	0	0	0
+External adjustment climate system 3	MODBUS_INPUT_REGISTER	1055	1		4	0	0	0
+External adjustment climate system 2	MODBUS_INPUT_REGISTER	1056	1		4	0	0	0
+External adjustment climate system 1	MODBUS_INPUT_REGISTER	1057	1		4	0	0	0
+External blocking	MODBUS_INPUT_REGISTER	1058	1		4	0	0	0
 Blocked	MODBUS_INPUT_REGISTER	1059	1		4	0	0	0
-Exter­nal block­ing, active cooling (HPAC)	MODBUS_INPUT_REGISTER	1060	1		4	0	0	0
-Exter­nal block­ing, passive cooling (HPAC)	MODBUS_INPUT_REGISTER	1061	1		4	0	0	0
+External blocking, active cooling (HPAC)	MODBUS_INPUT_REGISTER	1060	1		4	0	0	0
+External blocking, passive cooling (HPAC)	MODBUS_INPUT_REGISTER	1061	1		4	0	0	0
 Step controlled add. heat blocking	MODBUS_INPUT_REGISTER	1062	1		4	0	0	0
-Exter­nal heating medium pump (GP10) status	MODBUS_INPUT_REGISTER	1066	1		4	0	0	0
+External heating medium pump (GP10) status	MODBUS_INPUT_REGISTER	1066	1		4	0	0	0
 Energy meter	MODBUS_INPUT_REGISTER	1067	10	kWh	6	0	9999999	0
-Total HW run time addi­tional heat	MODBUS_INPUT_REGISTER	1069	10	h	3	0	9999999	0
+Total HW run time additional heat	MODBUS_INPUT_REGISTER	1069	10	h	3	0	9999999	0
 More hot water status	MODBUS_INPUT_REGISTER	1078	1		4	0	0	0
 Relay status (HPAC)	MODBUS_INPUT_REGISTER	1079	1		4	0	0	0
 Holiday function status	MODBUS_HOLDING_REGISTER	19	1		1	0	0	0
 Docked compressors heating	MODBUS_INPUT_REGISTER	1108	1		4	0	0	0
-Docked compres­sors hot water	MODBUS_INPUT_REGISTER	1109	1		4	0	0	0
+Docked compressors hot water	MODBUS_INPUT_REGISTER	1109	1		4	0	0	0
 Docked compressors pool 1	MODBUS_INPUT_REGISTER	1110	1		4	0	0	0
-Revers­ing valve hot water (QN10)	MODBUS_INPUT_REGISTER	2196	1		4	0	0	0
+Reversing valve hot water (QN10)	MODBUS_INPUT_REGISTER	2196	1		4	0	0	0
 Relay status, base board (EB100-EP14)	MODBUS_INPUT_REGISTER	1117	1		4	0	0	0
 Relay status, imm. heat. board (EB100-EP14)	MODBUS_INPUT_REGISTER	1119	1		4	0	0	0
 Current status	MODBUS_INPUT_REGISTER	1120	1		6	0	0	0
-Func­tional­ity, heat pump (EP14)	MODBUS_INPUT_REGISTER	1122	1		6	0	0	0
+Functionality, heat pump (EP14)	MODBUS_INPUT_REGISTER	1122	1		6	0	0	0
 Active heat pumps	MODBUS_INPUT_REGISTER	1124	1		5	0	0	0
-Func­tional­ity, heat pump (EP15)	MODBUS_INPUT_REGISTER	1125	1		6	0	0	0
-Oper­ating mode HW comfort	MODBUS_INPUT_REGISTER	1129	1		4	0	0	0
-Oper­ating mode HW comfort addi­tional heat	MODBUS_INPUT_REGISTER	1130	1		4	0	0	0
+Functionality, heat pump (EP15)	MODBUS_INPUT_REGISTER	1125	1		6	0	0	0
+Operating mode HW comfort	MODBUS_INPUT_REGISTER	1129	1		4	0	0	0
+Operating mode HW comfort additional heat	MODBUS_INPUT_REGISTER	1130	1		4	0	0	0
 Blocked	MODBUS_INPUT_REGISTER	1131	1		4	0	0	0
 Blocked	MODBUS_INPUT_REGISTER	1132	1		4	0	0	0
 Pool 2 (QN19)	MODBUS_INPUT_REGISTER	1133	1		4	0	0	0
@@ -543,150 +549,150 @@ Pool 1 (QN19)	MODBUS_INPUT_REGISTER	1134	1		4	0	0	0
 Docked compressors pool 2	MODBUS_INPUT_REGISTER	1135	1		4	0	0	0
 Version (EB101)	MODBUS_INPUT_REGISTER	1451	1		5	0	0	0
 Heat pump type (EB101)	MODBUS_INPUT_REGISTER	1452	1		4	0	0	0
-Com­pressor size (EB101)	MODBUS_INPUT_REGISTER	1453	1		4	0	0	0
+Compressor size (EB101)	MODBUS_INPUT_REGISTER	1453	1		4	0	0	0
 Return line (EB101-BT3)	MODBUS_INPUT_REGISTER	1475	10	°C	2	0	0	0
 Supply line (EB101-BT12)	MODBUS_INPUT_REGISTER	1478	10	°C	2	0	0	0
-Dis­charge (EB101-BT14)	MODBUS_INPUT_REGISTER	1479	10	°C	2	0	0	0
+Discharge (EB101-BT14)	MODBUS_INPUT_REGISTER	1479	10	°C	2	0	0	0
 Liquid line (EB101-BT15)	MODBUS_INPUT_REGISTER	1480	10	°C	2	0	0	0
 Suction gas (EB101-BT17)	MODBUS_INPUT_REGISTER	1481	10	°C	2	0	0	0
-Compres­sor sensor (EB101-BT29)	MODBUS_INPUT_REGISTER	1482	10	°C	2	0	0	0
-Compres­sor status (EB101)	MODBUS_INPUT_REGISTER	1484	1		4	0	0	0
-Com­pressor, time to start (EB101-EP14)	MODBUS_INPUT_REGISTER	1485	1	min	4	0	0	0
+Compressor sensor (EB101-BT29)	MODBUS_INPUT_REGISTER	1482	10	°C	2	0	0	0
+Compressor status (EB101)	MODBUS_INPUT_REGISTER	1484	1		4	0	0	0
+Compressor, time to start (EB101-EP14)	MODBUS_INPUT_REGISTER	1485	1	min	4	0	0	0
 Relay status (EB101-EP14)	MODBUS_INPUT_REGISTER	1486	1		5	0	0	0
-Com­pressor, number of starts (EB101-EP14)	MODBUS_INPUT_REGISTER	1489	1		6	-2147483648	2147483647	0
-Com­pressor, oper. time, total (EB101-EP14)	MODBUS_INPUT_REGISTER	1491	1	h	6	-2147483648	2147483647	0
-Com­pressor, oper. time, hot water (EB101-EP14)	MODBUS_INPUT_REGISTER	1493	1	h	6	-2147483648	2147483647	0
+Compressor, number of starts (EB101-EP14)	MODBUS_INPUT_REGISTER	1489	1		6	-2147483648	2147483647	0
+Compressor, oper. time, total (EB101-EP14)	MODBUS_INPUT_REGISTER	1491	1	h	6	-2147483648	2147483647	0
+Compressor, oper. time, hot water (EB101-EP14)	MODBUS_INPUT_REGISTER	1493	1	h	6	-2147483648	2147483647	0
 Alarm number (EB101-EP14)	MODBUS_INPUT_REGISTER	1495	1		5	0	0	0
 Version (EB100)	MODBUS_INPUT_REGISTER	1496	1		5	0	0	0
 Heat pump type (EB100)	MODBUS_INPUT_REGISTER	1497	1		4	0	0	0
-Com­pressor size (EB100)	MODBUS_INPUT_REGISTER	1498	1		4	0	0	0
-Com­pressor, oper. time, total (EB100-EP15)	MODBUS_INPUT_REGISTER	1515	1	h	6	0	0	0
-Com­pressor, oper. time, hot water (EB100-EP15)	MODBUS_INPUT_REGISTER	1517	1	h	6	0	0	0
+Compressor size (EB100)	MODBUS_INPUT_REGISTER	1498	1		4	0	0	0
+Compressor, oper. time, total (EB100-EP15)	MODBUS_INPUT_REGISTER	1515	1	h	6	0	0	0
+Compressor, oper. time, hot water (EB100-EP15)	MODBUS_INPUT_REGISTER	1517	1	h	6	0	0	0
 Return line (EB100-BT3)	MODBUS_INPUT_REGISTER	1520	10	°C	2	0	0	0
 Brine sensor in (EB100-BT10)	MODBUS_INPUT_REGISTER	1521	10	°C	2	0	0	0
 Brine sensor out (EB100-BT11)	MODBUS_INPUT_REGISTER	1522	10	°C	2	0	0	0
-Con­denser (EB100-BT2)	MODBUS_INPUT_REGISTER	1523	10	°C	2	0	0	0
-Dis­charge sensor (EB100-BT14)	MODBUS_INPUT_REGISTER	1524	10	°C	2	0	0	0
+Condenser (EB100-BT2)	MODBUS_INPUT_REGISTER	1523	10	°C	2	0	0	0
+Discharge sensor (EB100-BT14)	MODBUS_INPUT_REGISTER	1524	10	°C	2	0	0	0
 Liquid line sensor (EB100-BT15)	MODBUS_INPUT_REGISTER	1525	10	°C	2	0	0	0
 Suction gas sensor (EB100-BT17)	MODBUS_INPUT_REGISTER	1526	10	°C	2	0	0	0
-Compres­sor sensor (EB100-BT29)	MODBUS_INPUT_REGISTER	1527	10	°C	2	0	0	0
+Compressor sensor (EB100-BT29)	MODBUS_INPUT_REGISTER	1527	10	°C	2	0	0	0
 Low press (EB100-BP8)	MODBUS_INPUT_REGISTER	1528	10	°C	2	0	0	0
-Compres­sor status (EB100)	MODBUS_INPUT_REGISTER	1529	1		4	0	0	0
-Com­pressor, time to start (EB100-EP14)	MODBUS_INPUT_REGISTER	1530	1	min	4	0	0	0
+Compressor status (EB100)	MODBUS_INPUT_REGISTER	1529	1		4	0	0	0
+Compressor, time to start (EB100-EP14)	MODBUS_INPUT_REGISTER	1530	1	min	4	0	0	0
 Relay status (EB100-EP14)	MODBUS_INPUT_REGISTER	1531	1		5	0	0	0
 Heating medium pump (EB100)	MODBUS_INPUT_REGISTER	1532	1	%	4	0	0	0
 Brine pump (EB100)	MODBUS_INPUT_REGISTER	1533	1	%	4	0	0	0
-Com­pressor, number of starts (EB100-EP14)	MODBUS_INPUT_REGISTER	1534	1		6	0	0	0
-Com­pressor, oper. time, total (EB100-EP14)	MODBUS_INPUT_REGISTER	1536	1	h	6	0	0	0
-Com­pressor, oper. time, hot water (EB100-EP14)	MODBUS_INPUT_REGISTER	1538	1	h	6	0	0	0
-Com­pressor, re­quested (EB108-EP14)	MODBUS_INPUT_REGISTER	1542	1		4	0	0	0
-Com­pressor, re­quested (EB107-EP14)	MODBUS_INPUT_REGISTER	1544	1		4	0	0	0
-Com­pressor, re­quested (EB106-EP14)	MODBUS_INPUT_REGISTER	1546	1		4	0	0	0
-Com­pressor, re­quested (EB105-EP14)	MODBUS_INPUT_REGISTER	1548	1		4	0	0	0
-Com­pressor, re­quested (EB104-EP14)	MODBUS_INPUT_REGISTER	1550	1		4	0	0	0
-Com­pressor, re­quested (EB103-EP14)	MODBUS_INPUT_REGISTER	1552	1		4	0	0	0
-Com­pressor, re­quested (EB102-EP14)	MODBUS_INPUT_REGISTER	1554	1		4	0	0	0
-Com­pressor, re­quested (EB101-EP14)	MODBUS_INPUT_REGISTER	1556	1		4	0	0	0
+Compressor, number of starts (EB100-EP14)	MODBUS_INPUT_REGISTER	1534	1		6	0	0	0
+Compressor, oper. time, total (EB100-EP14)	MODBUS_INPUT_REGISTER	1536	1	h	6	0	0	0
+Compressor, oper. time, hot water (EB100-EP14)	MODBUS_INPUT_REGISTER	1538	1	h	6	0	0	0
+Compressor, requested (EB108-EP14)	MODBUS_INPUT_REGISTER	1542	1		4	0	0	0
+Compressor, requested (EB107-EP14)	MODBUS_INPUT_REGISTER	1544	1		4	0	0	0
+Compressor, requested (EB106-EP14)	MODBUS_INPUT_REGISTER	1546	1		4	0	0	0
+Compressor, requested (EB105-EP14)	MODBUS_INPUT_REGISTER	1548	1		4	0	0	0
+Compressor, requested (EB104-EP14)	MODBUS_INPUT_REGISTER	1550	1		4	0	0	0
+Compressor, requested (EB103-EP14)	MODBUS_INPUT_REGISTER	1552	1		4	0	0	0
+Compressor, requested (EB102-EP14)	MODBUS_INPUT_REGISTER	1554	1		4	0	0	0
+Compressor, requested (EB101-EP14)	MODBUS_INPUT_REGISTER	1556	1		4	0	0	0
 Cooling blocking	MODBUS_INPUT_REGISTER	1559	1		4	0	0	0
-Date, period­ic hot water	MODBUS_INPUT_REGISTER	1561	1		-	-	-	-
-Blocked com­pressors	MODBUS_INPUT_REGISTER	2174	1		6	0	0	0
+Date, periodic hot water	MODBUS_INPUT_REGISTER	1561	1		-	-	-	-
+Blocked compressors	MODBUS_INPUT_REGISTER	2174	1		6	0	0	0
 Cooling degree minutes	MODBUS_HOLDING_REGISTER	20	10	DM	2	-30000	30000	0
 Status (ACS)	MODBUS_INPUT_REGISTER	1568	1		4	0	0	0
 Status, heating dumping (ACS)	MODBUS_INPUT_REGISTER	1569	1		4	0	0	0
 Status, cooling dumping (ACS)	MODBUS_INPUT_REGISTER	1570	1		4	0	0	0
-Used compres­sors hot water	MODBUS_INPUT_REGISTER	1571	1		4	0	0	0
+Used compressors hot water	MODBUS_INPUT_REGISTER	1571	1		4	0	0	0
 Used compressors heating	MODBUS_INPUT_REGISTER	1572	1		4	0	0	0
 Used compressors pool 1	MODBUS_INPUT_REGISTER	1573	1		4	0	0	0
 Used compressors pool 2	MODBUS_INPUT_REGISTER	1574	1		4	0	0	0
-Hot water, includ­ing int. add. heat	MODBUS_INPUT_REGISTER	1575	10	kWh	6	0	9999999	0
-Hot water, com­pressor only	MODBUS_INPUT_REGISTER	1583	10	kWh	6	0	9999999	0
-Heating, com­pressor only	MODBUS_INPUT_REGISTER	1585	10	kWh	6	0	9999999	0
+Hot water, including int. add. heat	MODBUS_INPUT_REGISTER	1575	10	kWh	6	0	9999999	0
+Hot water, compressor only	MODBUS_INPUT_REGISTER	1583	10	kWh	6	0	9999999	0
+Heating, compressor only	MODBUS_INPUT_REGISTER	1585	10	kWh	6	0	9999999	0
 id:2728	MODBUS_HOLDING_REGISTER	3099	1		3	0	9999999	0
 Used compressors cooling	MODBUS_INPUT_REGISTER	1588	1		4	0	0	0
 Speed (GP12)	MODBUS_INPUT_REGISTER	1589	1	%	4	0	0	0
-Outdoor temper­ature (EB101-BT28)	MODBUS_INPUT_REGISTER	1621	10	°C	2	0	0	0
-Evap­orator (EB101-BT16)	MODBUS_INPUT_REGISTER	1622	10	°C	2	0	0	0
+Outdoor temperature (EB101-BT28)	MODBUS_INPUT_REGISTER	1621	10	°C	2	0	0	0
+Evaporator (EB101-BT16)	MODBUS_INPUT_REGISTER	1622	10	°C	2	0	0	0
 (EB100-EP15-BT28)	MODBUS_INPUT_REGISTER	1623	10	°C	2	0	0	0
 (EB100-EP15-BT16)	MODBUS_INPUT_REGISTER	1624	10	°C	2	0	0	0
 (EB100-EP14-BT28)	MODBUS_INPUT_REGISTER	1625	10	°C	2	0	0	0
 (EB100-EP14-BT16)	MODBUS_INPUT_REGISTER	1626	10	°C	2	0	0	0
 Heating medium pump speed (GP1)	MODBUS_INPUT_REGISTER	1636	1	%	4	0	0	0
-Frost protec­tion heat ex­changer heat pump 1	MODBUS_INPUT_REGISTER	1638	1		4	0	0	0
-Bit regis­ter (EB100)	MODBUS_INPUT_REGISTER	1687	1		4	0	0	0
-Control­ling hot water sensor (EB100-BT6)	MODBUS_INPUT_REGISTER	1688	10	°C	2	0	0	0
+Frost protection heat exchanger heat pump 1	MODBUS_INPUT_REGISTER	1638	1		4	0	0	0
+Bit register (EB100)	MODBUS_INPUT_REGISTER	1687	1		4	0	0	0
+Controlling hot water sensor (EB100-BT6)	MODBUS_INPUT_REGISTER	1688	10	°C	2	0	0	0
 Display hot water sensor (EB100-BT7)	MODBUS_INPUT_REGISTER	1689	10	°C	2	0	0	0
-Supply temper­ature sensor (EB100-BT2)	MODBUS_INPUT_REGISTER	1690	10	°C	2	0	0	0
-Com­pressor status (EB100-EP15)	MODBUS_INPUT_REGISTER	1691	1		4	0	0	0
-Com­pressor status (EB100-EP14)	MODBUS_INPUT_REGISTER	1692	1		4	0	0	0
-Oper­ating mode extra addi­tional heat	MODBUS_INPUT_REGISTER	1693	1		4	0	0	0
+Supply temperature sensor (EB100-BT2)	MODBUS_INPUT_REGISTER	1690	10	°C	2	0	0	0
+Compressor status (EB100-EP15)	MODBUS_INPUT_REGISTER	1691	1		4	0	0	0
+Compressor status (EB100-EP14)	MODBUS_INPUT_REGISTER	1692	1		4	0	0	0
+Operating mode extra additional heat	MODBUS_INPUT_REGISTER	1693	1		4	0	0	0
 Docked compressors cooling	MODBUS_INPUT_REGISTER	1694	1		4	0	0	0
-BP4, unpro­cessed (EB108-EP15)	MODBUS_INPUT_REGISTER	1695	1		2	0	0	0
+BP4, unprocessed (EB108-EP15)	MODBUS_INPUT_REGISTER	1695	1		2	0	0	0
 Low pressure (EB108-EP15--BP8)	MODBUS_INPUT_REGISTER	1697	10	bar	2	0	0	0
 Prot. status (EB108-EP15)	MODBUS_INPUT_REGISTER	1699	1		5	0	0	0
-Defrost­ing (EB108-EP15)	MODBUS_INPUT_REGISTER	1700	1		4	0	0	0
-BP4, unpro­cessed (EB108-EP14)	MODBUS_INPUT_REGISTER	1702	1		2	0	0	0
-Defrost­ing (EB108)	MODBUS_INPUT_REGISTER	1707	1		4	0	0	0
-BP4, unpro­cessed (EB107-EP15)	MODBUS_INPUT_REGISTER	1709	1		2	0	0	0
+Defrosting (EB108-EP15)	MODBUS_INPUT_REGISTER	1700	1		4	0	0	0
+BP4, unprocessed (EB108-EP14)	MODBUS_INPUT_REGISTER	1702	1		2	0	0	0
+Defrosting (EB108)	MODBUS_INPUT_REGISTER	1707	1		4	0	0	0
+BP4, unprocessed (EB107-EP15)	MODBUS_INPUT_REGISTER	1709	1		2	0	0	0
 Low pressure (EB107-EP15--BP8)	MODBUS_INPUT_REGISTER	1711	10	bar	2	0	0	0
 Prot. status (EB107-EP15)	MODBUS_INPUT_REGISTER	1713	1		5	0	0	0
-Defrost­ing (EB107-EP15)	MODBUS_INPUT_REGISTER	1714	1		4	0	0	0
+Defrosting (EB107-EP15)	MODBUS_INPUT_REGISTER	1714	1		4	0	0	0
 Power (EB107-EP15)	MODBUS_INPUT_REGISTER	1715	1	kW	4	0	0	0
-BP4, unpro­cessed (EB107-EP14)	MODBUS_INPUT_REGISTER	1716	1		2	0	0	0
-Defrost­ing (EB107)	MODBUS_INPUT_REGISTER	1721	1		4	0	0	0
+BP4, unprocessed (EB107-EP14)	MODBUS_INPUT_REGISTER	1716	1		2	0	0	0
+Defrosting (EB107)	MODBUS_INPUT_REGISTER	1721	1		4	0	0	0
 Power (EB107-EP14)	MODBUS_INPUT_REGISTER	1722	1	kW	4	0	0	0
-BP4, unpro­cessed (EB106-EP15)	MODBUS_INPUT_REGISTER	1723	1		2	0	0	0
+BP4, unprocessed (EB106-EP15)	MODBUS_INPUT_REGISTER	1723	1		2	0	0	0
 Low pressure (EB106-EP15--BP8)	MODBUS_INPUT_REGISTER	1725	10	bar	2	0	0	0
 Prot. status (EB106-EP15)	MODBUS_INPUT_REGISTER	1727	1		5	0	0	0
-Defrost­ing (EB106-EP15)	MODBUS_INPUT_REGISTER	1728	1		4	0	0	0
+Defrosting (EB106-EP15)	MODBUS_INPUT_REGISTER	1728	1		4	0	0	0
 Power (EB106-EP15)	MODBUS_INPUT_REGISTER	1729	1	kW	4	0	0	0
-BP4, unpro­cessed (EB106-EP14)	MODBUS_INPUT_REGISTER	1730	1		2	0	0	0
-Defrost­ing (EB106)	MODBUS_INPUT_REGISTER	1735	1		4	0	0	0
+BP4, unprocessed (EB106-EP14)	MODBUS_INPUT_REGISTER	1730	1		2	0	0	0
+Defrosting (EB106)	MODBUS_INPUT_REGISTER	1735	1		4	0	0	0
 Power (EB106-EP14)	MODBUS_INPUT_REGISTER	1736	1	kW	4	0	0	0
-BP4, unpro­cessed (EB105-EP15)	MODBUS_INPUT_REGISTER	1737	1		2	0	0	0
+BP4, unprocessed (EB105-EP15)	MODBUS_INPUT_REGISTER	1737	1		2	0	0	0
 Low pressure (EB105-EP15--BP8)	MODBUS_INPUT_REGISTER	1739	10	bar	2	0	0	0
 Prot. status (EB105-EP15)	MODBUS_INPUT_REGISTER	1741	1		5	0	0	0
-Defrost­ing (EB105-EP15)	MODBUS_INPUT_REGISTER	1742	1		4	0	0	0
+Defrosting (EB105-EP15)	MODBUS_INPUT_REGISTER	1742	1		4	0	0	0
 Power (EB105-EP15)	MODBUS_INPUT_REGISTER	1743	1	kW	4	0	0	0
-BP4, unpro­cessed (EB105-EP14)	MODBUS_INPUT_REGISTER	1744	1		2	0	0	0
-Defrost­ing (EB105)	MODBUS_INPUT_REGISTER	1749	1		4	0	0	0
+BP4, unprocessed (EB105-EP14)	MODBUS_INPUT_REGISTER	1744	1		2	0	0	0
+Defrosting (EB105)	MODBUS_INPUT_REGISTER	1749	1		4	0	0	0
 Power (EB105-EP15)	MODBUS_INPUT_REGISTER	1750	1	kW	4	0	0	0
-BP4, unpro­cessed (EB104-EP15)	MODBUS_INPUT_REGISTER	1751	1		2	0	0	0
+BP4, unprocessed (EB104-EP15)	MODBUS_INPUT_REGISTER	1751	1		2	0	0	0
 Low pressure (EB104-EP15--BP8)	MODBUS_INPUT_REGISTER	1753	10	bar	2	0	0	0
 Prot. status (EB104-EP15)	MODBUS_INPUT_REGISTER	1755	1		5	0	0	0
 Low pressure (EB103-EP15--BP8)	MODBUS_INPUT_REGISTER	1767	10	bar	2	0	0	0
-BP4, unpro­cessed (EB103-EP14)	MODBUS_INPUT_REGISTER	1772	1		2	0	0	0
-Defrost­ing (EB103)	MODBUS_INPUT_REGISTER	1777	1		4	0	0	0
+BP4, unprocessed (EB103-EP14)	MODBUS_INPUT_REGISTER	1772	1		2	0	0	0
+Defrosting (EB103)	MODBUS_INPUT_REGISTER	1777	1		4	0	0	0
 Power (EB103-EP14)	MODBUS_INPUT_REGISTER	1778	1	kW	4	0	0	0
-BP4, unpro­cessed (EB102-EP15)	MODBUS_INPUT_REGISTER	1779	1		2	0	0	0
+BP4, unprocessed (EB102-EP15)	MODBUS_INPUT_REGISTER	1779	1		2	0	0	0
 Low pressure (EB102-EP15--BP8)	MODBUS_INPUT_REGISTER	1781	10	bar	2	0	0	0
 Prot. status (EB102-EP15)	MODBUS_INPUT_REGISTER	1783	1		5	0	0	0
-Defrost­ing (EB102-EP15)	MODBUS_INPUT_REGISTER	1784	1		4	0	0	0
+Defrosting (EB102-EP15)	MODBUS_INPUT_REGISTER	1784	1		4	0	0	0
 Power (EB102-EP15)	MODBUS_INPUT_REGISTER	1785	1	kW	4	0	0	0
-BP4, unpro­cessed (EB102-EP14)	MODBUS_INPUT_REGISTER	1786	1		2	0	0	0
-Defrost­ing (EB102)	MODBUS_INPUT_REGISTER	1791	1		4	0	0	0
+BP4, unprocessed (EB102-EP14)	MODBUS_INPUT_REGISTER	1786	1		2	0	0	0
+Defrosting (EB102)	MODBUS_INPUT_REGISTER	1791	1		4	0	0	0
 Power (EB102-EP14)	MODBUS_INPUT_REGISTER	1792	1	kW	4	0	0	0
-BP4, unpro­cessed (EB101-EP15)	MODBUS_INPUT_REGISTER	1793	1		2	0	0	0
+BP4, unprocessed (EB101-EP15)	MODBUS_INPUT_REGISTER	1793	1		2	0	0	0
 Low pressure (EB101-EP15-BP8)	MODBUS_INPUT_REGISTER	1795	10	bar	2	0	0	0
 Prot. status (EB101-EP15)	MODBUS_INPUT_REGISTER	1797	1		5	0	0	0
-Defrost­ing (EB101-EP15)	MODBUS_INPUT_REGISTER	1798	1		4	0	0	0
+Defrosting (EB101-EP15)	MODBUS_INPUT_REGISTER	1798	1		4	0	0	0
 Power (EB101-EP15)	MODBUS_INPUT_REGISTER	1799	1	kW	4	0	0	0
-BP4, unpro­cessed (EB101-EP14)	MODBUS_INPUT_REGISTER	1800	1		2	0	0	0
+BP4, unprocessed (EB101-EP14)	MODBUS_INPUT_REGISTER	1800	1		2	0	0	0
 Low pressure (EB101-BP8)	MODBUS_INPUT_REGISTER	1802	10	bar	2	0	0	0
-Current compres­sor fre­quency (EB101)	MODBUS_INPUT_REGISTER	1803	10	Hz	2	0	0	0
+Current compressor frequency (EB101)	MODBUS_INPUT_REGISTER	1803	10	Hz	2	0	0	0
 Protection mode (EB101)	MODBUS_INPUT_REGISTER	1804	1		5	0	0	0
-Defrost­ing (EB101)	MODBUS_INPUT_REGISTER	1805	1		4	0	0	0
+Defrosting (EB101)	MODBUS_INPUT_REGISTER	1805	1		4	0	0	0
 Power (EB101-EP14)	MODBUS_INPUT_REGISTER	1806	1	kW	4	0	0	0
-BP4, unpro­cessed (EB100-EP15)	MODBUS_INPUT_REGISTER	1807	1		2	0	0	0
-Pres­sure sensor, con­denser (EB100-EP15-BP4)	MODBUS_INPUT_REGISTER	1808	10	bar	2	0	0	0
-Low pres­sure (EB100-EP15-BP8)	MODBUS_INPUT_REGISTER	1809	10	bar	2	0	0	0
+BP4, unprocessed (EB100-EP15)	MODBUS_INPUT_REGISTER	1807	1		2	0	0	0
+Pressure sensor, condenser (EB100-EP15-BP4)	MODBUS_INPUT_REGISTER	1808	10	bar	2	0	0	0
+Low pressure (EB100-EP15-BP8)	MODBUS_INPUT_REGISTER	1809	10	bar	2	0	0	0
 Prot. status (EB100-EP15)	MODBUS_INPUT_REGISTER	1811	1		5	0	0	0
-Defrost­ing (EB100-EP15)	MODBUS_INPUT_REGISTER	1812	1		4	0	0	0
+Defrosting (EB100-EP15)	MODBUS_INPUT_REGISTER	1812	1		4	0	0	0
 Power (EB100-EP15)	MODBUS_INPUT_REGISTER	1813	1	kW	4	0	0	0
-BP4, unpro­cessed (EB100-EP14)	MODBUS_INPUT_REGISTER	1814	1		2	0	0	0
-Pres­sure sensor, con­denser (EB100-EP14-BP4)	MODBUS_INPUT_REGISTER	1815	10	bar	2	0	0	0
-Low pres­sure (EB100-EP14-BP8)	MODBUS_INPUT_REGISTER	1816	10	bar	2	0	0	0
+BP4, unprocessed (EB100-EP14)	MODBUS_INPUT_REGISTER	1814	1		2	0	0	0
+Pressure sensor, condenser (EB100-EP14-BP4)	MODBUS_INPUT_REGISTER	1815	10	bar	2	0	0	0
+Low pressure (EB100-EP14-BP8)	MODBUS_INPUT_REGISTER	1816	10	bar	2	0	0	0
 Prot. status (EB100-EP14)	MODBUS_INPUT_REGISTER	1818	1		5	0	0	0
-Defrost­ing (EB100-EP14)	MODBUS_INPUT_REGISTER	1819	1		4	0	0	0
+Defrosting (EB100-EP14)	MODBUS_INPUT_REGISTER	1819	1		4	0	0	0
 Power (EB100-EP14)	MODBUS_INPUT_REGISTER	1820	1	kW	4	0	0	0
 Climate system 4	MODBUS_INPUT_REGISTER	1823	1		4	0	0	0
 Climate system 3	MODBUS_INPUT_REGISTER	1824	1		4	0	0	0
@@ -698,43 +704,43 @@ ACS EQ1-QN12	MODBUS_INPUT_REGISTER	1830	1		4	0	0	0
 ACS EQ1-GP20	MODBUS_INPUT_REGISTER	1831	1		4	0	0	0
 Alarm number (EB100-EP15)	MODBUS_INPUT_REGISTER	1837	1		5	0	0	0
 Alarm number (EB100-EP14)	MODBUS_INPUT_REGISTER	1838	1		5	0	0	0
-Re­quested compres­sor fre­quency (EB108-EP15)	MODBUS_INPUT_REGISTER	1839	1	Hz	4	0	0	0
-Re­quested compres­sor fre­quency (EB107-EP15)	MODBUS_INPUT_REGISTER	1841	1	Hz	4	0	0	0
-Re­quested compres­sor fre­quency (EB106-EP15)	MODBUS_INPUT_REGISTER	1843	1	Hz	4	0	0	0
-Re­quested compres­sor fre­quency (EB105-EP15)	MODBUS_INPUT_REGISTER	1845	1	Hz	4	0	0	0
-Re­quested compres­sor fre­quency (EB104-EP15)	MODBUS_INPUT_REGISTER	1847	1	Hz	4	0	0	0
-Re­quested compres­sor fre­quency (EB103-EP15)	MODBUS_INPUT_REGISTER	1849	1	Hz	4	0	0	0
-Re­quested compres­sor fre­quency (EB102-EP15)	MODBUS_INPUT_REGISTER	1851	1	Hz	4	0	0	0
-Re­quested compres­sor fre­quency (EB101-EP15)	MODBUS_INPUT_REGISTER	1853	1	Hz	4	0	0	0
-Re­quested compres­sor fre­quency (EB101)	MODBUS_INPUT_REGISTER	1854	1	Hz	4	0	0	0
-Re­quested compres­sor fre­quency (EP15)	MODBUS_INPUT_REGISTER	1855	1	Hz	4	0	0	0
-Re­quested compres­sor fre­quency	MODBUS_INPUT_REGISTER	1856	1	Hz	4	0	0	0
-Low press. sensor, unpro­cessed (EB101-EP14)	MODBUS_INPUT_REGISTER	1902	1		2	0	0	0
+Requested compressor frequency (EB108-EP15)	MODBUS_INPUT_REGISTER	1839	1	Hz	4	0	0	0
+Requested compressor frequency (EB107-EP15)	MODBUS_INPUT_REGISTER	1841	1	Hz	4	0	0	0
+Requested compressor frequency (EB106-EP15)	MODBUS_INPUT_REGISTER	1843	1	Hz	4	0	0	0
+Requested compressor frequency (EB105-EP15)	MODBUS_INPUT_REGISTER	1845	1	Hz	4	0	0	0
+Requested compressor frequency (EB104-EP15)	MODBUS_INPUT_REGISTER	1847	1	Hz	4	0	0	0
+Requested compressor frequency (EB103-EP15)	MODBUS_INPUT_REGISTER	1849	1	Hz	4	0	0	0
+Requested compressor frequency (EB102-EP15)	MODBUS_INPUT_REGISTER	1851	1	Hz	4	0	0	0
+Requested compressor frequency (EB101-EP15)	MODBUS_INPUT_REGISTER	1853	1	Hz	4	0	0	0
+Requested compressor frequency (EB101)	MODBUS_INPUT_REGISTER	1854	1	Hz	4	0	0	0
+Requested compressor frequency (EP15)	MODBUS_INPUT_REGISTER	1855	1	Hz	4	0	0	0
+Requested compressor frequency	MODBUS_INPUT_REGISTER	1856	1	Hz	4	0	0	0
+Low press. sensor, unprocessed (EB101-EP14)	MODBUS_INPUT_REGISTER	1902	1		2	0	0	0
 Current sensor (EB101-EP14)	MODBUS_INPUT_REGISTER	1903	10	A	2	0	0	0
-Low press. sensor, unpro­cessed (EB100-EP15)	MODBUS_INPUT_REGISTER	1905	1		2	0	0	0
+Low press. sensor, unprocessed (EB100-EP15)	MODBUS_INPUT_REGISTER	1905	1		2	0	0	0
 Current sensor (EB100-EP15)	MODBUS_INPUT_REGISTER	1906	10	A	2	0	0	0
-Low press. sensor, unpro­cessed (EB100-EP14)	MODBUS_INPUT_REGISTER	1908	1		2	0	0	0
+Low press. sensor, unprocessed (EB100-EP14)	MODBUS_INPUT_REGISTER	1908	1		2	0	0	0
 Current sensor (EB100-EP14)	MODBUS_INPUT_REGISTER	1909	10	A	2	0	0	0
-Oper­ating mode (SG Ready)	MODBUS_INPUT_REGISTER	1911	1		4	0	0	0
+Operating mode (SG Ready)	MODBUS_INPUT_REGISTER	1911	1		4	0	0	0
 SG ready, input A	MODBUS_INPUT_REGISTER	1912	1		4	0	0	0
 SG ready, input B	MODBUS_INPUT_REGISTER	1913	1		4	0	0	0
 Heating offset (SPA)	MODBUS_INPUT_REGISTER	1914	10		1	0	0	0
 Hot water comfort mode (SPA)	MODBUS_INPUT_REGISTER	1915	1		1	0	0	0
 Pool offset (SPA)	MODBUS_INPUT_REGISTER	1916	1		1	0	0	0
 Cooling offset (SPA)	MODBUS_INPUT_REGISTER	1917	1		1	0	0	0
-Oper­ating mode (Smart Price Adaption)	MODBUS_INPUT_REGISTER	1918	1		4	0	0	0
-Evap­orator 2 (EB101-EP14-BT16)	MODBUS_INPUT_REGISTER	1966	10	°C	2	0	0	0
-Temp­erature, inver­ter (EB101-EP14)	MODBUS_INPUT_REGISTER	1967	10	°C	2	0	0	0
+Operating mode (Smart Price Adaption)	MODBUS_INPUT_REGISTER	1918	1		4	0	0	0
+Evaporator 2 (EB101-EP14-BT16)	MODBUS_INPUT_REGISTER	1966	10	°C	2	0	0	0
+Temperature, inverter (EB101-EP14)	MODBUS_INPUT_REGISTER	1967	10	°C	2	0	0	0
 fan speed (EB101-EP14)	MODBUS_INPUT_REGISTER	1968	1		4	0	0	0
-Evap­orator 2 (EB100-EP15-BT16)	MODBUS_INPUT_REGISTER	1969	10	°C	2	0	0	0
-Temp­erature, inver­ter (EB100-EP15)	MODBUS_INPUT_REGISTER	1970	10	°C	2	0	0	0
+Evaporator 2 (EB100-EP15-BT16)	MODBUS_INPUT_REGISTER	1969	10	°C	2	0	0	0
+Temperature, inverter (EB100-EP15)	MODBUS_INPUT_REGISTER	1970	10	°C	2	0	0	0
 fan speed (EB100-EP15)	MODBUS_INPUT_REGISTER	1971	1		4	0	0	0
-Evap­orator 2 (EB100-EP14-BT16)	MODBUS_INPUT_REGISTER	1972	10	°C	2	0	0	0
-Temp­erature, inver­ter (EB100-EP14)	MODBUS_INPUT_REGISTER	1973	10	°C	2	0	0	0
+Evaporator 2 (EB100-EP14-BT16)	MODBUS_INPUT_REGISTER	1972	10	°C	2	0	0	0
+Temperature, inverter (EB100-EP14)	MODBUS_INPUT_REGISTER	1973	10	°C	2	0	0	0
 fan speed (EB100-EP14)	MODBUS_INPUT_REGISTER	1974	1		4	0	0	0
 Alarm number	MODBUS_INPUT_REGISTER	1975	1		2	0	0	0
 Reset alarm	MODBUS_HOLDING_REGISTER	22	1		4	0	0	0
-Non module-spe­cific alarm numbers	MODBUS_INPUT_REGISTER	1976	1		2	0	0	0
+Non module-specific alarm numbers	MODBUS_INPUT_REGISTER	1976	1		2	0	0	0
 Heating curve climate system 1	MODBUS_HOLDING_REGISTER	26	1		1	0	15	9
 Heating offset climate system 1	MODBUS_HOLDING_REGISTER	30	1		1	-10	10	0
 Min supply climate system 1	MODBUS_HOLDING_REGISTER	34	10	°C	2	50	800	200
@@ -746,26 +752,26 @@ Own curve, heating P4	MODBUS_HOLDING_REGISTER	42	1	°C	1	5	80	32
 Own curve, heating P3	MODBUS_HOLDING_REGISTER	43	1	°C	1	5	80	35
 Own curve, heating P2	MODBUS_HOLDING_REGISTER	44	1	°C	1	5	80	40
 Own curve, heating P1	MODBUS_HOLDING_REGISTER	45	1	°C	1	5	80	45
-Point offset outdoor temper­ature	MODBUS_HOLDING_REGISTER	46	1	°C	1	-40	30	0
+Point offset outdoor temperature	MODBUS_HOLDING_REGISTER	46	1	°C	1	-40	30	0
 Point offset	MODBUS_HOLDING_REGISTER	47	1	°C	1	-10	10	0
-Exter­nal adjust­ment climate system 1	MODBUS_HOLDING_REGISTER	51	1		1	-10	10	0
-Exter­nal adjust­ment with room sensor climate system 1	MODBUS_HOLDING_REGISTER	55	10	°C	2	50	300	200
+External adjustment climate system 1	MODBUS_HOLDING_REGISTER	51	1		1	-10	10	0
+External adjustment with room sensor climate system 1	MODBUS_HOLDING_REGISTER	55	10	°C	2	50	300	200
 Hot water demand mode	MODBUS_HOLDING_REGISTER	56	1		1	0	4	1
-Start temper­ature HW high temper­ature	MODBUS_HOLDING_REGISTER	58	10	°C	2	50	700	490
-Start temper­ature HW normal temper­ature	MODBUS_HOLDING_REGISTER	59	10	°C	2	50	600	460
-Start temper­ature HW low temper­ature	MODBUS_HOLDING_REGISTER	60	10	°C	2	50	550	420
-Stop temper­ature HW peri­odic in­crease	MODBUS_HOLDING_REGISTER	61	10	°C	2	550	700	550
-Stop temper­ature HW high temper­ature	MODBUS_HOLDING_REGISTER	62	10	°C	2	50	700	530
-Stop temper­ature HW normal temper­ature	MODBUS_HOLDING_REGISTER	63	10	°C	2	50	650	500
-Stop temper­ature HW low temper­ature	MODBUS_HOLDING_REGISTER	64	10	°C	2	50	600	480
-Peri­odic hot water	MODBUS_HOLDING_REGISTER	65	1		1	0	1	1
-Peri­odic hot water inter­val	MODBUS_HOLDING_REGISTER	66	1	days	1	1	90	7
-Start time peri­odic hot water	MODBUS_HOLDING_REGISTER	67	1		-	-	-	-
+Start temperature HW high temperature	MODBUS_HOLDING_REGISTER	58	10	°C	2	50	700	490
+Start temperature HW normal temperature	MODBUS_HOLDING_REGISTER	59	10	°C	2	50	600	460
+Start temperature HW low temperature	MODBUS_HOLDING_REGISTER	60	10	°C	2	50	550	420
+Stop temperature HW periodic increase	MODBUS_HOLDING_REGISTER	61	10	°C	2	550	700	550
+Stop temperature HW high temperature	MODBUS_HOLDING_REGISTER	62	10	°C	2	50	700	530
+Stop temperature HW normal temperature	MODBUS_HOLDING_REGISTER	63	10	°C	2	50	650	500
+Stop temperature HW low temperature	MODBUS_HOLDING_REGISTER	64	10	°C	2	50	600	480
+Periodic hot water	MODBUS_HOLDING_REGISTER	65	1		1	0	1	1
+Periodic hot water interval	MODBUS_HOLDING_REGISTER	66	1	days	1	1	90	7
+Start time periodic hot water	MODBUS_HOLDING_REGISTER	67	1		-	-	-	-
 Language	MODBUS_HOLDING_REGISTER	91	1		1	0	22	0
 Period time hot water	MODBUS_HOLDING_REGISTER	92	1	min	4	0	180	30
 Period time heating	MODBUS_HOLDING_REGISTER	93	1	min	4	0	180	30
-Oper­ating mode	MODBUS_HOLDING_REGISTER	2743	1		4	0	2	0
-Oper­ating mode heating medium pump	MODBUS_HOLDING_REGISTER	95	1		4	10	40	40
+Operating mode	MODBUS_HOLDING_REGISTER	2743	1		4	0	2	0
+Operating mode heating medium pump	MODBUS_HOLDING_REGISTER	95	1		4	10	40	40
 Activate force control	MODBUS_HOLDING_REGISTER	5000	1		4	0	0	0
 Fuse	MODBUS_HOLDING_REGISTER	103	1	A	5	1	400	32
 id:3826	MODBUS_HOLDING_REGISTER	2747	1		4	1	128	4
@@ -787,16 +793,16 @@ Floor drying temp. 3	MODBUS_HOLDING_REGISTER	132	1	°C	4	15	70	40
 Floor drying temp. 2	MODBUS_HOLDING_REGISTER	133	1	°C	4	15	70	30
 Floor drying temp. 1	MODBUS_HOLDING_REGISTER	134	1	°C	4	15	70	20
 Floor drying ongoing time.	MODBUS_INPUT_REGISTER	1977	1		5	0	10000	0
-Dimen­sioned outdoor temper­ature	MODBUS_HOLDING_REGISTER	140	10	°C	2	-400	200	-180
+Dimensioned outdoor temperature	MODBUS_HOLDING_REGISTER	140	10	°C	2	-400	200	-180
 Delta T for DOT	MODBUS_HOLDING_REGISTER	141	10	°C	2	10	250	100
 Climate system 2	MODBUS_HOLDING_REGISTER	142	1		4	0	1	0
 Climate system 3	MODBUS_HOLDING_REGISTER	143	1		4	0	1	0
 Climate system 4	MODBUS_HOLDING_REGISTER	144	1		4	0	1	0
-Shunt con­trolled addi­tional heat	MODBUS_HOLDING_REGISTER	153	1		4	0	1	0
-Wait time shunt, shunt con­trolled addi­tional heat	MODBUS_HOLDING_REGISTER	157	1	s	2	10	300	30
-Step con­trolled addi­tional heat acces­sory	MODBUS_HOLDING_REGISTER	158	1		4	0	1	0
-DM start step con­trolled addi­tional heat	MODBUS_HOLDING_REGISTER	159	1	DM	2	-2000	-30	-400
-Ground water pump acces­sory	MODBUS_HOLDING_REGISTER	162	1		4	0	1	0
+Shunt controlled additional heat	MODBUS_HOLDING_REGISTER	153	1		4	0	1	0
+Wait time shunt, shunt controlled additional heat	MODBUS_HOLDING_REGISTER	157	1	s	2	10	300	30
+Step controlled additional heat accessory	MODBUS_HOLDING_REGISTER	158	1		4	0	1	0
+DM start step controlled additional heat	MODBUS_HOLDING_REGISTER	159	1	DM	2	-2000	-30	-400
+Ground water pump accessory	MODBUS_HOLDING_REGISTER	162	1		4	0	1	0
 Waiting time cooling/heating	MODBUS_HOLDING_REGISTER	165	1	h	1	0	48	2
 Heating start at under temp.	MODBUS_HOLDING_REGISTER	166	10	°C	1	5	100	10
 Cooling start at over temp.	MODBUS_HOLDING_REGISTER	167	10	°C	1	5	100	30
@@ -805,20 +811,20 @@ Cooling with room sensors	MODBUS_HOLDING_REGISTER	170	10		4	0	41	0
 Start passive cooling DM	MODBUS_HOLDING_REGISTER	172	1	DM	2	10	500	30
 Start active cooling DM	MODBUS_HOLDING_REGISTER	173	1	DM	2	10	300	30
 Changes have been made	MODBUS_HOLDING_REGISTER	2744	1		4	0	1	0
-Permit addi­tional heat, heating	MODBUS_HOLDING_REGISTER	180	1		4	0	1	1
+Permit additional heat, heating	MODBUS_HOLDING_REGISTER	180	1		4	0	1	1
 Permit heating	MODBUS_HOLDING_REGISTER	181	1		4	0	1	1
 Permit cooling	MODBUS_HOLDING_REGISTER	182	1		4	0	1	1
-Auto mode, start temper­ature for cooling	MODBUS_HOLDING_REGISTER	183	10	°C	2	0	400	250
-Auto mode, stop temper­ature for heating	MODBUS_HOLDING_REGISTER	184	10	°C	2	-200	400	170
-Auto mode, addi­tional heat stop temper­ature	MODBUS_HOLDING_REGISTER	185	10	°C	2	-250	400	50
+Auto mode, start temperature for cooling	MODBUS_HOLDING_REGISTER	183	10	°C	2	0	400	250
+Auto mode, stop temperature for heating	MODBUS_HOLDING_REGISTER	184	10	°C	2	-200	400	170
+Auto mode, additional heat stop temperature	MODBUS_HOLDING_REGISTER	185	10	°C	2	-250	400	50
 Auto mode filter time	MODBUS_HOLDING_REGISTER	186	1	h	4	0	48	24
-Max differ­ence supply, compres­sor	MODBUS_HOLDING_REGISTER	187	10	°C	2	10	250	100
-Max differ­ence supply, addi­tional heat	MODBUS_HOLDING_REGISTER	188	10	°C	2	10	240	70
+Max difference supply, compressor	MODBUS_HOLDING_REGISTER	187	10	°C	2	10	250	100
+Max difference supply, additional heat	MODBUS_HOLDING_REGISTER	188	10	°C	2	10	240	70
 Time format	MODBUS_HOLDING_REGISTER	194	1		4	0	1	1
-Hot water permit­ted	MODBUS_HOLDING_REGISTER	195	1		4	0	1	0
-Alarm action, lower room temper­ature	MODBUS_HOLDING_REGISTER	196	1		4	0	1	0
-Alarm action lower HW temper­ature	MODBUS_HOLDING_REGISTER	197	1		4	0	1	0
-Auxil­iary oper­ation on alarm	MODBUS_HOLDING_REGISTER	198	1		4	0	0	0
+Hot water permitted	MODBUS_HOLDING_REGISTER	195	1		4	0	1	0
+Alarm action, lower room temperature	MODBUS_HOLDING_REGISTER	196	1		4	0	1	0
+Alarm action lower HW temperature	MODBUS_HOLDING_REGISTER	197	1		4	0	1	0
+Auxiliary operation on alarm	MODBUS_HOLDING_REGISTER	198	1		4	0	0	0
 Use room sensor climate system 4	MODBUS_HOLDING_REGISTER	199	1		4	0	1	0
 Use room sensor climate system 3	MODBUS_HOLDING_REGISTER	200	1		4	0	1	0
 Use room sensor climate system 2	MODBUS_HOLDING_REGISTER	201	1		4	0	1	0
@@ -831,11 +837,11 @@ Room sensor factor climate system 4	MODBUS_HOLDING_REGISTER	207	10		4	0	60	20
 Room sensor factor climate system 3	MODBUS_HOLDING_REGISTER	208	10		4	0	60	20
 Room sensor factor climate system 2	MODBUS_HOLDING_REGISTER	209	10		4	0	60	20
 Room sensor factor climate system 1	MODBUS_HOLDING_REGISTER	210	10		4	0	60	20
-Input AUX5	MODBUS_HOLDING_REGISTER	211	1		4	0	57	0
-Input AUX4	MODBUS_HOLDING_REGISTER	212	1		4	0	57	0
-Input AUX3	MODBUS_HOLDING_REGISTER	213	1		4	0	57	0
-Input AUX2	MODBUS_HOLDING_REGISTER	214	1		4	0	57	0
-Input AUX1	MODBUS_HOLDING_REGISTER	215	1		4	0	57	0
+Input AUX5	MODBUS_HOLDING_REGISTER	211	1		4	0	59	0
+Input AUX4	MODBUS_HOLDING_REGISTER	212	1		4	0	59	0
+Input AUX3	MODBUS_HOLDING_REGISTER	213	1		4	0	59	0
+Input AUX2	MODBUS_HOLDING_REGISTER	214	1		4	0	59	0
+Input AUX1	MODBUS_HOLDING_REGISTER	215	1		4	0	59	0
 Output AUX1	MODBUS_HOLDING_REGISTER	216	1		4	0	25	0
 id:3968	MODBUS_HOLDING_REGISTER	2752	1		5	1	3600	5
 Preset flow setting for climate system	MODBUS_HOLDING_REGISTER	223	1		4	0	3	1
@@ -843,8 +849,8 @@ id:3977	MODBUS_HOLDING_REGISTER	2753	1		4	21	22	21
 More hot water	MODBUS_HOLDING_REGISTER	225	10		-	-	-	-
 id:4050	MODBUS_HOLDING_REGISTER	4046	1		4	0	1	0
 Oper. mode	MODBUS_HOLDING_REGISTER	237	1		4	0	0	0
-Max. step internal addi­tional heat	MODBUS_HOLDING_REGISTER	238	1		4	0	7	3
-Inter­nal addi­tional heat step­ping mode	MODBUS_HOLDING_REGISTER	239	1		4	0	1	0
+Max. step internal additional heat	MODBUS_HOLDING_REGISTER	238	1		4	0	7	3
+Internal additional heat stepping mode	MODBUS_HOLDING_REGISTER	239	1		4	0	1	0
 Cooling heat sensor set point value	MODBUS_HOLDING_REGISTER	681	10		2	50	400	210
 Heating medium pump manual speed	MODBUS_HOLDING_REGISTER	682	1	%	1	1	100	70
 Pool 2 accessory	MODBUS_HOLDING_REGISTER	684	1		4	0	1	0
@@ -852,20 +858,21 @@ Pool 1 accessory	MODBUS_HOLDING_REGISTER	685	1		4	0	1	0
 Hot water comfort	MODBUS_HOLDING_REGISTER	694	1		4	0	1	0
 Manual heating medium pump speed	MODBUS_HOLDING_REGISTER	695	1	%	1	0	1	0
 More hot water	MODBUS_HOLDING_REGISTER	697	1		1	0	0	0
-Start diff. DM, step-con­trolled add. heat	MODBUS_HOLDING_REGISTER	703	1	DM	2	0	2000	400
+Start diff. DM, step-controlled add. heat	MODBUS_HOLDING_REGISTER	703	1	DM	2	0	2000	400
 HW comfort shunt on/off	MODBUS_HOLDING_REGISTER	705	1		4	0	1	0
-Exter­nal cooling acces­sory	MODBUS_HOLDING_REGISTER	709	1		4	0	1	0
-HW comfort addi­tional heat	MODBUS_HOLDING_REGISTER	710	1		4	0	1	0
-Cooling con­nected, climate system 1	MODBUS_HOLDING_REGISTER	726	1		4	0	0	0
+External cooling accessory	MODBUS_HOLDING_REGISTER	709	1		4	0	1	0
+HW comfort additional heat	MODBUS_HOLDING_REGISTER	710	1		4	0	1	0
+id:4591	MODBUS_HOLDING_REGISTER	4052	1		1	5	80	30
+Cooling connected, climate system 1	MODBUS_HOLDING_REGISTER	726	1		4	0	0	0
 ACS	MODBUS_HOLDING_REGISTER	731	1		4	0	1	0
 id:4617	MODBUS_HOLDING_REGISTER	4053	1		1	0	1	0
 id:4634	MODBUS_HOLDING_REGISTER	4054	1		1	0	1	1
-Oper­ating mode charge pump climate system 1	MODBUS_HOLDING_REGISTER	748	1		4	0	1	0
+Operating mode charge pump climate system 1	MODBUS_HOLDING_REGISTER	748	1		4	0	1	0
 id:4660	MODBUS_HOLDING_REGISTER	4063	1		4	0	1	0
 Shunted brine max. temp.	MODBUS_HOLDING_REGISTER	4067	1	°C	4	0	30	20
-Hot water compres­sors step diff.	MODBUS_HOLDING_REGISTER	755	100		2	0	400	100
-Addi­tional heat after revers­ing valve	MODBUS_HOLDING_REGISTER	758	1		4	0	1	1
-Hot water addi­tional heat in tank	MODBUS_HOLDING_REGISTER	759	1		4	0	1	0
+Hot water compressors step diff.	MODBUS_HOLDING_REGISTER	755	100		2	0	400	100
+Additional heat after reversing valve	MODBUS_HOLDING_REGISTER	758	1		4	0	1	1
+Hot water additional heat in tank	MODBUS_HOLDING_REGISTER	759	1		4	0	1	0
 Heating (SG Ready)	MODBUS_HOLDING_REGISTER	760	1		4	0	1	1
 id:4703	MODBUS_HOLDING_REGISTER	4068	1		4	0	1	0
 id:4704	MODBUS_HOLDING_REGISTER	4069	1		4	0	1	0
@@ -876,36 +883,36 @@ id:4708	MODBUS_HOLDING_REGISTER	4073	1		4	0	1	0
 id:4709	MODBUS_HOLDING_REGISTER	4074	1		4	0	1	0
 id:4710	MODBUS_HOLDING_REGISTER	4075	1		4	0	1	0
 id:4711	MODBUS_HOLDING_REGISTER	0	1		4	0	1	0
-Input AUX5	MODBUS_HOLDING_REGISTER	767	1		4	0	57	0
-Oper­ating mode circu­lation pump heating heat pump 1	MODBUS_HOLDING_REGISTER	783	1		4	0	1	1
-Oper­ating mode circu­lation pump hot water heat pump 8	MODBUS_HOLDING_REGISTER	792	1		4	0	1	1
-Oper­ating mode circu­lation pump hot water heat pump 7	MODBUS_HOLDING_REGISTER	793	1		4	0	1	1
-Oper­ating mode circu­lation pump hot water heat pump 6	MODBUS_HOLDING_REGISTER	794	1		4	0	1	1
-Oper­ating mode circu­lation pump hot water heat pump 5	MODBUS_HOLDING_REGISTER	795	1		4	0	1	1
-Oper­ating mode circu­lation pump hot water heat pump 4	MODBUS_HOLDING_REGISTER	796	1		4	0	1	1
-Oper­ating mode circu­lation pump hot water heat pump 3	MODBUS_HOLDING_REGISTER	797	1		4	0	1	1
-Oper­ating mode circu­lation pump hot water heat pump 2	MODBUS_HOLDING_REGISTER	798	1		4	0	1	1
-Oper­ating mode circu­lation pump hot water heat pump 1	MODBUS_HOLDING_REGISTER	799	1		4	0	1	1
-Speed circu­lation pump waiting mode heat pump 1	MODBUS_HOLDING_REGISTER	841	1	%	4	1	100	30
-Speed, circu­lation pump, standby mode (EB100)	MODBUS_HOLDING_REGISTER	842	1	%	4	1	100	30
+Input AUX5	MODBUS_HOLDING_REGISTER	767	1		4	0	59	0
+Operating mode circulation pump heating heat pump 1	MODBUS_HOLDING_REGISTER	783	1		4	0	1	1
+Operating mode circulation pump hot water heat pump 8	MODBUS_HOLDING_REGISTER	792	1		4	0	1	1
+Operating mode circulation pump hot water heat pump 7	MODBUS_HOLDING_REGISTER	793	1		4	0	1	1
+Operating mode circulation pump hot water heat pump 6	MODBUS_HOLDING_REGISTER	794	1		4	0	1	1
+Operating mode circulation pump hot water heat pump 5	MODBUS_HOLDING_REGISTER	795	1		4	0	1	1
+Operating mode circulation pump hot water heat pump 4	MODBUS_HOLDING_REGISTER	796	1		4	0	1	1
+Operating mode circulation pump hot water heat pump 3	MODBUS_HOLDING_REGISTER	797	1		4	0	1	1
+Operating mode circulation pump hot water heat pump 2	MODBUS_HOLDING_REGISTER	798	1		4	0	1	1
+Operating mode circulation pump hot water heat pump 1	MODBUS_HOLDING_REGISTER	799	1		4	0	1	1
+Speed circulation pump waiting mode heat pump 1	MODBUS_HOLDING_REGISTER	841	1	%	4	1	100	30
+Speed, circulation pump, standby mode (EB100)	MODBUS_HOLDING_REGISTER	842	1	%	4	1	100	30
 Activated (Smart Price Adaption)	MODBUS_HOLDING_REGISTER	843	1		4	0	1	0
 (SPA), cooling activated	MODBUS_HOLDING_REGISTER	849	1		4	0	1	1
 (SPA), area	MODBUS_HOLDING_REGISTER	851	1		4	0	254	23
-Inter­nal shunt con­trolled addi­tional heat	MODBUS_HOLDING_REGISTER	857	1		4	0	1	0
-Max. speed con­trolled charge pump (EB101)	MODBUS_HOLDING_REGISTER	867	1	%	4	80	100	100
-Exter­nal adjust­ment climate system 8	MODBUS_HOLDING_REGISTER	893	1		1	-10	10	0
-Exter­nal adjust­ment climate system 7	MODBUS_HOLDING_REGISTER	894	1		1	-10	10	0
-Exter­nal adjust­ment climate system 6	MODBUS_HOLDING_REGISTER	895	1		1	-10	10	0
-Exter­nal adjust­ment climate system 5	MODBUS_HOLDING_REGISTER	896	1		1	-10	10	0
-Exter­nal adjust­ment with room sensor climate system 8	MODBUS_HOLDING_REGISTER	897	10	°C	2	50	300	200
-Exter­nal adjust­ment with room sensor climate system 7	MODBUS_HOLDING_REGISTER	898	10	°C	2	50	300	200
-Exter­nal adjust­ment with room sensor climate system 6	MODBUS_HOLDING_REGISTER	899	10	°C	2	50	300	200
-Exter­nal adjust­ment with room sensor climate system 5	MODBUS_HOLDING_REGISTER	900	10	°C	2	50	300	200
+Internal shunt controlled additional heat	MODBUS_HOLDING_REGISTER	857	1		4	0	1	0
+Max. speed controlled charge pump (EB101)	MODBUS_HOLDING_REGISTER	867	1	%	4	80	100	100
+External adjustment climate system 8	MODBUS_HOLDING_REGISTER	893	1		1	-10	10	0
+External adjustment climate system 7	MODBUS_HOLDING_REGISTER	894	1		1	-10	10	0
+External adjustment climate system 6	MODBUS_HOLDING_REGISTER	895	1		1	-10	10	0
+External adjustment climate system 5	MODBUS_HOLDING_REGISTER	896	1		1	-10	10	0
+External adjustment with room sensor climate system 8	MODBUS_HOLDING_REGISTER	897	10	°C	2	50	300	200
+External adjustment with room sensor climate system 7	MODBUS_HOLDING_REGISTER	898	10	°C	2	50	300	200
+External adjustment with room sensor climate system 6	MODBUS_HOLDING_REGISTER	899	10	°C	2	50	300	200
+External adjustment with room sensor climate system 5	MODBUS_HOLDING_REGISTER	900	10	°C	2	50	300	200
 Climate system 5	MODBUS_HOLDING_REGISTER	905	1		4	0	1	0
 Climate system 6	MODBUS_HOLDING_REGISTER	906	1		4	0	1	0
 Climate system 7	MODBUS_HOLDING_REGISTER	907	1		4	0	1	0
 Climate system 8	MODBUS_HOLDING_REGISTER	908	1		4	0	1	0
-Heating con­nected, climate system 1	MODBUS_HOLDING_REGISTER	932	1		4	0	1	1
+Heating connected, climate system 1	MODBUS_HOLDING_REGISTER	932	1		4	0	1	1
 ERS 1	MODBUS_HOLDING_REGISTER	933	1		4	0	1	0
 EB103/104-GP12	MODBUS_HOLDING_REGISTER	939	1		4	0	1	0
 EB105/106-GP12	MODBUS_HOLDING_REGISTER	940	1		4	0	1	0
@@ -960,23 +967,23 @@ Exhaust air fan speed 3 (ERS 1)	MODBUS_HOLDING_REGISTER	1022	1	%	4	0	100	80
 Exhaust air fan speed 2 (ERS 1)	MODBUS_HOLDING_REGISTER	1023	1	%	4	0	100	30
 Exhaust air fan speed 1 (ERS 1)	MODBUS_HOLDING_REGISTER	1024	1	%	4	0	100	0
 Exhaust air fan speed normal (ERS 1)	MODBUS_HOLDING_REGISTER	1025	1	%	4	1	100	75
-Filter­ing time (BT64)	MODBUS_HOLDING_REGISTER	1027	1	min	4	5	30	5
+Filtering time (BT64)	MODBUS_HOLDING_REGISTER	1027	1	min	4	5	30	5
 (ACS) - Thermostat, hysteresis between compressors	MODBUS_HOLDING_REGISTER	1028	1	°C	1	1	10	2
 Start temperature (BT64)	MODBUS_HOLDING_REGISTER	1029	1	°C	1	-8	30	10
-Flow sensor acti­vated X21	MODBUS_HOLDING_REGISTER	1031	1		4	0	1	0
+Flow sensor activated X21	MODBUS_HOLDING_REGISTER	1031	1		4	0	1	0
 S135	MODBUS_HOLDING_REGISTER	1035	1		4	0	1	0
 Pump speed (S135)	MODBUS_HOLDING_REGISTER	1036	1	%	4	1	100	70
 Bypass temp. (ERS 1)	MODBUS_HOLDING_REGISTER	1044	1	°C	4	2	10	4
-Exter­nal cooling acces­sory pump type	MODBUS_HOLDING_REGISTER	1046	1		4	0	1	1
-Flow sensor acti­vated X22	MODBUS_HOLDING_REGISTER	1049	1		4	0	1	0
-Flow sensor acti­vated X21	MODBUS_HOLDING_REGISTER	1050	1		4	0	1	0
-Max. inter­nal addi­tional heat SG Ready	MODBUS_HOLDING_REGISTER	1052	100	kW	2	0	900	700
+External cooling accessory pump type	MODBUS_HOLDING_REGISTER	1046	1		4	0	1	1
+Flow sensor activated X22	MODBUS_HOLDING_REGISTER	1049	1		4	0	1	0
+Flow sensor activated X21	MODBUS_HOLDING_REGISTER	1050	1		4	0	1	0
+Max. internal additional heat SG Ready	MODBUS_HOLDING_REGISTER	1052	100	kW	2	0	900	700
 Hysteresis (OPT)	MODBUS_HOLDING_REGISTER	1066	1		2	10	2000	100
 Activated (EME10)	MODBUS_HOLDING_REGISTER	1068	1		4	0	1	0
 PV panel affects heating (EME)	MODBUS_HOLDING_REGISTER	1069	1		4	0	1	0
 PV panel affects hot water (EME)	MODBUS_HOLDING_REGISTER	1070	1		4	0	1	0
 Delay timer EME	MODBUS_HOLDING_REGISTER	1071	1		5	0	0	0
-AUX block­ing (OPT)	MODBUS_HOLDING_REGISTER	1095	1		4	0	0	0
+AUX blocking (OPT)	MODBUS_HOLDING_REGISTER	1095	1		4	0	0	0
 Outdoor air mixing	MODBUS_HOLDING_REGISTER	1096	1		4	0	1	0
 Smart home room control	MODBUS_HOLDING_REGISTER	1102	1		4	0	1	0
 Smart Energy Source	MODBUS_HOLDING_REGISTER	1105	1		4	0	1	0
@@ -1003,13 +1010,13 @@ Shunt add. heat, high tariff price smart energy source	MODBUS_HOLDING_REGISTER	1
 Shunt add. heat, low tariff price smart energy source	MODBUS_HOLDING_REGISTER	1126	1		5	1	10000	100
 El. price, fixed, high tariff smart energy source	MODBUS_HOLDING_REGISTER	1127	1		5	1	10000	100
 El. price, fixed, low tariff smart energy source	MODBUS_HOLDING_REGISTER	1128	1		5	1	10000	100
-El. price, vari­able, high tariff smart energy source	MODBUS_HOLDING_REGISTER	1129	1		5	1	10000	100
-El. price, vari­able, low tariff smart energy source	MODBUS_HOLDING_REGISTER	1130	1		5	1	10000	100
-DM start source, prior­ity 5 smart energy source	MODBUS_HOLDING_REGISTER	1131	1		2	100	2000	400
-DM start source, prior­ity 4 smart energy source	MODBUS_HOLDING_REGISTER	1132	1		2	100	2000	400
-DM start source, prior­ity 3 smart energy source	MODBUS_HOLDING_REGISTER	1133	1		2	100	2000	400
-DM start source, prior­ity 2 smart energy source	MODBUS_HOLDING_REGISTER	1134	1		2	100	2000	400
-DM start source, prior­ity 1 smart energy source	MODBUS_HOLDING_REGISTER	1135	1		2	-2000	-10	-60
+El. price, variable, high tariff smart energy source	MODBUS_HOLDING_REGISTER	1129	1		5	1	10000	100
+El. price, variable, low tariff smart energy source	MODBUS_HOLDING_REGISTER	1130	1		5	1	10000	100
+DM start source, priority 5 smart energy source	MODBUS_HOLDING_REGISTER	1131	1		2	100	2000	400
+DM start source, priority 4 smart energy source	MODBUS_HOLDING_REGISTER	1132	1		2	100	2000	400
+DM start source, priority 3 smart energy source	MODBUS_HOLDING_REGISTER	1133	1		2	100	2000	400
+DM start source, priority 2 smart energy source	MODBUS_HOLDING_REGISTER	1134	1		2	100	2000	400
+DM start source, priority 1 smart energy source	MODBUS_HOLDING_REGISTER	1135	1		2	-2000	-10	-60
 Start day, tariff smart energy source	MODBUS_HOLDING_REGISTER	1136	1		4	1	31	1
 End day, tariff smart energy source	MODBUS_HOLDING_REGISTER	1137	1		4	1	31	31
 Start month, tariff smart energy source	MODBUS_HOLDING_REGISTER	1138	1		4	1	12	1
@@ -1022,18 +1029,18 @@ Start day, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1208	1		4	1	
 End day, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1209	1		4	1	31	31
 Start month, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1210	1		4	1	12	1
 End month, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1211	1		4	1	12	12
-Start day tariff, shunt addi­tional heat smart energy source	MODBUS_HOLDING_REGISTER	1244	1		4	1	31	1
-End day tariff, shunt addi­tional heat  smart energy source	MODBUS_HOLDING_REGISTER	1245	1		4	1	31	31
-Start month tariff, shunt addi­tional heat smart energy source	MODBUS_HOLDING_REGISTER	1246	1		4	1	12	1
-End month tariff, shunt addi­tional heat smart energy source	MODBUS_HOLDING_REGISTER	1247	1		4	1	12	12
+Start day tariff, shunt additional heat smart energy source	MODBUS_HOLDING_REGISTER	1244	1		4	1	31	1
+End day tariff, shunt additional heat  smart energy source	MODBUS_HOLDING_REGISTER	1245	1		4	1	31	31
+Start month tariff, shunt additional heat smart energy source	MODBUS_HOLDING_REGISTER	1246	1		4	1	12	1
+End month tariff, shunt additional heat smart energy source	MODBUS_HOLDING_REGISTER	1247	1		4	1	12	12
 Start day tariff, ext. step add. heat smart energy source	MODBUS_HOLDING_REGISTER	1280	1		4	1	31	1
 End day tariff, ext. step add. heat  smart energy source	MODBUS_HOLDING_REGISTER	1281	1		4	1	31	31
 Start month tariff, ext. step add. heat smart energy source	MODBUS_HOLDING_REGISTER	1282	1		4	1	12	1
 End month tariff, ext. step add. heat smart energy source	MODBUS_HOLDING_REGISTER	1283	1		4	1	12	12
-Ground water pump temper­ature alarm	MODBUS_HOLDING_REGISTER	1316	1		4	0	1	0
-Ground water pump temper­ature alarm level	MODBUS_HOLDING_REGISTER	1317	1	°C	1	-15	20	3
-Max differ­ence, SES priority 1 energy source	MODBUS_HOLDING_REGISTER	1326	10	°C	2	10	250	100
-Max differ­ence, SES lower prior­ity energy source	MODBUS_HOLDING_REGISTER	1327	10	°C	2	10	250	70
+Ground water pump temperature alarm	MODBUS_HOLDING_REGISTER	1316	1		4	0	1	0
+Ground water pump temperature alarm level	MODBUS_HOLDING_REGISTER	1317	1	°C	1	-15	20	3
+Max difference, SES priority 1 energy source	MODBUS_HOLDING_REGISTER	1326	10	°C	2	10	250	100
+Max difference, SES lower priority energy source	MODBUS_HOLDING_REGISTER	1327	10	°C	2	10	250	70
 Installed (EB101)	MODBUS_HOLDING_REGISTER	1550	1		4	0	1	1
 EME20	MODBUS_HOLDING_REGISTER	4000	1		4	0	1	0
 Current power (EME 20)	MODBUS_INPUT_REGISTER	2176	1	W	6	0	0	0
@@ -1041,11 +1048,11 @@ id:6028	MODBUS_INPUT_REGISTER	1993	1		4	0	0	0
 id:6029	MODBUS_INPUT_REGISTER	1994	1		5	0	0	0
 Total average power (EME 20)	MODBUS_INPUT_REGISTER	2178	1	W	6	0	0	0
 Total energy (EME 20)	MODBUS_INPUT_REGISTER	2180	10	kWh	3	0	0	0
-Ex­ternal energy meter 2 pulse per kWh	MODBUS_HOLDING_REGISTER	4018	1		5	1	10000	500
+External energy meter 2 pulse per kWh	MODBUS_HOLDING_REGISTER	4018	1		5	1	10000	500
 ERS 2	MODBUS_HOLDING_REGISTER	4076	1		4	0	1	0
 ERS 3	MODBUS_HOLDING_REGISTER	4077	1		4	0	1	0
 ERS 4	MODBUS_HOLDING_REGISTER	4078	1		4	0	1	0
-Hot water addi­tional heat used in heating mode	MODBUS_HOLDING_REGISTER	4203	1		4	0	1	0
+Hot water additional heat used in heating mode	MODBUS_HOLDING_REGISTER	4203	1		4	0	1	0
 id:6486	MODBUS_HOLDING_REGISTER	4135	1		4	0	1	0
 id:6756	MODBUS_INPUT_REGISTER	2004	10	%RH	2	0	0	0
 id:6757	MODBUS_INPUT_REGISTER	2005	10	%RH	2	0	0	0
@@ -1053,22 +1060,22 @@ id:6758	MODBUS_INPUT_REGISTER	2006	10	%RH	2	0	0	0
 HTS 2	MODBUS_HOLDING_REGISTER	1981	1		4	0	1	0
 HTS 3	MODBUS_HOLDING_REGISTER	1982	1		4	0	1	0
 HTS 4	MODBUS_HOLDING_REGISTER	1983	1		4	0	1	0
-Exter­nal adjust­ment, cooling climate system 8	MODBUS_HOLDING_REGISTER	4138	1		1	-10	10	0
-Exter­nal adjust­ment, cooling climate system 7	MODBUS_HOLDING_REGISTER	4139	1		1	-10	10	0
-Exter­nal adjust­ment, cooling climate system 6	MODBUS_HOLDING_REGISTER	4140	1		1	-10	10	0
-Exter­nal adjust­ment, cooling climate system 5	MODBUS_HOLDING_REGISTER	4141	1		1	-10	10	0
-Exter­nal adjust­ment, cooling climate system 4	MODBUS_HOLDING_REGISTER	4142	1		1	-10	10	0
-Exter­nal adjust­ment, cooling climate system 3	MODBUS_HOLDING_REGISTER	4143	1		1	-10	10	0
-Exter­nal adjust­ment, cooling climate system 2	MODBUS_HOLDING_REGISTER	4144	1		1	-10	10	0
-Exter­nal adjust­ment, cooling climate system 1	MODBUS_HOLDING_REGISTER	4145	1		1	-10	10	0
-Exter­nal adjust­ment with room sensor, cooling climate system 8	MODBUS_HOLDING_REGISTER	4146	10	°C	2	50	300	200
-Exter­nal adjust­ment with room sensor, cooling climate system 7	MODBUS_HOLDING_REGISTER	4147	10	°C	2	50	300	200
-Exter­nal adjust­ment with room sensor, cooling climate system 6	MODBUS_HOLDING_REGISTER	4148	10	°C	2	50	300	200
-Exter­nal adjust­ment with room sensor, cooling climate system 5	MODBUS_HOLDING_REGISTER	4149	10	°C	2	50	300	200
-Exter­nal adjust­ment with room sensor, cooling climate system 4	MODBUS_HOLDING_REGISTER	4150	10	°C	2	50	300	200
-Exter­nal adjust­ment with room sensor, cooling climate system 3	MODBUS_HOLDING_REGISTER	4151	10	°C	2	50	300	200
-Exter­nal adjust­ment with room sensor, cooling climate system 2	MODBUS_HOLDING_REGISTER	4152	10	°C	2	50	300	200
-Exter­nal adjust­ment with room sensor, cooling climate system 1	MODBUS_HOLDING_REGISTER	4153	10	°C	2	50	300	200
+External adjustment, cooling climate system 8	MODBUS_HOLDING_REGISTER	4138	1		1	-10	10	0
+External adjustment, cooling climate system 7	MODBUS_HOLDING_REGISTER	4139	1		1	-10	10	0
+External adjustment, cooling climate system 6	MODBUS_HOLDING_REGISTER	4140	1		1	-10	10	0
+External adjustment, cooling climate system 5	MODBUS_HOLDING_REGISTER	4141	1		1	-10	10	0
+External adjustment, cooling climate system 4	MODBUS_HOLDING_REGISTER	4142	1		1	-10	10	0
+External adjustment, cooling climate system 3	MODBUS_HOLDING_REGISTER	4143	1		1	-10	10	0
+External adjustment, cooling climate system 2	MODBUS_HOLDING_REGISTER	4144	1		1	-10	10	0
+External adjustment, cooling climate system 1	MODBUS_HOLDING_REGISTER	4145	1		1	-10	10	0
+External adjustment with room sensor, cooling climate system 8	MODBUS_HOLDING_REGISTER	4146	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 7	MODBUS_HOLDING_REGISTER	4147	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 6	MODBUS_HOLDING_REGISTER	4148	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 5	MODBUS_HOLDING_REGISTER	4149	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 4	MODBUS_HOLDING_REGISTER	4150	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 3	MODBUS_HOLDING_REGISTER	4151	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 2	MODBUS_HOLDING_REGISTER	4152	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 1	MODBUS_HOLDING_REGISTER	4153	10	°C	2	50	300	200
 id:6917	MODBUS_HOLDING_REGISTER	4072	1		4	0	200	1
 id:6918	MODBUS_HOLDING_REGISTER	4073	1		4	0	20	1
 id:6920	MODBUS_HOLDING_REGISTER	4074	1		4	0	20	0
@@ -1083,7 +1090,7 @@ BlockFreq 1 (EB106)	MODBUS_HOLDING_REGISTER	4168	1		4	0	1	0
 BlockFreq 1 (EB107)	MODBUS_HOLDING_REGISTER	4169	1		4	0	1	0
 BlockFreq 1 (EB108)	MODBUS_HOLDING_REGISTER	4170	1		4	0	1	0
 id:6977	MODBUS_HOLDING_REGISTER	4201	1		4	0	100	0
-Power at DOT, manual value	MODBUS_HOLDING_REGISTER	4200	1	kW	4	0	1	0
+Power at DOT, manual value	MODBUS_HOLDING_REGISTER	4200	1		4	0	1	0
 Blocking actions (ERS 3)	MODBUS_HOLDING_REGISTER	4100	1		4	0	2	2
 Blocking actions (ERS 4)	MODBUS_HOLDING_REGISTER	4101	1		4	0	2	2
 id:7048	MODBUS_HOLDING_REGISTER	3987	1		4	0	1	0
@@ -1103,7 +1110,7 @@ id:7150	MODBUS_HOLDING_REGISTER	4021	1	%	4	0	100	70
 id:7176	MODBUS_HOLDING_REGISTER	4023	1		4	0	1	0
 id:8002	MODBUS_HOLDING_REGISTER	1996	1	%	4	-15	10	-3
 id:8003	MODBUS_HOLDING_REGISTER	1997	1	%	4	1	254	65
-Minimum permit­ted speed (EB101 GP12)	MODBUS_HOLDING_REGISTER	3243	1	%	4	1	50	1
+Minimum permitted speed (EB101 GP12)	MODBUS_HOLDING_REGISTER	3243	1	%	4	1	50	1
 Start fan de-icing (EB101)	MODBUS_HOLDING_REGISTER	3251	1		1	0	1	0
 id:8060	MODBUS_HOLDING_REGISTER	3259	1		1	0	1	0
 id:8061	MODBUS_HOLDING_REGISTER	3260	1		1	0	1	0
@@ -1125,9 +1132,9 @@ System 4 (RMU)	MODBUS_HOLDING_REGISTER	2001	1		4	0	1	0
 id:8982	MODBUS_HOLDING_REGISTER	3346	1		4	0	0	0
 The start guide has been run	MODBUS_HOLDING_REGISTER	2742	1		4	0	1	1
 Audio signal on alarm	MODBUS_HOLDING_REGISTER	3232	1		4	0	1	1
-Sound when press­ing button	MODBUS_HOLDING_REGISTER	3233	1		4	0	1	1
+Sound when pressing button	MODBUS_HOLDING_REGISTER	3233	1		4	0	1	1
 BT12 offset, heat pump 1	MODBUS_HOLDING_REGISTER	3234	10	°C	1	-50	50	0
-Addi­tional heat step, emer­gency mode	MODBUS_HOLDING_REGISTER	3058	1		4	0	7	0
+Additional heat step, emergency mode	MODBUS_HOLDING_REGISTER	3058	1		4	0	7	0
 Heating, auto	MODBUS_HOLDING_REGISTER	3059	1		4	0	1	1
 Factor	MODBUS_HOLDING_REGISTER	3033	1		4	1	10	5
 id:10881	MODBUS_HOLDING_REGISTER	3062	1		4	0	1	0
@@ -1343,6 +1350,14 @@ id:12877	MODBUS_HOLDING_REGISTER	2657	10	°C	3	50	300	250
 id:12878	MODBUS_HOLDING_REGISTER	2659	10	°C	3	50	300	250
 id:12879	MODBUS_HOLDING_REGISTER	2661	10	°C	3	50	300	250
 id:12880	MODBUS_HOLDING_REGISTER	2663	10	°C	3	50	300	250
+id:13796	MODBUS_INPUT_REGISTER	2243	1		4	0	0	0
+id:13797	MODBUS_INPUT_REGISTER	2244	1		4	0	0	0
+id:13798	MODBUS_INPUT_REGISTER	2245	1		4	0	0	0
+id:13799	MODBUS_INPUT_REGISTER	2246	1		4	0	0	0
+id:13800	MODBUS_INPUT_REGISTER	2247	1		4	0	0	0
+id:13801	MODBUS_INPUT_REGISTER	2248	1		4	0	0	0
+id:13802	MODBUS_INPUT_REGISTER	2249	1		4	0	0	0
+id:13803	MODBUS_INPUT_REGISTER	2250	1		4	0	0	0
 Offset cooling (EME20)	MODBUS_HOLDING_REGISTER	2667	1		1	-10	0	-1
 Offset heating (EME20)	MODBUS_HOLDING_REGISTER	2668	1		4	0	10	1
 Offset pool (EME20)	MODBUS_HOLDING_REGISTER	2669	1	°C	4	0	10	10
@@ -1350,58 +1365,58 @@ Cooling (EME20)	MODBUS_HOLDING_REGISTER	2666	1		4	0	1	0
 AUX (EME20)	MODBUS_HOLDING_REGISTER	2675	1		4	0	1	0
 id:14052	MODBUS_HOLDING_REGISTER	2670	1	kW	6	1	999	1
 id:14061	MODBUS_HOLDING_REGISTER	2672	1		4	0	1	0
-Temp­erature, Over­load, pool	MODBUS_HOLDING_REGISTER	0	1	°C	4	1	50	1
+Temperature, Overload, pool	MODBUS_HOLDING_REGISTER	0	1	°C	4	1	50	1
 EME20 API	MODBUS_HOLDING_REGISTER	2107	1		4	0	1	0
-EME20 API Include own consump­tion	MODBUS_HOLDING_REGISTER	2108	1		4	0	1	0
-EME20 API Avail­able power	MODBUS_HOLDING_REGISTER	2109	1		5	0	65535	0
-Exter­nal adjust­ment input, main unit (ECS1)	MODBUS_HOLDING_REGISTER	2111	1		4	0	1	0
-Exter­nal adjust­ment input (ECS2)	MODBUS_HOLDING_REGISTER	2112	1		4	0	1	0
-Exter­nal adjust­ment input (ECS3)	MODBUS_HOLDING_REGISTER	2113	1		4	0	1	0
-Exter­nal adjust­ment input (ECS4)	MODBUS_HOLDING_REGISTER	2114	1		4	0	1	0
-Exter­nal adjust­ment input (ECS5)	MODBUS_HOLDING_REGISTER	2115	1		4	0	1	0
-Exter­nal adjust­ment input (ECS6)	MODBUS_HOLDING_REGISTER	2116	1		4	0	1	0
-Exter­nal adjust­ment input (ECS7)	MODBUS_HOLDING_REGISTER	2117	1		4	0	1	0
-Exter­nal adjust­ment input (ECS8)	MODBUS_HOLDING_REGISTER	2118	1		4	0	1	0
-Zone 1 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2119	1		4	0	1	0
-Zone 2 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2120	1		4	0	1	0
-Zone 3 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2121	1		4	0	1	0
-Zone 4 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2122	1		4	0	1	0
-Zone 5 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2123	1		4	0	1	0
-Zone 6 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2124	1		4	0	1	0
-Zone 7 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2125	1		4	0	1	0
-Zone 8 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2126	1		4	0	1	0
-Zone 9 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2127	1		4	0	1	0
-Zone 10 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2128	1		4	0	1	0
-Zone 11 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2129	1		4	0	1	0
-Zone 12 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2130	1		4	0	1	0
-Zone 13 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2131	1		4	0	1	0
-Zone 14 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2132	1		4	0	1	0
-Zone 15 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2133	1		4	0	1	0
-Zone 16 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2134	1		4	0	1	0
-Zone 17 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2135	1		4	0	1	0
-Zone 18 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2136	1		4	0	1	0
-Zone 19 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2137	1		4	0	1	0
-Zone 20 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2138	1		4	0	1	0
-Zone 21 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2139	1		4	0	1	0
-Zone 22 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2140	1		4	0	1	0
-Zone 23 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2141	1		4	0	1	0
-Zone 24 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2142	1		4	0	1	0
-Zone 25 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2143	1		4	0	1	0
-Zone 26 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2144	1		4	0	1	0
-Zone 27 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2145	1		4	0	1	0
-Zone 28 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2146	1		4	0	1	0
-Zone 29 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2147	1		4	0	1	0
-Zone 30 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2148	1		4	0	1	0
-Zone 31 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2149	1		4	0	1	0
-Zone 32 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2150	1		4	0	1	0
-Zone 33 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2151	1		4	0	1	0
-Zone 34 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2152	1		4	0	1	0
-Zone 35 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2153	1		4	0	1	0
-Zone 36 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2154	1		4	0	1	0
-Zone 37 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2155	1		4	0	1	0
-Zone 38 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2156	1		4	0	1	0
-Zone 39 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2157	1		4	0	1	0
-Zone 40 affect­ed by ECS1	MODBUS_HOLDING_REGISTER	2158	1		4	0	1	0
+EME20 API Include own consumption	MODBUS_HOLDING_REGISTER	2108	1		4	0	1	0
+EME20 API Available power	MODBUS_HOLDING_REGISTER	2109	1		5	0	65535	0
+External adjustment input, main unit (ECS1)	MODBUS_HOLDING_REGISTER	2111	1		4	0	1	0
+External adjustment input (ECS2)	MODBUS_HOLDING_REGISTER	2112	1		4	0	1	0
+External adjustment input (ECS3)	MODBUS_HOLDING_REGISTER	2113	1		4	0	1	0
+External adjustment input (ECS4)	MODBUS_HOLDING_REGISTER	2114	1		4	0	1	0
+External adjustment input (ECS5)	MODBUS_HOLDING_REGISTER	2115	1		4	0	1	0
+External adjustment input (ECS6)	MODBUS_HOLDING_REGISTER	2116	1		4	0	1	0
+External adjustment input (ECS7)	MODBUS_HOLDING_REGISTER	2117	1		4	0	1	0
+External adjustment input (ECS8)	MODBUS_HOLDING_REGISTER	2118	1		4	0	1	0
+Zone 1 affected by ECS1	MODBUS_HOLDING_REGISTER	2119	1		4	0	1	0
+Zone 2 affected by ECS1	MODBUS_HOLDING_REGISTER	2120	1		4	0	1	0
+Zone 3 affected by ECS1	MODBUS_HOLDING_REGISTER	2121	1		4	0	1	0
+Zone 4 affected by ECS1	MODBUS_HOLDING_REGISTER	2122	1		4	0	1	0
+Zone 5 affected by ECS1	MODBUS_HOLDING_REGISTER	2123	1		4	0	1	0
+Zone 6 affected by ECS1	MODBUS_HOLDING_REGISTER	2124	1		4	0	1	0
+Zone 7 affected by ECS1	MODBUS_HOLDING_REGISTER	2125	1		4	0	1	0
+Zone 8 affected by ECS1	MODBUS_HOLDING_REGISTER	2126	1		4	0	1	0
+Zone 9 affected by ECS1	MODBUS_HOLDING_REGISTER	2127	1		4	0	1	0
+Zone 10 affected by ECS1	MODBUS_HOLDING_REGISTER	2128	1		4	0	1	0
+Zone 11 affected by ECS1	MODBUS_HOLDING_REGISTER	2129	1		4	0	1	0
+Zone 12 affected by ECS1	MODBUS_HOLDING_REGISTER	2130	1		4	0	1	0
+Zone 13 affected by ECS1	MODBUS_HOLDING_REGISTER	2131	1		4	0	1	0
+Zone 14 affected by ECS1	MODBUS_HOLDING_REGISTER	2132	1		4	0	1	0
+Zone 15 affected by ECS1	MODBUS_HOLDING_REGISTER	2133	1		4	0	1	0
+Zone 16 affected by ECS1	MODBUS_HOLDING_REGISTER	2134	1		4	0	1	0
+Zone 17 affected by ECS1	MODBUS_HOLDING_REGISTER	2135	1		4	0	1	0
+Zone 18 affected by ECS1	MODBUS_HOLDING_REGISTER	2136	1		4	0	1	0
+Zone 19 affected by ECS1	MODBUS_HOLDING_REGISTER	2137	1		4	0	1	0
+Zone 20 affected by ECS1	MODBUS_HOLDING_REGISTER	2138	1		4	0	1	0
+Zone 21 affected by ECS1	MODBUS_HOLDING_REGISTER	2139	1		4	0	1	0
+Zone 22 affected by ECS1	MODBUS_HOLDING_REGISTER	2140	1		4	0	1	0
+Zone 23 affected by ECS1	MODBUS_HOLDING_REGISTER	2141	1		4	0	1	0
+Zone 24 affected by ECS1	MODBUS_HOLDING_REGISTER	2142	1		4	0	1	0
+Zone 25 affected by ECS1	MODBUS_HOLDING_REGISTER	2143	1		4	0	1	0
+Zone 26 affected by ECS1	MODBUS_HOLDING_REGISTER	2144	1		4	0	1	0
+Zone 27 affected by ECS1	MODBUS_HOLDING_REGISTER	2145	1		4	0	1	0
+Zone 28 affected by ECS1	MODBUS_HOLDING_REGISTER	2146	1		4	0	1	0
+Zone 29 affected by ECS1	MODBUS_HOLDING_REGISTER	2147	1		4	0	1	0
+Zone 30 affected by ECS1	MODBUS_HOLDING_REGISTER	2148	1		4	0	1	0
+Zone 31 affected by ECS1	MODBUS_HOLDING_REGISTER	2149	1		4	0	1	0
+Zone 32 affected by ECS1	MODBUS_HOLDING_REGISTER	2150	1		4	0	1	0
+Zone 33 affected by ECS1	MODBUS_HOLDING_REGISTER	2151	1		4	0	1	0
+Zone 34 affected by ECS1	MODBUS_HOLDING_REGISTER	2152	1		4	0	1	0
+Zone 35 affected by ECS1	MODBUS_HOLDING_REGISTER	2153	1		4	0	1	0
+Zone 36 affected by ECS1	MODBUS_HOLDING_REGISTER	2154	1		4	0	1	0
+Zone 37 affected by ECS1	MODBUS_HOLDING_REGISTER	2155	1		4	0	1	0
+Zone 38 affected by ECS1	MODBUS_HOLDING_REGISTER	2156	1		4	0	1	0
+Zone 39 affected by ECS1	MODBUS_HOLDING_REGISTER	2157	1		4	0	1	0
+Zone 40 affected by ECS1	MODBUS_HOLDING_REGISTER	2158	1		4	0	1	0
 Input on ECS1 affects ECS1	MODBUS_HOLDING_REGISTER	2439	1		4	0	1	0
 Input on ECS1 affects ECS2	MODBUS_HOLDING_REGISTER	2440	1		4	0	1	0
 Input on ECS1 affects ECS3	MODBUS_HOLDING_REGISTER	2441	1		4	0	1	0
@@ -1410,15 +1425,15 @@ Input on ECS1 affects ECS5	MODBUS_HOLDING_REGISTER	2443	1		4	0	1	0
 Input on ECS1 affects ECS6	MODBUS_HOLDING_REGISTER	2444	1		4	0	1	0
 Input on ECS1 affects ECS7	MODBUS_HOLDING_REGISTER	2445	1		4	0	1	0
 Input on ECS1 affects ECS8	MODBUS_HOLDING_REGISTER	2446	1		4	0	1	0
-Exter­nal setting for adjust­ment migrat­ed	MODBUS_HOLDING_REGISTER	2503	1		4	0	1	0
-Max. step internal addi­tional heat	MODBUS_HOLDING_REGISTER	2504	1		4	0	7	3
-Version, inver­ter (EB101)	MODBUS_INPUT_REGISTER	2147	1		4	0	0	0
-Time between filter replace­ment	MODBUS_HOLDING_REGISTER	2676	1		4	1	24	3
-Time between filter replace­ment	MODBUS_HOLDING_REGISTER	2677	1		4	1	24	3
-Time between filter replace­ment	MODBUS_HOLDING_REGISTER	2678	1		4	1	24	3
-Time between filter replace­ment	MODBUS_HOLDING_REGISTER	2679	1		4	1	24	3
+External setting for adjustment migrated	MODBUS_HOLDING_REGISTER	2503	1		4	0	1	0
+Max. step internal additional heat	MODBUS_HOLDING_REGISTER	2504	1		4	0	7	3
+Version, inverter (EB101)	MODBUS_INPUT_REGISTER	2147	1		4	0	0	0
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2676	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2677	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2678	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2679	1		4	1	24	3
 Total oper. time ext. add. heat, heating	MODBUS_INPUT_REGISTER	2182	10	h	3	0	9999999	0
-Total HW run time addi­tional heat	MODBUS_INPUT_REGISTER	2184	10	h	3	0	9999999	0
+Total HW run time additional heat	MODBUS_INPUT_REGISTER	2184	10	h	3	0	9999999	0
 id:21077	MODBUS_HOLDING_REGISTER	3020	1		4	0	0	0
 id:21078	MODBUS_HOLDING_REGISTER	3021	1		4	0	0	0
 id:21079	MODBUS_HOLDING_REGISTER	3022	1		4	0	0	0
@@ -1443,11 +1458,11 @@ Return time fan 4	MODBUS_HOLDING_REGISTER	2712	1	h	4	1	24	4
 Return time fan 4	MODBUS_HOLDING_REGISTER	2713	1	h	4	1	24	4
 Return time fan 4	MODBUS_HOLDING_REGISTER	2714	1	h	4	1	24	4
 Return time fan 4	MODBUS_HOLDING_REGISTER	2715	1	h	4	1	24	4
-Time between filter replace­ment	MODBUS_HOLDING_REGISTER	2728	1		4	1	24	3
-Time between filter replace­ment	MODBUS_HOLDING_REGISTER	2729	1		4	1	24	3
-Time between filter replace­ment	MODBUS_HOLDING_REGISTER	2730	1		4	1	24	3
-Time between filter replace­ment	MODBUS_HOLDING_REGISTER	2731	1		4	1	24	3
-AUX from Modbus	MODBUS_HOLDING_REGISTER	2740	1		4	0	57	0
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2728	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2729	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2730	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2731	1		4	1	24	3
+AUX from Modbus	MODBUS_HOLDING_REGISTER	2740	1		4	0	59	0
 AUX from Modbus	MODBUS_HOLDING_REGISTER	2741	1		2	0	0	0
 Last defrost, heat pump 1	MODBUS_INPUT_REGISTER	2158	1		4	0	255	255
 ERS 2	MODBUS_HOLDING_REGISTER	2820	1		4	0	1	0
@@ -1482,6 +1497,25 @@ Fan mode 5	MODBUS_INPUT_REGISTER	2168	1	%	4	0	0	0
 Fan mode 6	MODBUS_INPUT_REGISTER	2169	1	%	4	0	0	0
 Fan mode 7	MODBUS_INPUT_REGISTER	2170	1	%	4	0	0	0
 Fan mode 8	MODBUS_INPUT_REGISTER	2171	1	%	4	0	0	0
+Disable emergency restart GP1	MODBUS_HOLDING_REGISTER	4204	1		4	0	1	0
+Disable emergency restart GP1	MODBUS_HOLDING_REGISTER	5025	1		4	0	1	0
+id:24483	MODBUS_HOLDING_REGISTER	5008	1		4	0	1	0
+id:24484	MODBUS_HOLDING_REGISTER	5009	10	°C	2	50	800	450
+id:24485	MODBUS_HOLDING_REGISTER	5010	10	°C	2	50	800	450
+id:24486	MODBUS_HOLDING_REGISTER	5011	10	°C	2	50	800	450
+id:24487	MODBUS_HOLDING_REGISTER	5012	10	°C	2	50	800	450
+id:24488	MODBUS_HOLDING_REGISTER	5013	10	°C	2	50	800	450
+id:24489	MODBUS_HOLDING_REGISTER	5014	10	°C	2	50	800	450
+id:24490	MODBUS_HOLDING_REGISTER	5015	10	°C	2	50	800	450
+id:24491	MODBUS_HOLDING_REGISTER	5016	10	°C	2	50	800	450
+id:24492	MODBUS_HOLDING_REGISTER	5017	10	°C	2	-50	300	250
+id:24493	MODBUS_HOLDING_REGISTER	5018	10	°C	2	-50	300	250
+id:24494	MODBUS_HOLDING_REGISTER	5019	10	°C	2	-50	300	250
+id:24495	MODBUS_HOLDING_REGISTER	5020	10	°C	2	-50	300	250
+id:24496	MODBUS_HOLDING_REGISTER	5021	10	°C	2	-50	300	250
+id:24497	MODBUS_HOLDING_REGISTER	5022	10	°C	2	-50	300	250
+id:24498	MODBUS_HOLDING_REGISTER	5023	10	°C	2	-50	300	250
+id:24499	MODBUS_HOLDING_REGISTER	5024	10	°C	2	-50	300	250
 id:55035	MODBUS_HOLDING_REGISTER	1555	1		4	0	40	0
 id:55036	MODBUS_HOLDING_REGISTER	1556	1		4	0	40	0
 id:55037	MODBUS_HOLDING_REGISTER	1557	1		4	0	40	0
@@ -1493,7 +1527,7 @@ id:55080	MODBUS_HOLDING_REGISTER	2881	1		4	0	1	0
 id:55081	MODBUS_HOLDING_REGISTER	2882	1		4	0	1	0
 id:55082	MODBUS_HOLDING_REGISTER	2883	1		4	0	1	0
 id:55083	MODBUS_HOLDING_REGISTER	2884	1		4	0	1	0
-Immer­sion heater power, emer­gency mode	MODBUS_HOLDING_REGISTER	3028	100	kW	2	0	4500	940
+Immersion heater power, emergency mode	MODBUS_HOLDING_REGISTER	3028	100	kW	2	0	4500	940
 Disable emergency restart GP1	MODBUS_HOLDING_REGISTER	3986	1		4	0	1	0
 Return line (AZ2-BT69)	MODBUS_INPUT_REGISTER	2190	10	°C	2	0	0	0
 Supply line (AZ2-BT68)	MODBUS_INPUT_REGISTER	2191	10	°C	2	0	0	0

--- a/nibe/data/smos40.json
+++ b/nibe/data/smos40.json
@@ -5840,7 +5840,7 @@
     "factor": 1,
     "size": "u8",
     "min": 0.0,
-    "max": 57.0,
+    "max": 59.0,
     "default": 0.0,
     "name": "input-aux5-40211",
     "write": true
@@ -5850,7 +5850,7 @@
     "factor": 1,
     "size": "u8",
     "min": 0.0,
-    "max": 57.0,
+    "max": 59.0,
     "default": 0.0,
     "name": "input-aux4-40212",
     "write": true
@@ -5860,7 +5860,7 @@
     "factor": 1,
     "size": "u8",
     "min": 0.0,
-    "max": 57.0,
+    "max": 59.0,
     "default": 0.0,
     "name": "input-aux3-40213",
     "write": true
@@ -5870,7 +5870,7 @@
     "factor": 1,
     "size": "u8",
     "min": 0.0,
-    "max": 57.0,
+    "max": 59.0,
     "default": 0.0,
     "name": "input-aux2-40214",
     "write": true
@@ -5880,7 +5880,7 @@
     "factor": 1,
     "size": "u8",
     "min": 0.0,
-    "max": 57.0,
+    "max": 59.0,
     "default": 0.0,
     "name": "input-aux1-40215",
     "write": true
@@ -6132,7 +6132,7 @@
     "factor": 1,
     "size": "u8",
     "min": 0.0,
-    "max": 57.0,
+    "max": 59.0,
     "default": 0.0,
     "name": "input-aux5-40767",
     "write": true
@@ -7978,7 +7978,6 @@
   "44200": {
     "title": "Power at DOT, manual value",
     "factor": 1,
-    "unit": "kW",
     "size": "u8",
     "min": 0.0,
     "max": 1.0,
@@ -9262,7 +9261,7 @@
     "factor": 1,
     "size": "u8",
     "min": 0.0,
-    "max": 57.0,
+    "max": 59.0,
     "default": 0.0,
     "name": "aux-from-modbus-42740",
     "write": true
@@ -9474,6 +9473,26 @@
     "unit": "%",
     "size": "u8",
     "name": "fan-mode-8-32171"
+  },
+  "44204": {
+    "title": "Disable emergency restart GP1",
+    "factor": 1,
+    "size": "u8",
+    "min": 0.0,
+    "max": 1.0,
+    "default": 0.0,
+    "name": "disable-emergency-restart-gp1-44204",
+    "write": true
+  },
+  "45025": {
+    "title": "Disable emergency restart GP1",
+    "factor": 1,
+    "size": "u8",
+    "min": 0.0,
+    "max": 1.0,
+    "default": 0.0,
+    "name": "disable-emergency-restart-gp1-45025",
+    "write": true
   },
   "43028": {
     "title": "Immersion heater power, emergency mode",

--- a/nibe/heatpump.py
+++ b/nibe/heatpump.py
@@ -33,6 +33,8 @@ class Model(Enum):
     F370 = "f370_f470"
     F470 = "f370_f470"
 
+    S320 = "s350"
+
     SMO20 = "smo20"
     SMO40 = "smo40"
 


### PR DESCRIPTION
* Updated file for SMOS40. I've kept the Roomsensor sensor that oddly was dropped. Also the file contains these annoying invisible line break points. That is why the diff is so large on the csv.
* Added S320 support
* Adjust numbering offset of parameters. The register in the CSV file, is the raw modbus value, we want the entity number instead which happens to be one larger.