### PR TITLE
Fix invalid datatype of `Cooling with room sensor` for SMO40

### DIFF
--- a/nibe/data/extensions.json
+++ b/nibe/data/extensions.json
@@ -238,5 +238,21 @@
         "mappings": null
       }
     }
+  },
+  {
+    "description": "Fix invalid datatype of 'Cooling with room sensor'",
+    "files": [
+      "smo40.json"
+    ],
+    "data": {
+      "47340": {
+         "factor": 1,
+         "max": 1.0,
+         "mappings": {
+           "0": "Off",
+           "1": "On"
+         }
+      }
+    }
   }
 ]

--- a/nibe/data/smo40.json
+++ b/nibe/data/smo40.json
@@ -7248,12 +7248,16 @@
     "title": "Cooling with room sensor",
     "info": "Enables use of room sensor together with cooling 0=Off 1=On",
     "size": "u8",
-    "factor": 10,
+    "factor": 1,
     "min": 0.0,
-    "max": 18.0,
+    "max": 1.0,
     "default": 0.0,
     "name": "cooling-with-room-sensor-47340",
-    "write": true
+    "write": true,
+    "mappings": {
+      "0": "Off",
+      "1": "On"
+    }
   },
   "47343": {
     "title": "Start Active Cooling DM",


### PR DESCRIPTION
Should be a binary toggle, description says `0=Off 1=On`. Took necessary edits from `47394`. This should cascade down to home assistant, enabling `Heat/Cool` for the climate entries provided by @elupus' integration ([this line](https://github.com/home-assistant/core/blob/dev/homeassistant/components/nibe_heatpump/climate.py#L142)). For your convenience, I've already regenerated `smo40.json` this time :).