### PR TITLE
Add missing modbus fields to f730 and smo20

### DIFF
--- a/nibe/data/extensions.json
+++ b/nibe/data/extensions.json
@@ -105,5 +105,36 @@
         }
       }
     }
+  },
+  {
+    "files": ["f730.json", "smo20.json"],
+    "data": {
+      "48852": {
+        "title": "Modbus40 Word Swap",
+        "info": "If set; swapping the words in 32-bit variables when value requested via ''read holding register'' commando.",
+        "size": "u8",
+        "factor": 1,
+        "min": 0.0,
+        "max": 1.0,
+        "default": 1.0,
+        "name": "modbus40-word-swap-48852",
+        "write": true
+      },
+      "48889": {
+        "title": "MODBUS40 Disable LOG.SET",
+        "info": "If set, the system will ignore the existing LOG.SET on the USB stick.1=ignore LOG.SET,0=use LOG.SET",
+        "size": "u8",
+        "factor": 1,
+        "min": 0.0,
+        "max": 1.0,
+        "default": 0.0,
+        "name": "modbus40-disable-log-set-48889",
+        "write": true,
+        "mappings": {
+          "0": "use LOG.SET",
+          "1": "ignore LOG.SET"
+        }
+      }
+    }
   }
 ]

--- a/nibe/data/f730.json
+++ b/nibe/data/f730.json
@@ -5406,5 +5406,31 @@
     "default": 6.0,
     "name": "night-cooling-min-diff-49366",
     "write": true
+  },
+  "48852": {
+    "title": "Modbus40 Word Swap",
+    "info": "If set; swapping the words in 32-bit variables when value requested via ''read holding register'' commando.",
+    "size": "u8",
+    "factor": 1,
+    "min": 0.0,
+    "max": 1.0,
+    "default": 1.0,
+    "name": "modbus40-word-swap-48852",
+    "write": true
+  },
+  "48889": {
+    "title": "MODBUS40 Disable LOG.SET",
+    "info": "If set, the system will ignore the existing LOG.SET on the USB stick.1=ignore LOG.SET,0=use LOG.SET",
+    "size": "u8",
+    "factor": 1,
+    "min": 0.0,
+    "max": 1.0,
+    "default": 0.0,
+    "name": "modbus40-disable-log-set-48889",
+    "write": true,
+    "mappings": {
+      "0": "use LOG.SET",
+      "1": "ignore LOG.SET"
+    }
   }
 }

--- a/nibe/data/smo20.json
+++ b/nibe/data/smo20.json
@@ -3360,5 +3360,31 @@
       "0": "not activated",
       "1": "activated"
     }
+  },
+  "48852": {
+    "title": "Modbus40 Word Swap",
+    "info": "If set; swapping the words in 32-bit variables when value requested via ''read holding register'' commando.",
+    "size": "u8",
+    "factor": 1,
+    "min": 0.0,
+    "max": 1.0,
+    "default": 1.0,
+    "name": "modbus40-word-swap-48852",
+    "write": true
+  },
+  "48889": {
+    "title": "MODBUS40 Disable LOG.SET",
+    "info": "If set, the system will ignore the existing LOG.SET on the USB stick.1=ignore LOG.SET,0=use LOG.SET",
+    "size": "u8",
+    "factor": 1,
+    "min": 0.0,
+    "max": 1.0,
+    "default": 0.0,
+    "name": "modbus40-disable-log-set-48889",
+    "write": true,
+    "mappings": {
+      "0": "use LOG.SET",
+      "1": "ignore LOG.SET"
+    }
   }
 }


### PR DESCRIPTION
These models are missing the modbus fields from their exports which are needed for home assistant to detect the units

Fixes: https://github.com/elupus/esphome-nibe/issues/16