### PR TITLE
Allow data removal by setting value to `null` in extensions.json

### DIFF
--- a/nibe/console_scripts/convert_csv.py
+++ b/nibe/console_scripts/convert_csv.py
@@ -13,10 +13,12 @@ from nibe.heatpump import HeatPump, Model
 logger = logging.getLogger("nibe").getChild(__name__)
 
 
-def update_dict(d: MutableMapping, u: Mapping) -> Mapping:
+def update_dict(d: MutableMapping, u: Mapping, removeExplicitNulls: bool) -> Mapping:
     for k, v in u.items():
-        if isinstance(v, Mapping):
-            update_dict(d.setdefault(k, {}), v)
+        if v is None and removeExplicitNulls:
+            d.pop(k, None)
+        elif isinstance(v, Mapping):
+            update_dict(d.setdefault(k, {}), v, removeExplicitNulls)
         else:
             d[k] = v
 
@@ -238,7 +240,7 @@ class CSVConverter:
 
     def _export_to_file(self):
         o = self._make_dict()
-        update_dict(o, self.extensions)
+        update_dict(o, self.extensions, True)
         with open(self.out_file, "w") as fh:
             json.dump(o, fh, indent=2, default=self._convert_series_to_dict)
             fh.write("\n")
@@ -255,12 +257,12 @@ async def run():
         for extra in all_extensions:
             if out_file.name not in extra["files"]:
                 continue
-            update_dict(extensions, extra["data"])
+            update_dict(extensions, extra["data"], False)
 
         logger.info(f"Converting {in_file} to {out_file}")
         try:
             CSVConverter(in_file, out_file, extensions).convert()
-
+            
             await _validate(out_file)
 
             logger.info(f"Converted {in_file} to {out_file}")


### PR DESCRIPTION
This allows for setting a value of a certain key to `null`, while converting `csv` to `json` the key & value pair will be removed. Needed for necessary extensions.json edit to allow for a fix of #77.

Example usage (`extensions.json`):
```json
"data": {
 "47377": {
    "mappings": null
  }
}
```

<table> 
<thead>
<th> Before </th>
<th>After </th>
</thead>
<tr>
<td>
<pre><code>"47377": {
  "title": "Outdoor Filter Time",
  "info": " 12=12 Hours 24=24 Hours",
  "unit": "h",
  "size": "u8",
  "factor": 1,
  "min": 0.0,
  "max": 48.0,
  "default": 24.0,
  "name": "outdoor-filter-time-47377",
  "write": true,
  "mappings": {
    "12": "12 Hours",
    "24": "24 Hours"
  }
}</code></pre>
</td>
<td>
<pre><code>"47377": {
  "title": "Outdoor Filter Time",
  "info": " 12=12 Hours 24=24 Hours",
  "unit": "h",
  "size": "s16",
  "factor": 1,
  "min": 0.0,
  "max": 48.0,
  "default": 24.0,
  "name": "outdoor-filter-time-47377",
  "write": true
}
</code></pre>
</td>
</tr>
</table>