### PR TITLE
Empty byte in response is actually part of addressing

### DIFF
--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -595,10 +595,11 @@ Command = Enum(
     ECS_DATA_MSG_1=0x55,
     ECS_DATA_MSG_2=0xA0,
     STRING_MSG=0xB1,
+    HEATPUMP_REQ=0xF7,
 )
 
 Address = Enum(
-    Int8ub,
+    Int16ub,
     ECS_S2=0x02,
     # 0x13 = 19, ?
     SMS40=0x16,
@@ -607,6 +608,14 @@ Address = Enum(
     RMU40_S3=0x1B,
     RMU40_S4=0x1C,
     MODBUS40=0x20,
+    HEATPUMP_1=0x41C9,
+    HEATPUMP_2=0x42C9,
+    HEATPUMP_3=0x43C9,
+    HEATPUMP_4=0x44C9,
+    HEATPUMP_5=0x45C9,
+    HEATPUMP_6=0x46C9,
+    HEATPUMP_7=0x47C9,
+    HEATPUMP_8=0x48C9,
 )
 
 RmuWriteIndex = Enum(
@@ -628,7 +637,6 @@ ADDRESS_TO_ROOM_TEMP_COIL = {
 # fmt: off
 Response = Struct(
     "start_byte" / Const(0x5C, Int8ub),
-    "empty_byte" / Const(0x00, Int8ub),
     "fields" / RawCopy(
         Struct(
             "address" / Address,

--- a/tests/connection/test_nibegw_message_parsing.py
+++ b/tests/connection/test_nibegw_message_parsing.py
@@ -16,6 +16,13 @@ class MessageResponseParsingTestCase(unittest.TestCase):
         assert data.data.coil_address == 47372
         assert data.data.value == b"\x01\x00\x00\x00"
 
+    def test_parse_token_response_16bit_address(self):
+        data = self._parse_hexlified_raw_message("5c41c9f7007f06")
+        assert data.address == "HEATPUMP_1"
+        assert data.cmd == "HEATPUMP_REQ"
+        assert data.length == 0
+        assert data.data == b""
+
     def test_parse_escaped_read_response(self):
         data = self._parse_hexlified_raw_message("5c00206a074f9c5c5c002c00b2")
 


### PR DESCRIPTION
The empty byte that was assumed to be constant 0 is actually part of the addressing. For nibe heatpumps like 2021, this is used for communication with other heat pumps.

This was found out during analysis of issue on home assistant and discussions on nibepi forums, where some details on the numbers additional pumps where found.

Related to: https://github.com/home-assistant/core/issues/81748 
Related to: https://github.com/elupus/esphome-nibe/pull/17