### PR TITLE
Adding SMOS40 energy logs for S2125

### DIFF
--- a/nibe/data/smos40.csv
+++ b/nibe/data/smos40.csv
@@ -1516,6 +1516,19 @@ id:24496	MODBUS_HOLDING_REGISTER	5021	10	°C	2	-50	300	250
 id:24497	MODBUS_HOLDING_REGISTER	5022	10	°C	2	-50	300	250
 id:24498	MODBUS_HOLDING_REGISTER	5023	10	°C	2	-50	300	250
 id:24499	MODBUS_HOLDING_REGISTER	5024	10	°C	2	-50	300	250
+Energy log - Energy produced for heat during current hour	MODBUS_INPUT_REGISTER	2283	100	kWh	6	0	0	0
+Energy log - Energy produced for hot water during current hour	MODBUS_INPUT_REGISTER	2285	100	kWh	6	0	0	0
+Energy log - Energy produced for pool during current hour	MODBUS_INPUT_REGISTER	2287	100	kWh	6	0	0	0
+Energy log - Energy produced for cooling during current hour	MODBUS_INPUT_REGISTER	2289	100	kWh	6	0	0	0
+Energy log - Energy used for heat during current hour	MODBUS_INPUT_REGISTER	2291	100	kWh	6	0	0	0
+Energy log - Energy used for hot water during current hour	MODBUS_INPUT_REGISTER	2293	100	kWh	6	0	0	0
+Energy log - Energy used for pool during current hour	MODBUS_INPUT_REGISTER	2295	100	kWh	6	0	0	0
+Energy log - Energy used for cooling during current hour	MODBUS_INPUT_REGISTER	2297	100	kWh	6	0	0	0
+Energy log - Energy used by additional heater for heat during current hour	MODBUS_INPUT_REGISTER	2299	100	kWh	6	0	0	0
+Energy log - Energy used by additional heater for hot water during current hour	MODBUS_INPUT_REGISTER	2301	100	kWh	6	0	0	0
+Energy log - Energy used by additional heater for pool during current hour	MODBUS_INPUT_REGISTER	2303	100	kWh	6	0	0	0
+Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kW	6	0	0	0
+Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2307	100	kW	6	0	0	0
 id:55035	MODBUS_HOLDING_REGISTER	1555	1		4	0	40	0
 id:55036	MODBUS_HOLDING_REGISTER	1556	1		4	0	40	0
 id:55037	MODBUS_HOLDING_REGISTER	1557	1		4	0	40	0

--- a/nibe/data/smos40.json
+++ b/nibe/data/smos40.json
@@ -9515,6 +9515,97 @@
     "name": "disable-emergency-restart-gp1-43987",
     "write": true
   },
+  "32284": {
+    "title": "Energy log - Energy produced for heat during current hour",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "name": "energy-log-energy-produced-for-heat-during-current-hour-32284"
+  },
+  "32286": {
+    "title": "Energy log - Energy produced for hot water during current hour",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "name": "energy-log-energy-produced-for-hot-water-during-current-hour-32286"
+  },
+  "32288": {
+    "title": "Energy log - Energy produced for pool during current hour",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "name": "energy-log-energy-produced-for-pool-during-current-hour-32288"
+  },
+  "32290": {
+    "title": "Energy log - Energy produced for cooling during current hour",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "name": "energy-log-energy-produced-for-cooling-during-current-hour-32290"
+  },
+  "32292": {
+    "title": "Energy log - Energy used for heat during current hour",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "name": "energy-log-energy-used-for-heat-during-current-hour-32292"
+  },
+  "32294": {
+    "title": "Energy log - Energy used for hot water during current hour",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "name": "energy-log-energy-used-for-hot-water-during-current-hour-32294"
+  },
+  "32296": {
+    "title": "Energy log - Energy used for pool during current hour",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "name": "energy-log-energy-used-for-pool-during-current-hour-32296"
+  },
+  "32298": {
+    "title": "Energy log - Energy used for cooling during current hour",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "name": "energy-log-energy-used-for-cooling-during-current-hour-32298"
+  },
+  "32300": {
+    "title": "Energy log - Energy used by additional heater for heat during current hour",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "name": "energy-log-energy-used-by-additional-heater-for-heat-during-current-hour-32300"
+  },
+  "32302": {
+    "title": "Energy log - Energy used by additional heater for hot water during current hour",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "name": "energy-log-energy-used-by-additional-heater-for-hot-water-during-current-hour-32302"
+  },
+  "32304": {
+    "title": "Energy log - Energy used by additional heater for pool during current hour",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "name": "energy-log-energy-used-by-additional-heater-for-pool-during-current-hour-32304"
+  },
+  "32306": {
+    "title": "Energy log - Current power consumption",
+    "factor": 100,
+    "unit": "kW",
+    "size": "u32",
+    "name": "energy-log-current-power-consumption-32306"
+  },
+  "32308": {
+    "title": "Energy log - Current power consumption, components",
+    "factor": 100,
+    "unit": "kW",
+    "size": "u32",
+    "name": "energy-log-current-power-consumption-components-32308"
+  },
   "32191": {
     "title": "Return line (AZ2-BT69)",
     "factor": 10,


### PR DESCRIPTION
I have a KNV / Nibe S2125-12 running since a few days and this PR adds the missing energy logs provided by SMOS40 mentioned in #92 