### PR TITLE
Convert SMO40 filter time to numeric value

### DIFF
--- a/nibe/data/extensions.json
+++ b/nibe/data/extensions.json
@@ -226,5 +226,17 @@
         "unit": "A"
       }
     }
+  },
+  {
+    "description": "Allow for numerical selection for Outdoor Filter Time",
+    "files": [
+      "smo40.json"
+    ],
+    "data": {
+     "47377": {
+        "size": "s16",
+        "mappings": null
+      }
+    }
   }
 ]

--- a/nibe/data/smo40.json
+++ b/nibe/data/smo40.json
@@ -7394,17 +7394,13 @@
     "title": "Outdoor Filter Time",
     "info": " 12=12 Hours 24=24 Hours",
     "unit": "h",
-    "size": "u8",
+    "size": "s16",
     "factor": 1,
     "min": 0.0,
     "max": 48.0,
     "default": 24.0,
     "name": "outdoor-filter-time-47377",
-    "write": true,
-    "mappings": {
-      "12": "12 Hours",
-      "24": "24 Hours"
-    }
+    "write": true
   },
   "47378": {
     "title": "Max diff. comp.",


### PR DESCRIPTION
This PR converts `Outdoor Filter Time` to a numerical value instead of an enum. For SMO40 this binding allows for any value between `1-48` as discussed in #77, setting this to an enum seems to be a copy paste mistake somewhere (Nibe themselves?). If you feel more heatpumps should support this, please feel free to add them.

This PR is dependent on #78.