### PR TITLE
Postpone exception until after all read

### DIFF
--- a/nibe/exceptions.py
+++ b/nibe/exceptions.py
@@ -1,3 +1,6 @@
+from exceptiongroup import ExceptionGroup
+
+
 class NibeException(Exception):
     pass
 
@@ -44,6 +47,12 @@ class ReadException(NibeException):
 
 class CoilReadException(ReadException):
     pass
+
+
+class CoilReadExceptionGroup(ExceptionGroup, CoilReadException):
+    def __str__(self) -> str:
+        messages = ", ".join(str(exception) for exception in self._exceptions)
+        return f"{self.message} ({messages})"
 
 
 class CoilReadSendException(CoilReadException):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ async_timeout >= 4.0.0
 black>=22.0.0
 construct >= 2.10.0, < 3.0.0
 coverage>=6.0.0
+exceptiongroup >= 1.0.0
 isort>=5.0.0
 
 pandas>=1.0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     async_modbus >= 0.2.0
     async_timeout >= 4.0.0
     tenacity >= 8.0.0
-    exceptiongroup
+    exceptiongroup >= 1.0.0
 
 [options.package_data]
 * = *.json, *.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     async_modbus >= 0.2.0
     async_timeout >= 4.0.0
     tenacity >= 8.0.0
+    exceptiongroup
 
 [options.package_data]
 * = *.json, *.md

--- a/tests/connection/test_init.py
+++ b/tests/connection/test_init.py
@@ -1,0 +1,32 @@
+from pytest import raises
+
+from nibe.coil import Coil
+from nibe.connection import Connection
+from nibe.exceptions import CoilReadException, CoilWriteException
+
+
+async def test_read_coils():
+    coil1 = Coil(123, "test", "test", "u8")
+    coil2 = Coil(231, "test2", "test", "u8")
+    coil3 = Coil(231, "test3", "test", "u8")
+
+    class MyConnection(Connection):
+        async def read_coil(self, coil: Coil, timeout: float = ...) -> Coil:
+            if coil is coil2:
+                raise CoilReadException(f"{coil.address}")
+            return coil
+
+        async def verify_connectivity(self):
+            return True
+
+        async def write_coil(self, coil: Coil, timeout: float = ...) -> Coil:
+            raise CoilWriteException()
+
+    connection = MyConnection()
+
+    result = []
+    with raises(CoilReadException) as excinfo:
+        async for coil in connection.read_coils([coil1, coil2, coil3]):
+            result.append(coil)
+    assert str(excinfo.value) == "Failed to read some or all coils (231)"
+    assert result == [coil1, coil3]


### PR DESCRIPTION
The current read_coils function would abort on first error, even if some of the wanted coils could be read. Group up all read exceptions in an exception group and raise after iteration is completed.