### PR TITLE
Avoid crashing on numpy uint16

### DIFF
--- a/nibe/connection/modbus.py
+++ b/nibe/connection/modbus.py
@@ -43,7 +43,7 @@ def decode_u16_list(data: bytes, count: int) -> List[int]:
 
 def encode_u16_list(data: List[int]) -> bytes:
     return bytes(
-        byte for val in data for byte in val.to_bytes(2, "little", signed=False)
+        byte for val in data for byte in int(val).to_bytes(2, "little", signed=False)
     )
 
 

--- a/tests/connection/test_modbus.py
+++ b/tests/connection/test_modbus.py
@@ -2,7 +2,6 @@ from typing import List, Union
 from unittest.mock import AsyncMock, patch
 
 from async_modbus import AsyncClient
-import numpy
 import pytest
 
 from nibe.coil import Coil
@@ -37,6 +36,7 @@ def fixture_connection(heatpump: HeatPump):
         ("u32", [0, 32768], 0x80000000),
         ("u16", [1], 0x0001),
         ("u16", [32768], 0x8000),
+        ("u16", ["32768"], 0x8000),
         ("u8", [1], 0x01),
         ("u8", [128], 0x80),
     ],
@@ -49,7 +49,7 @@ async def test_read_holding_register_coil(
     value: Union[int, float, str],
 ):
     coil = Coil(40001, "test", "test", size, 1)
-    modbus_client.read_holding_registers.return_value = [numpy.uint16(x) for x in raw]
+    modbus_client.read_holding_registers.return_value = raw
     coil = await connection.read_coil(coil)
     assert coil.value == value
     modbus_client.read_holding_registers.assert_called()
@@ -88,6 +88,7 @@ async def test_write_holding_register(
         ("u32", [0, 32768], 0x80000000),
         ("u16", [1], 0x0001),
         ("u16", [32768], 0x8000),
+        ("u16", ["32768"], 0x8000),
         ("u8", [1], 0x01),
         ("u8", [128], 0x80),
     ],
@@ -100,7 +101,7 @@ async def test_read_input_register_coil(
     value: Union[int, float, str],
 ):
     coil = Coil(30001, "test", "test", size, 1)
-    modbus_client.read_input_registers.return_value = [numpy.uint16(x) for x in raw]
+    modbus_client.read_input_registers.return_value = raw
     coil = await connection.read_coil(coil)
     assert coil.value == value
     modbus_client.read_input_registers.assert_called()
@@ -111,6 +112,7 @@ async def test_read_input_register_coil(
     [
         ("u8", [1], 0x01),
         ("u8", [0], 0x00),
+        ("u8", ["0"], 0x00),
     ],
 )
 async def test_read_discrete_input_coil(
@@ -121,7 +123,7 @@ async def test_read_discrete_input_coil(
     value: Union[int, float, str],
 ):
     coil = Coil(10001, "test", "test", size, 1)
-    modbus_client.read_discrete_inputs.return_value = [numpy.uint16(x) for x in raw]
+    modbus_client.read_discrete_inputs.return_value = raw
     coil = await connection.read_coil(coil)
     assert coil.value == value
     modbus_client.read_discrete_inputs.assert_called()
@@ -132,6 +134,7 @@ async def test_read_discrete_input_coil(
     [
         ("u8", [1], 0x01),
         ("u8", [0], 0x00),
+        ("u8", ["0"], 0x00),
     ],
 )
 async def test_read_coil_coil(

--- a/tests/connection/test_modbus.py
+++ b/tests/connection/test_modbus.py
@@ -2,6 +2,7 @@ from typing import List, Union
 from unittest.mock import AsyncMock, patch
 
 from async_modbus import AsyncClient
+import numpy
 import pytest
 
 from nibe.coil import Coil
@@ -48,7 +49,7 @@ async def test_read_holding_register_coil(
     value: Union[int, float, str],
 ):
     coil = Coil(40001, "test", "test", size, 1)
-    modbus_client.read_holding_registers.return_value = raw
+    modbus_client.read_holding_registers.return_value = [numpy.uint16(x) for x in raw]
     coil = await connection.read_coil(coil)
     assert coil.value == value
     modbus_client.read_holding_registers.assert_called()
@@ -99,7 +100,7 @@ async def test_read_input_register_coil(
     value: Union[int, float, str],
 ):
     coil = Coil(30001, "test", "test", size, 1)
-    modbus_client.read_input_registers.return_value = raw
+    modbus_client.read_input_registers.return_value = [numpy.uint16(x) for x in raw]
     coil = await connection.read_coil(coil)
     assert coil.value == value
     modbus_client.read_input_registers.assert_called()
@@ -120,7 +121,7 @@ async def test_read_discrete_input_coil(
     value: Union[int, float, str],
 ):
     coil = Coil(10001, "test", "test", size, 1)
-    modbus_client.read_discrete_inputs.return_value = raw
+    modbus_client.read_discrete_inputs.return_value = [numpy.uint16(x) for x in raw]
     coil = await connection.read_coil(coil)
     assert coil.value == value
     modbus_client.read_discrete_inputs.assert_called()


### PR DESCRIPTION
```
2022-10-20 15:19:10.494 ERROR (MainThread) [custom_components.nibe_heatpump] Unexpected exception
Traceback (most recent call last):
  File "/config/custom_components/nibe_heatpump/config_flow.py", line 191, in async_step_modbus
    title, data = await validate_modbus_input(self.hass, user_input)
  File "/config/custom_components/nibe_heatpump/config_flow.py", line 144, in validate_modbus_input
    coil = await connection.read_coil(coil)
  File "/usr/local/lib/python3.10/site-packages/nibe/connection/modbus.py", line 110, in read_coil
    coil.value = self.coil_encoder.decode(coil, encode_u16_list(result))
  File "/usr/local/lib/python3.10/site-packages/nibe/connection/modbus.py", line 45, in encode_u16_list
    return bytes(
  File "/usr/local/lib/python3.10/site-packages/nibe/connection/modbus.py", line 46, in <genexpr>
    byte for val in data for byte in val.to_bytes(2, "little", signed=False)
AttributeError: 'numpy.uint16' object has no attribute 'to_bytes'
```