### PR TITLE
ReadExceptionGroup must be all exceptions

### DIFF
--- a/nibe/connection/__init__.py
+++ b/nibe/connection/__init__.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterable
 
 from nibe.coil import Coil, CoilData
-from nibe.exceptions import ReadExceptionGroup, ReadIOException
+from nibe.exceptions import ReadException, ReadExceptionGroup
 from nibe.heatpump import HeatPump, ProductInfo, Series
 
 DEFAULT_TIMEOUT: float = 5
@@ -41,7 +41,7 @@ class Connection(ABC):
         for coil in coils:
             try:
                 yield await self.read_coil(coil, timeout)
-            except ReadIOException as exception:
+            except ReadException as exception:
                 exceptions.append(exception)
         if exceptions:
             raise ReadExceptionGroup("Failed to read some or all coils", exceptions)

--- a/nibe/exceptions.py
+++ b/nibe/exceptions.py
@@ -53,7 +53,7 @@ class ReadIOException(ReadException):
     pass
 
 
-class ReadExceptionGroup(ExceptionGroup, ReadIOException):
+class ReadExceptionGroup(ExceptionGroup, ReadException):
     def __str__(self) -> str:
         messages = ", ".join(str(exception) for exception in self.exceptions)
         return f"{self.message} ({messages})"

--- a/tests/connection/test_init.py
+++ b/tests/connection/test_init.py
@@ -2,18 +2,26 @@ from pytest import raises
 
 from nibe.coil import Coil, CoilData
 from nibe.connection import Connection
-from nibe.exceptions import ReadExceptionGroup, ReadIOException, WriteIOException
+from nibe.exceptions import (
+    ReadException,
+    ReadExceptionGroup,
+    ReadIOException,
+    WriteIOException,
+)
 
 
 async def test_read_coils():
     coil1 = Coil(123, "test", "test", "u8")
     coil2 = Coil(231, "test2", "test", "u8")
     coil3 = Coil(231, "test3", "test", "u8")
+    coil4 = Coil(233, "test3", "test", "u8")
 
     class MyConnection(Connection):
         async def read_coil(self, coil: Coil, timeout: float = ...) -> CoilData:
             if coil is coil2:
                 raise ReadIOException(f"{coil.address}")
+            if coil is coil4:
+                raise ReadException(f"{coil.address}")
             return CoilData(coil, 1)
 
         async def verify_connectivity(self):
@@ -26,7 +34,7 @@ async def test_read_coils():
 
     coils = []
     with raises(ReadExceptionGroup) as excinfo:
-        async for coil_data in connection.read_coils([coil1, coil2, coil3]):
+        async for coil_data in connection.read_coils([coil1, coil2, coil3, coil4]):
             coils.append(coil_data.coil)
-    assert str(excinfo.value) == "Failed to read some or all coils (231)"
+    assert str(excinfo.value) == "Failed to read some or all coils (231, 233)"
     assert coils == [coil1, coil3]


### PR DESCRIPTION
We must wrap both IO exceptions and standard (Decode) exceptions in the read exception group so we can handle them independently in home assistant.

Related to: https://github.com/home-assistant/core/issues/89027