### PR TITLE
Add data for VVM S320 + F2120-8 + ERS S10-500

### DIFF
--- a/nibe/data/vvms320_f2120-8_erss10-500.csv
+++ b/nibe/data/vvms320_f2120-8_erss10-500.csv
@@ -1,0 +1,1238 @@
+Title	Register type	Register	Division factor	Unit	Size of variable	Min value	Max value	Default value	
+Current outdoor temperature (BT1)	MODBUS_INPUT_REGISTER	1	10	°C	2	0	0	0
+Supply line (EP23-BT2)	MODBUS_INPUT_REGISTER	2	10	°C	2	0	0	0
+Supply line (EP22-BT2)	MODBUS_INPUT_REGISTER	3	10	°C	2	0	0	0
+Supply line (EP21-BT2)	MODBUS_INPUT_REGISTER	4	10	°C	2	0	0	0
+Supply line (BT2)	MODBUS_INPUT_REGISTER	5	10	°C	2	0	0	0
+Return line (BT3)	MODBUS_INPUT_REGISTER	7	10	°C	2	0	0	0
+Hot water top (BT7)	MODBUS_INPUT_REGISTER	8	10	°C	2	0	0	0
+Hot water charging (BT6)	MODBUS_INPUT_REGISTER	9	10	°C	2	0	0	0
+Exh. air (AZ30-BT20)	MODBUS_INPUT_REGISTER	19	10	°C	2	0	0	0
+Extr. air (AZ30-BT21)	MODBUS_INPUT_REGISTER	20	10	°C	2	0	0	0
+Temperature limiter (EB100-FD1)	MODBUS_INPUT_REGISTER	36	1		2	0	0	0
+Average temperature (BT1)	MODBUS_INPUT_REGISTER	37	10	°C	2	0	0	0
+Boiler temperature (BT52)	MODBUS_INPUT_REGISTER	38	10	°C	2	0	0	0
+Flow sensor (BF1)	MODBUS_INPUT_REGISTER	40	10	l/m	2	0	0	0
+Electrical anode (EB100-FR1)	MODBUS_INPUT_REGISTER	41	1		2	0	0	0
+Supp. air (AZ30-BT22)	MODBUS_INPUT_REGISTER	42	10	°C	2	0	0	0
+Exh. air (AZ33-BT20)	MODBUS_INPUT_REGISTER	60	10	°C	2	0	0	0
+Exh. air (AZ32-BT20)	MODBUS_INPUT_REGISTER	61	10	°C	2	0	0	0
+Exh. air (AZ31-BT20)	MODBUS_INPUT_REGISTER	62	10	°C	2	0	0	0
+Extract air (AZ33-BT21)	MODBUS_INPUT_REGISTER	63	10	°C	2	0	0	0
+Extract air (AZ32-BT21)	MODBUS_INPUT_REGISTER	64	10	°C	2	0	0	0
+Extract air (AZ31-BT21)	MODBUS_INPUT_REGISTER	65	10	°C	2	0	0	0
+Additional heat (BT63)	MODBUS_INPUT_REGISTER	72	10	°C	2	0	0	0
+Return line (EP23-BT3)	MODBUS_INPUT_REGISTER	75	10	°C	2	0	0	0
+Return line (EP22-BT3)	MODBUS_INPUT_REGISTER	76	10	°C	2	0	0	0
+Return line (EP21-BT3)	MODBUS_INPUT_REGISTER	77	10	°C	2	0	0	0
+Return line (EP15-BT3)	MODBUS_INPUT_REGISTER	78	10	°C	2	0	0	0
+Outgoing hot water (BT70)	MODBUS_INPUT_REGISTER	87	10	°C	2	0	0	0
+Supply line (EP47-BT2)	MODBUS_INPUT_REGISTER	94	10	°C	2	0	0	0
+Supply line (EP46-BT2)	MODBUS_INPUT_REGISTER	95	10	°C	2	0	0	0
+Supply line (EP45-BT2)	MODBUS_INPUT_REGISTER	96	10	°C	2	0	0	0
+Supply line (EP44-BT2)	MODBUS_INPUT_REGISTER	97	10	°C	2	0	0	0
+Return line (EP47-BT3)	MODBUS_INPUT_REGISTER	98	10	°C	2	0	0	0
+Return line (EP46-BT3)	MODBUS_INPUT_REGISTER	99	10	°C	2	0	0	0
+Return line (EP45-BT3)	MODBUS_INPUT_REGISTER	100	10	°C	2	0	0	0
+Return line (EP44-BT3)	MODBUS_INPUT_REGISTER	101	10	°C	2	0	0	0
+Outd temperature (AZ30-BT23)	MODBUS_INPUT_REGISTER	107	10	°C	2	0	0	0
+id:149	MODBUS_INPUT_REGISTER	108	10	°C	2	0	0	0
+Room average temp. clim. system 8 (BT50)	MODBUS_INPUT_REGISTER	109	10	°C	2	0	0	0
+Room average temp. clim. system 7 (BT50)	MODBUS_INPUT_REGISTER	110	10	°C	2	0	0	0
+Room average temp. clim. system 6 (BT50)	MODBUS_INPUT_REGISTER	111	10	°C	2	0	0	0
+Room average temp. clim. system 5 (BT50)	MODBUS_INPUT_REGISTER	112	10	°C	2	0	0	0
+Room average temp. clim. system 4 (BT50)	MODBUS_INPUT_REGISTER	113	10	°C	2	0	0	0
+Room average temp. clim. system 3 (BT50)	MODBUS_INPUT_REGISTER	114	10	°C	2	0	0	0
+Room average temp. clim. system 2 (BT50)	MODBUS_INPUT_REGISTER	115	10	°C	2	0	0	0
+Room average temp. clim. system 1 (BT50)	MODBUS_INPUT_REGISTER	116	10	°C	2	0	0	0
+External cooling supply temperature (BT25)	MODBUS_INPUT_REGISTER	119	10	°C	2	0	0	0
+id:193	MODBUS_INPUT_REGISTER	128	1		4	0	0	0
+Oper. mode shunt climate system 8	MODBUS_INPUT_REGISTER	129	1		4	0	0	0
+Oper. mode shunt climate system 7	MODBUS_INPUT_REGISTER	130	1		4	0	0	0
+Oper. mode shunt climate system 6	MODBUS_INPUT_REGISTER	131	1		4	0	0	0
+Oper. mode shunt climate system 5	MODBUS_INPUT_REGISTER	132	1		4	0	0	0
+id:246	MODBUS_INPUT_REGISTER	133	1		4	0	0	0
+Relay status (ERS 1)	MODBUS_INPUT_REGISTER	134	1		4	0	0	0
+Fan speed (AZ30-GQ2)	MODBUS_INPUT_REGISTER	135	1	%	4	0	0	0
+Fan speed (AZ30-GQ3)	MODBUS_INPUT_REGISTER	136	1	%	4	0	0	0
+Current hot water mode controlled by	MODBUS_INPUT_REGISTER	137	1		1	0	0	0
+Max. compressor frequency, heating	MODBUS_INPUT_REGISTER	141	100	Hz	5	0	0	0
+Inverter alarm code	MODBUS_INPUT_REGISTER	142	1		5	0	0	0
+Inverter alarm code	MODBUS_INPUT_REGISTER	143	1		5	0	0	0
+External adjustment climate system 8	MODBUS_INPUT_REGISTER	151	1		4	0	0	0
+External adjustment climate system 7	MODBUS_INPUT_REGISTER	152	1		4	0	0	0
+External adjustment climate system 6	MODBUS_INPUT_REGISTER	153	1		4	0	0	0
+External adjustment climate system 5	MODBUS_INPUT_REGISTER	154	1		4	0	0	0
+Climate system 8	MODBUS_INPUT_REGISTER	156	1		4	0	0	0
+Climate system 7	MODBUS_INPUT_REGISTER	157	1		4	0	0	0
+Climate system 6	MODBUS_INPUT_REGISTER	158	1		4	0	0	0
+Climate system 5	MODBUS_INPUT_REGISTER	159	1		4	0	0	0
+Hot water comfort return (BT82)	MODBUS_INPUT_REGISTER	174	10	°C	2	0	0	0
+Hot water comfort heater (BT83)	MODBUS_INPUT_REGISTER	175	10	°C	2	0	0	0
+id:599	MODBUS_INPUT_REGISTER	267	1	h	6	-2147483648	2147483647	0
+id:600	MODBUS_INPUT_REGISTER	269	1	h	6	-2147483648	2147483647	0
+id:601	MODBUS_INPUT_REGISTER	271	1	h	6	-2147483648	2147483647	0
+Compressor, total time cooling, main unit (EP14)	MODBUS_INPUT_REGISTER	279	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool, main unit (EP14)	MODBUS_INPUT_REGISTER	281	1	h	6	-2147483648	2147483647	0
+Compressor, total time pool 2, main unit (EP14)	MODBUS_INPUT_REGISTER	283	1	h	6	-2147483648	2147483647	0
+Heat pump 1 requested compressor frequency	MODBUS_INPUT_REGISTER	301	1	Hz	4	0	0	0
+Main unit, requested compressor freq	MODBUS_INPUT_REGISTER	302	1	Hz	4	0	0	0
+Frost protection heat exchanger, main unit	MODBUS_INPUT_REGISTER	310	1		4	0	0	0
+Status (OPT)	MODBUS_INPUT_REGISTER	311	1		4	0	0	0
+Version (OPT)	MODBUS_INPUT_REGISTER	312	1		5	0	0	0
+OPT relay, modulation level	MODBUS_INPUT_REGISTER	313	10	%	2	0	0	0
+OPT operating time	MODBUS_INPUT_REGISTER	315	1	h	5	0	0	0
+Available compressors heating	MODBUS_INPUT_REGISTER	317	1		4	0	0	0
+Available compressors hot water	MODBUS_INPUT_REGISTER	318	1		4	0	0	0
+Available compressors pool 1	MODBUS_INPUT_REGISTER	319	1		4	0	0	0
+Available compressors cooling	MODBUS_INPUT_REGISTER	321	1		4	0	0	0
++Adjust, port	MODBUS_INPUT_REGISTER	327	1		4	0	0	0
++Adjust, operating mode	MODBUS_INPUT_REGISTER	328	1		4	0	0	0
++Adjust, comfort	MODBUS_INPUT_REGISTER	329	1		4	0	0	0
++Adjust, parallel adjustment	MODBUS_INPUT_REGISTER	330	1		1	0	0	0
++Adjust, humidity	MODBUS_INPUT_REGISTER	331	10	%RH	2	0	0	0
++Adjust, indoor temperature	MODBUS_INPUT_REGISTER	332	10	°C	2	0	0	0
++Adjust, outdoor temperature	MODBUS_INPUT_REGISTER	333	10	°C	2	0	0	0
++Adjust, version	MODBUS_INPUT_REGISTER	334	1		5	0	0	0
++Adjust, active	MODBUS_INPUT_REGISTER	335	1		4	0	0	0
++Adjust, demand	MODBUS_INPUT_REGISTER	336	1		4	0	0	0
++Adjust, parallel factor	MODBUS_HOLDING_REGISTER	1	1		1	1	10	5
++Adjust, Parallel (min-max)	MODBUS_HOLDING_REGISTER	2	1		1	1	100	100
+Supply temperature (BT64)	MODBUS_INPUT_REGISTER	337	10	°C	2	0	0	0
+Heat pump functionality 2	MODBUS_INPUT_REGISTER	338	1		6	0	0	0
+Status (S135)	MODBUS_INPUT_REGISTER	344	1		4	0	0	0
+Status, demand, pump speed (S135)	MODBUS_INPUT_REGISTER	345	1		4	0	0	0
+Status, demand, fan speed (S135)	MODBUS_INPUT_REGISTER	346	1		4	0	0	0
+Status, solenoid (S135)	MODBUS_INPUT_REGISTER	347	1		4	0	0	0
+Status, compressor, heater(S135)	MODBUS_INPUT_REGISTER	348	1		4	0	0	0
+Status, compressor, demand (S135)	MODBUS_INPUT_REGISTER	350	1		4	0	0	0
+No. of starts (S135)	MODBUS_INPUT_REGISTER	351	1		6	0	9999999	0
+Operating time (S135)	MODBUS_INPUT_REGISTER	353	1	h	6	0	9999999	0
+Degree minutes	MODBUS_HOLDING_REGISTER	11	10	DM	3	-30000	30000	0
+Blocking (ERS 1)	MODBUS_INPUT_REGISTER	358	1		4	0	0	0
+AZ30-EB17	MODBUS_INPUT_REGISTER	359	1		4	0	0	0
+Supply line (S135-BT12)	MODBUS_INPUT_REGISTER	360	10	°C	2	0	0	0
+Return line (S135-BT13)	MODBUS_INPUT_REGISTER	361	10	°C	2	0	0	0
+Evaporator (S135-BT16)	MODBUS_INPUT_REGISTER	362	10	°C	2	0	0	0
+Defrosting sensor (S135-BT76)	MODBUS_INPUT_REGISTER	363	10	°C	2	0	0	0
+Incoming air (S135-BT77)	MODBUS_INPUT_REGISTER	364	10	°C	2	0	0	0
+Alarm number (S135)	MODBUS_INPUT_REGISTER	365	1		5	0	0	0
+Defrosting (S135)	MODBUS_INPUT_REGISTER	366	1		4	0	0	0
+Status, relay 5 (S135)	MODBUS_INPUT_REGISTER	367	1		4	0	0	0
+Status, relay 4 (S135)	MODBUS_INPUT_REGISTER	368	1		4	0	0	0
+Status, relay 3 (S135)	MODBUS_INPUT_REGISTER	369	1		4	0	0	0
+Status, relay 2 (S135)	MODBUS_INPUT_REGISTER	370	1		4	0	0	0
+Status, relay 1 (S135)	MODBUS_INPUT_REGISTER	371	1		4	0	0	0
+Status, relay 0 (S135)	MODBUS_INPUT_REGISTER	372	1		4	0	0	0
+Pump speed (S135)	MODBUS_INPUT_REGISTER	373	1	%	4	0	0	0
+Selected fan speed	MODBUS_INPUT_REGISTER	374	1	%	4	0	0	0
+Version (S135)	MODBUS_INPUT_REGISTER	376	1		5	0	0	0
+id:803	MODBUS_INPUT_REGISTER	377	1		6	0	2147483647	0
+id:804	MODBUS_INPUT_REGISTER	379	1		6	0	0	0
+id:805	MODBUS_INPUT_REGISTER	381	1		6	0	2147483647	0
+id:806	MODBUS_INPUT_REGISTER	383	1		6	0	0	0
+Seconds of blank time left, charge pump 1	MODBUS_INPUT_REGISTER	392	1		4	0	0	0
+Seconds of blank time left, charge pump 0	MODBUS_INPUT_REGISTER	393	1		4	0	0	0
+Alarm number from outdoor air heat pump (EB101)	MODBUS_INPUT_REGISTER	400	1		4	0	0	0
+Fan speed (EB101)	MODBUS_INPUT_REGISTER	401	1	rpm	5	0	0	0
+Max fan speed (EB101)	MODBUS_INPUT_REGISTER	402	1	rpm	5	0	0	0
+Min fan speed (EB101)	MODBUS_INPUT_REGISTER	403	1	rpm	5	0	0	0
+Max compressor speed (EB101)	MODBUS_INPUT_REGISTER	404	10	Hz	5	0	0	0
+Min compressor speed (EB101)	MODBUS_INPUT_REGISTER	405	10	Hz	5	0	0	0
+Power (EB101)	MODBUS_INPUT_REGISTER	406	10	kW	5	0	0	0
+Time to defrosting (EB101)	MODBUS_INPUT_REGISTER	407	1	min	5	0	0	0
+Defrosting index (EB101)	MODBUS_INPUT_REGISTER	408	1		5	0	0	0
+Superheat reference EEV (EB101)	MODBUS_INPUT_REGISTER	409	10	°C	2	0	0	0
+Superheat EEV (EB101)	MODBUS_INPUT_REGISTER	410	10	°C	2	0	0	0
+EEV-ssh-error (EB101)	MODBUS_INPUT_REGISTER	411	10	°C	2	0	0	0
+Superheat temp. reference EEV (EB101)	MODBUS_INPUT_REGISTER	412	10	°C	2	0	0	0
+Set point value EEV (EB101)	MODBUS_INPUT_REGISTER	413	10	°C	2	0	0	0
+EEV PV (EB101)	MODBUS_INPUT_REGISTER	414	10	°C	2	0	0	0
+EEV-te-error average open (EB101)	MODBUS_INPUT_REGISTER	415	10	°C	2	0	0	0
+Degree of opening EEV (EB101)	MODBUS_INPUT_REGISTER	416	1		5	0	0	0
+Superheat reference EVI (EB101)	MODBUS_INPUT_REGISTER	417	10	°C	2	0	0	0
+Superheat EVI (EB101)	MODBUS_INPUT_REGISTER	418	10	°C	2	0	0	0
+EEV-ssh-error (EVI)(EB101)	MODBUS_INPUT_REGISTER	419	10	°C	2	0	0	0
+Superheat temp. reference EVI (EB101)	MODBUS_INPUT_REGISTER	420	10	°C	2	0	0	0
+Set point value EVI (EB101)	MODBUS_INPUT_REGISTER	421	10	°C	2	0	0	0
+EVI PV (EB101)	MODBUS_INPUT_REGISTER	422	10	°C	2	0	0	0
+EEV-te-error average open in (EVI)(EB101)	MODBUS_INPUT_REGISTER	423	10	°C	2	0	0	0
+Degree of opening EVI (EB101)	MODBUS_INPUT_REGISTER	424	1		5	0	0	0
+id:859	MODBUS_INPUT_REGISTER	426	10	%RH	2	0	0	0
+id:861	MODBUS_INPUT_REGISTER	427	1		6	0	0	0
+id:862	MODBUS_INPUT_REGISTER	429	1		5	0	0	0
+Low press (EB101 BP8 dew)	MODBUS_INPUT_REGISTER	550	10	°C	2	0	0	0
+Hi press (EB101 BP9 dew)	MODBUS_INPUT_REGISTER	551	10	°C	2	0	0	0
+Injection (EB101-BT81)	MODBUS_INPUT_REGISTER	552	10	°C	2	0	0	0
+Pressure sensor, injection (EB101-BP11)	MODBUS_INPUT_REGISTER	553	10		2	0	0	0
+EVI pressure (EB101-EP14-BP11 dew)	MODBUS_INPUT_REGISTER	554	10	°C	2	0	0	0
+Evaporator (EB101-BT84)	MODBUS_INPUT_REGISTER	555	10	°C	2	0	0	0
+Fan status (EB101-EP14)	MODBUS_INPUT_REGISTER	556	1		4	0	0	0
+Fan rpm (EB101-EP14)	MODBUS_INPUT_REGISTER	557	1	rpm	5	0	0	0
+High condenser out alarm (S135)	MODBUS_INPUT_REGISTER	575	1		5	0	0	0
+High condenser in alarm (S135)	MODBUS_INPUT_REGISTER	576	1		5	0	0	0
+Average current (EME 10)	MODBUS_INPUT_REGISTER	578	10	A	2	0	0	0
+Operating mode PV panels	MODBUS_INPUT_REGISTER	579	1		4	0	0	0
+EME lux mode without EME	MODBUS_INPUT_REGISTER	581	1		4	0	0	0
+Timer (EME)	MODBUS_INPUT_REGISTER	582	60	min	5	0	0	0
+Fan mode 4	MODBUS_INPUT_REGISTER	590	1	%	4	0	0	0
+Fan mode 3	MODBUS_INPUT_REGISTER	591	1	%	4	0	0	0
+Fan mode 2	MODBUS_INPUT_REGISTER	592	1	%	4	0	0	0
+Is the compressor accessible	MODBUS_INPUT_REGISTER	593	1		4	0	0	0
+Prio, hot water (OPT)	MODBUS_INPUT_REGISTER	604	1		4	0	0	0
+Permit (undefined)	MODBUS_INPUT_REGISTER	683	1		4	0	0	0
+Permit (undefined)	MODBUS_INPUT_REGISTER	684	1		4	0	0	0
+Permit (undefined)	MODBUS_INPUT_REGISTER	685	1		4	0	0	0
+Permit (OPT 10) additional heat	MODBUS_INPUT_REGISTER	686	1		4	0	0	0
+Permit ext. imm. heater step	MODBUS_INPUT_REGISTER	687	1		4	0	0	0
+Permit int. imm. heater step	MODBUS_INPUT_REGISTER	688	1		4	0	0	0
+Permit shunted additional heat	MODBUS_INPUT_REGISTER	689	1		4	0	0	0
+Permit prioritised additional heat	MODBUS_INPUT_REGISTER	690	1		4	0	0	0
+Permit (EB108-EP15)	MODBUS_INPUT_REGISTER	691	1		4	0	0	0
+Permit (EB107-EP15)	MODBUS_INPUT_REGISTER	692	1		4	0	0	0
+Permit (EB106-EP15)	MODBUS_INPUT_REGISTER	693	1		4	0	0	0
+Permit (EB105-EP15)	MODBUS_INPUT_REGISTER	694	1		4	0	0	0
+Permit (EB104-EP15)	MODBUS_INPUT_REGISTER	695	1		4	0	0	0
+Permit (EB103-EP15)	MODBUS_INPUT_REGISTER	696	1		4	0	0	0
+Permit (EB102-EP15)	MODBUS_INPUT_REGISTER	697	1		4	0	0	0
+Permit (EB101-EP15)	MODBUS_INPUT_REGISTER	698	1		4	0	0	0
+Permit (EB100-EP15)	MODBUS_INPUT_REGISTER	699	1		4	0	0	0
+Permit (EB108-EP14)	MODBUS_INPUT_REGISTER	700	1		4	0	0	0
+Permit (EB107-EP14)	MODBUS_INPUT_REGISTER	701	1		4	0	0	0
+Permit (EB106-EP14)	MODBUS_INPUT_REGISTER	702	1		4	0	0	0
+Permit (EB105-EP14)	MODBUS_INPUT_REGISTER	703	1		4	0	0	0
+Permit (EB104-EP14)	MODBUS_INPUT_REGISTER	704	1		4	0	0	0
+Permit (EB103-EP14)	MODBUS_INPUT_REGISTER	705	1		4	0	0	0
+Permit (EB102-EP14)	MODBUS_INPUT_REGISTER	706	1		4	0	0	0
+Permit (EB101-EP14)	MODBUS_INPUT_REGISTER	707	1		4	0	0	0
+Permit (EB100-EP14)	MODBUS_INPUT_REGISTER	708	1		4	0	0	0
+Smart energy source, priority 7, start DM	MODBUS_INPUT_REGISTER	709	1		3	0	0	0
+Smart energy source, priority 6, start DM	MODBUS_INPUT_REGISTER	711	1		3	0	0	0
+Smart energy source, priority 5, start DM	MODBUS_INPUT_REGISTER	713	1		3	0	0	0
+Smart energy source, priority 4, start DM	MODBUS_INPUT_REGISTER	715	1		3	0	0	0
+Smart energy source, priority 3, start DM	MODBUS_INPUT_REGISTER	717	1		3	0	0	0
+Smart energy source, priority 2, start DM	MODBUS_INPUT_REGISTER	719	1		3	0	0	0
+Smart energy source, priority 1, start DM	MODBUS_INPUT_REGISTER	721	1		3	0	0	0
+Smart energy source, priority 7, stop DM	MODBUS_INPUT_REGISTER	723	1		3	0	0	0
+Smart energy source, priority 6, stop DM	MODBUS_INPUT_REGISTER	725	1		3	0	0	0
+Smart energy source, priority 5, stop DM	MODBUS_INPUT_REGISTER	727	1		3	0	0	0
+Smart energy source, priority 4, stop DM	MODBUS_INPUT_REGISTER	729	1		3	0	0	0
+Smart energy source, priority 3, stop DM	MODBUS_INPUT_REGISTER	731	1		3	0	0	0
+Smart energy source, priority 2, stop DM	MODBUS_INPUT_REGISTER	733	1		3	0	0	0
+Smart energy source, priority 1, stop DM	MODBUS_INPUT_REGISTER	735	1		3	0	0	0
+Smart energy source, DM minimum value	MODBUS_INPUT_REGISTER	737	1		3	0	0	0
+External guide status	MODBUS_INPUT_REGISTER	745	1		4	0	0	0
+Test guide value	MODBUS_INPUT_REGISTER	746	1		5	0	0	0
+Temp. lux forces start of hot water demand	MODBUS_INPUT_REGISTER	747	1		4	0	0	0
+Smart energy source, prio OPT10 for hot water	MODBUS_INPUT_REGISTER	757	1		4	0	0	0
+Smart energy source, Permit OPT to produce hot water	MODBUS_INPUT_REGISTER	758	1		4	0	0	0
+Wood boiler activated	MODBUS_INPUT_REGISTER	759	1		4	0	0	0
+Time to defrosting (EB108)	MODBUS_INPUT_REGISTER	767	1	min	5	0	0	0
+Time to defrosting (EB107)	MODBUS_INPUT_REGISTER	792	1	min	5	0	0	0
+Time to defrosting (EB106)	MODBUS_INPUT_REGISTER	817	1	min	5	0	0	0
+Time to defrosting (EB105)	MODBUS_INPUT_REGISTER	842	1	min	5	0	0	0
+Time to defrosting (EB104)	MODBUS_INPUT_REGISTER	867	1	min	5	0	0	0
+Time to defrosting (EB103)	MODBUS_INPUT_REGISTER	892	1	min	5	0	0	0
+Time to defrosting (EB102)	MODBUS_INPUT_REGISTER	917	1	min	5	0	0	0
+Alarm number (EB100)	MODBUS_INPUT_REGISTER	935	1		4	0	0	0
+Fan speed (EB100)	MODBUS_INPUT_REGISTER	936	1	rpm	5	0	0	0
+Max fan speed (EB100)	MODBUS_INPUT_REGISTER	937	1	rpm	5	0	0	0
+Min fan speed (EB100)	MODBUS_INPUT_REGISTER	938	1	rpm	5	0	0	0
+Max compressor speed (EB100)	MODBUS_INPUT_REGISTER	939	10	Hz	5	0	0	0
+Min compressor speed (EB100)	MODBUS_INPUT_REGISTER	940	10	Hz	5	0	0	0
+Power (EB100)	MODBUS_INPUT_REGISTER	941	10	kW	5	0	0	0
+Time to defrosting (EB100)	MODBUS_INPUT_REGISTER	942	1	min	5	0	0	0
+Defrosting index (EB100)	MODBUS_INPUT_REGISTER	943	1		5	0	0	0
+Superheat reference (EEV)(EB100)	MODBUS_INPUT_REGISTER	944	10	°C	2	0	0	0
+Superheat EEV (EB100)	MODBUS_INPUT_REGISTER	945	10	°C	2	0	0	0
+EEV-ssh-error EB100)	MODBUS_INPUT_REGISTER	946	10	°C	2	0	0	0
+Superheat temp. reference (EEV)(EB100)	MODBUS_INPUT_REGISTER	947	10	°C	2	0	0	0
+Set point value EEV (EB100)	MODBUS_INPUT_REGISTER	948	10	°C	2	0	0	0
+EEV PV (EB100)	MODBUS_INPUT_REGISTER	949	10	°C	2	0	0	0
+EEV-te-error average open (EB100)	MODBUS_INPUT_REGISTER	950	10	°C	2	0	0	0
+Opening degree EEV (EB100)	MODBUS_INPUT_REGISTER	951	1		5	0	0	0
+Superheat reference EVI (EB100)	MODBUS_INPUT_REGISTER	952	10	°C	2	0	0	0
+Superheat EVI (EB100)	MODBUS_INPUT_REGISTER	953	10	°C	2	0	0	0
+EEV-ssh-error (EVI)(EB100)	MODBUS_INPUT_REGISTER	954	10	°C	2	0	0	0
+Superheat temp. reference (EVI)(EB100)	MODBUS_INPUT_REGISTER	955	10	°C	2	0	0	0
+Set point value EVI (EB100)	MODBUS_INPUT_REGISTER	956	10	°C	2	0	0	0
+EVI PV (EB100)	MODBUS_INPUT_REGISTER	957	10	°C	2	0	0	0
+EEV-te-error average open (EVI)(EB100)	MODBUS_INPUT_REGISTER	958	10	°C	2	0	0	0
+Opening degree EVI EB100)	MODBUS_INPUT_REGISTER	959	1		5	0	0	0
+Wind speed, weather forecast	MODBUS_INPUT_REGISTER	960	10		5	0	0	0
+Humidity, weather forecast	MODBUS_INPUT_REGISTER	961	10	%	5	0	0	0
+Temperature, weather forecast	MODBUS_INPUT_REGISTER	962	10	°C	2	0	0	0
+Temperature, weather data (forecast)	MODBUS_INPUT_REGISTER	963	10	°C	2	0	0	0
+Smart energy source, priority select. in hot water	MODBUS_INPUT_REGISTER	991	1		4	0	0	0
+Outd. air heat pump, inverter, limits	MODBUS_INPUT_REGISTER	992	1		4	0	0	0
+Outd. air heat pump, inverter, speed reducing	MODBUS_INPUT_REGISTER	993	1		4	0	0	0
+Has one phase (EB101)	MODBUS_INPUT_REGISTER	1008	1		4	0	0	0
+Serial index (EB101)	MODBUS_INPUT_REGISTER	1009	1		4	0	0	0
+Serial index (EB100)	MODBUS_INPUT_REGISTER	1011	1		4	0	0	0
+Alarm incompatible (heat pump)	MODBUS_INPUT_REGISTER	1012	1		5	0	0	0
+Limit DM	MODBUS_HOLDING_REGISTER	18	10	DM	2	-30000	30000	0
+Calculated supply climate system 1	MODBUS_INPUT_REGISTER	1017	10	°C	2	0	0	0
+Class 1 alarm	MODBUS_INPUT_REGISTER	2195	1		4	0	0	0
+Frost protection status	MODBUS_INPUT_REGISTER	1018	1		5	0	0	0
+Cooling status	MODBUS_INPUT_REGISTER	1019	1		4	0	0	0
+id:1726	MODBUS_HOLDING_REGISTER	2757	1		2	0	30000	0
+Total run time additional heat	MODBUS_INPUT_REGISTER	1025	10	h	3	0	1000000	0
+Power internal additional heat	MODBUS_INPUT_REGISTER	1027	100	kW	2	0	0	0
+id:1757	MODBUS_HOLDING_REGISTER	2758	1		4	0	1	0
+Priority	MODBUS_INPUT_REGISTER	1028	1		4	0	0	0
+Operating mode internal add. heat	MODBUS_INPUT_REGISTER	1029	1		4	0	0	0
+Oper. mode shunt climate system 4	MODBUS_INPUT_REGISTER	1030	1		4	0	0	0
+Oper. mode shunt climate system 3	MODBUS_INPUT_REGISTER	1031	1		4	0	0	0
+Oper. mode shunt climate system 2	MODBUS_INPUT_REGISTER	1032	1		4	0	0	0
+Oper. mode shunt climate system 1	MODBUS_INPUT_REGISTER	1033	1		4	0	0	0
+Operating. mode shunt controlled additional heat	MODBUS_INPUT_REGISTER	1034	1		4	0	0	0
+Fan mode 1	MODBUS_INPUT_REGISTER	1037	1	%	4	0	0	0
+Current hot water mode	MODBUS_INPUT_REGISTER	1038	1		1	0	0	0
+Blocking cooling	MODBUS_INPUT_REGISTER	1053	1		4	0	0	0
+External adjustment climate system 4	MODBUS_INPUT_REGISTER	1054	1		4	0	0	0
+External adjustment climate system 3	MODBUS_INPUT_REGISTER	1055	1		4	0	0	0
+External adjustment climate system 2	MODBUS_INPUT_REGISTER	1056	1		4	0	0	0
+External adjustment climate system 1	MODBUS_INPUT_REGISTER	1057	1		4	0	0	0
+External blocking	MODBUS_INPUT_REGISTER	1058	1		4	0	0	0
+Step controlled add. heat blocking	MODBUS_INPUT_REGISTER	1062	1		4	0	0	0
+Hot water circulation (GP11)	MODBUS_INPUT_REGISTER	1063	1		4	0	0	0
+Total HW run time additional heat	MODBUS_INPUT_REGISTER	1069	10	h	3	0	9999999	0
+More hot water status	MODBUS_INPUT_REGISTER	1078	1		4	0	0	0
+Holiday function status	MODBUS_HOLDING_REGISTER	19	1		1	0	0	0
+Heating medium pump speed (GP1)	MODBUS_INPUT_REGISTER	1102	1	%	4	0	0	0
+Docked compressors heating	MODBUS_INPUT_REGISTER	1108	1		4	0	0	0
+Docked compressors hot water	MODBUS_INPUT_REGISTER	1109	1		4	0	0	0
+Docked compressors pool 1	MODBUS_INPUT_REGISTER	1110	1		4	0	0	0
+Reversing valve hot water (QN10)	MODBUS_INPUT_REGISTER	2196	1		4	0	0	0
+Operating mode step controlled additional heat	MODBUS_INPUT_REGISTER	1115	1		4	0	0	0
+Relay status, base board (EB100-EP14)	MODBUS_INPUT_REGISTER	1117	1		4	0	0	0
+Relay status, imm. heat. board (EB100-EP14)	MODBUS_INPUT_REGISTER	1119	1		4	0	0	0
+Current status	MODBUS_INPUT_REGISTER	1120	1		6	0	0	0
+Functionality, heat pump (EP14)	MODBUS_INPUT_REGISTER	1122	1		6	0	0	0
+Active heat pumps	MODBUS_INPUT_REGISTER	1124	1		5	0	0	0
+Functionality, heat pump (EP15)	MODBUS_INPUT_REGISTER	1125	1		6	0	0	0
+Operating mode HW comfort	MODBUS_INPUT_REGISTER	1129	1		4	0	0	0
+Operating mode HW comfort additional heat	MODBUS_INPUT_REGISTER	1130	1		4	0	0	0
+Blocked	MODBUS_INPUT_REGISTER	1132	1		4	0	0	0
+Pool 1 (QN19)	MODBUS_INPUT_REGISTER	1134	1		4	0	0	0
+Version (EB101)	MODBUS_INPUT_REGISTER	1451	1		5	0	0	0
+Heat pump type (EB101)	MODBUS_INPUT_REGISTER	1452	1		4	0	0	0
+Compressor size (EB101)	MODBUS_INPUT_REGISTER	1453	1		4	0	0	0
+Return line (EB101-BT3)	MODBUS_INPUT_REGISTER	1475	10	°C	2	0	0	0
+Supply line (EB101-BT12)	MODBUS_INPUT_REGISTER	1478	10	°C	2	0	0	0
+Discharge (EB101-BT14)	MODBUS_INPUT_REGISTER	1479	10	°C	2	0	0	0
+Liquid line (EB101-BT15)	MODBUS_INPUT_REGISTER	1480	10	°C	2	0	0	0
+Suction gas (EB101-BT17)	MODBUS_INPUT_REGISTER	1481	10	°C	2	0	0	0
+Compressor, time to start (EB101-EP14)	MODBUS_INPUT_REGISTER	1485	1	min	4	0	0	0
+Compressor, number of starts (EB101-EP14)	MODBUS_INPUT_REGISTER	1489	1		6	-2147483648	2147483647	0
+Compressor, oper. time, total (EB101-EP14)	MODBUS_INPUT_REGISTER	1491	1	h	6	-2147483648	2147483647	0
+Compressor, oper. time, hot water (EB101-EP14)	MODBUS_INPUT_REGISTER	1493	1	h	6	-2147483648	2147483647	0
+Alarm number (EB101-EP14)	MODBUS_INPUT_REGISTER	1495	1		5	0	0	0
+Heat pump type (EB100)	MODBUS_INPUT_REGISTER	1497	1		4	0	0	0
+Compressor size (EB100)	MODBUS_INPUT_REGISTER	1498	1		4	0	0	0
+Compressor, requested (EB101-EP14)	MODBUS_INPUT_REGISTER	1556	1		4	0	0	0
+Cooling blocking	MODBUS_INPUT_REGISTER	1559	1		4	0	0	0
+Date, periodic hot water	MODBUS_INPUT_REGISTER	1561	1		-	-	-	-
+Blocked compressors	MODBUS_INPUT_REGISTER	2174	1		6	0	0	0
+Cooling degree minutes	MODBUS_HOLDING_REGISTER	20	10	DM	2	-30000	30000	0
+Calculated cooling supply climate system 1	MODBUS_INPUT_REGISTER	1567	10	°C	2	0	0	0
+Hot water, including int. add. heat	MODBUS_INPUT_REGISTER	1575	10	kWh	6	0	9999999	0
+Heating, including int. add. heat	MODBUS_INPUT_REGISTER	1577	10	kWh	6	0	9999999	0
+Cooling, compressor only	MODBUS_INPUT_REGISTER	1579	10	kWh	6	0	9999999	0
+Hot water, compressor only	MODBUS_INPUT_REGISTER	1583	10	kWh	6	0	9999999	0
+Heating, compressor only	MODBUS_INPUT_REGISTER	1585	10	kWh	6	0	9999999	0
+id:2728	MODBUS_HOLDING_REGISTER	3099	1		3	0	9999999	0
+Speed (GP12)	MODBUS_INPUT_REGISTER	1589	1	%	4	0	0	0
+Cooling pump manual speed	MODBUS_HOLDING_REGISTER	21	1	%	1	1	100	70
+Outdoor temperature (EB101-BT28)	MODBUS_INPUT_REGISTER	1621	10	°C	2	0	0	0
+Evaporator (EB101-BT16)	MODBUS_INPUT_REGISTER	1622	10	°C	2	0	0	0
+Heating medium pump speed (GP1)	MODBUS_INPUT_REGISTER	1636	1	%	4	0	0	0
+id:2793	MODBUS_INPUT_REGISTER	1637	1	%	4	0	0	0
+Frost protection heat exchanger heat pump 1	MODBUS_INPUT_REGISTER	1638	1		4	0	0	0
+Operating mode extra additional heat	MODBUS_INPUT_REGISTER	1693	1		4	0	0	0
+Docked compressors cooling	MODBUS_INPUT_REGISTER	1694	1		4	0	0	0
+BP4, unprocessed (EB101-EP14)	MODBUS_INPUT_REGISTER	1800	1		2	0	0	0
+Low pressure (EB101-BP8)	MODBUS_INPUT_REGISTER	1802	10	bar	2	0	0	0
+Current compressor frequency (EB101)	MODBUS_INPUT_REGISTER	1803	10	Hz	2	0	0	0
+Protection mode (EB101)	MODBUS_INPUT_REGISTER	1804	1		5	0	0	0
+Defrosting (EB101)	MODBUS_INPUT_REGISTER	1805	1		4	0	0	0
+Power (EB101-EP14)	MODBUS_INPUT_REGISTER	1806	1	kW	4	0	0	0
+Internal charge pump (GP12)	MODBUS_INPUT_REGISTER	1822	1		4	0	0	0
+Climate system 4	MODBUS_INPUT_REGISTER	1823	1		4	0	0	0
+Climate system 3	MODBUS_INPUT_REGISTER	1824	1		4	0	0	0
+Climate system 2	MODBUS_INPUT_REGISTER	1825	1		4	0	0	0
+Climate system 1 (HMP)	MODBUS_INPUT_REGISTER	1826	1		4	0	0	0
+Pool 1 pump status	MODBUS_INPUT_REGISTER	1828	1		4	0	0	0
+Requested compressor frequency (EB101)	MODBUS_INPUT_REGISTER	1854	1	Hz	4	0	0	0
+Low press. sensor, unprocessed (EB101-EP14)	MODBUS_INPUT_REGISTER	1902	1		2	0	0	0
+Current sensor (EB101-EP14)	MODBUS_INPUT_REGISTER	1903	10	A	2	0	0	0
+Operating mode (SG Ready)	MODBUS_INPUT_REGISTER	1911	1		4	0	0	0
+SG ready, input A	MODBUS_INPUT_REGISTER	1912	1		4	0	0	0
+SG ready, input B	MODBUS_INPUT_REGISTER	1913	1		4	0	0	0
+Heating offset (SPA)	MODBUS_INPUT_REGISTER	1914	10		1	0	0	0
+Hot water comfort mode (SPA)	MODBUS_INPUT_REGISTER	1915	1		1	0	0	0
+Pool offset (SPA)	MODBUS_INPUT_REGISTER	1916	1		1	0	0	0
+Cooling offset (SPA)	MODBUS_INPUT_REGISTER	1917	1		1	0	0	0
+Operating mode (Smart Price Adaption)	MODBUS_INPUT_REGISTER	1918	1		4	0	0	0
+Evaporator 2 (EB101-EP14-BT16)	MODBUS_INPUT_REGISTER	1966	10	°C	2	0	0	0
+Temperature, inverter (EB101-EP14)	MODBUS_INPUT_REGISTER	1967	10	°C	2	0	0	0
+fan speed (EB101-EP14)	MODBUS_INPUT_REGISTER	1968	1		4	0	0	0
+Evaporator 2 (EB100-EP15-BT16)	MODBUS_INPUT_REGISTER	1969	10	°C	2	0	0	0
+Temperature, inverter (EB100-EP15)	MODBUS_INPUT_REGISTER	1970	10	°C	2	0	0	0
+fan speed (EB100-EP15)	MODBUS_INPUT_REGISTER	1971	1		4	0	0	0
+Evaporator 2 (EB100-EP14-BT16)	MODBUS_INPUT_REGISTER	1972	10	°C	2	0	0	0
+Temperature, inverter (EB100-EP14)	MODBUS_INPUT_REGISTER	1973	10	°C	2	0	0	0
+fan speed (EB100-EP14)	MODBUS_INPUT_REGISTER	1974	1		4	0	0	0
+Alarm number	MODBUS_INPUT_REGISTER	1975	1		2	0	0	0
+Reset alarm	MODBUS_HOLDING_REGISTER	22	1		4	0	0	0
+Non module-specific alarm numbers	MODBUS_INPUT_REGISTER	1976	1		2	0	0	0
+Heating curve climate system 1	MODBUS_HOLDING_REGISTER	26	1		1	0	15	9
+Heating offset climate system 1	MODBUS_HOLDING_REGISTER	30	1		1	-10	10	0
+Min supply climate system 1	MODBUS_HOLDING_REGISTER	34	10	°C	2	50	800	200
+Max supply climate system 1	MODBUS_HOLDING_REGISTER	38	10	°C	2	50	800	600
+Own curve, heating P7	MODBUS_HOLDING_REGISTER	39	1	°C	1	5	80	15
+Own curve, heating P6	MODBUS_HOLDING_REGISTER	40	1	°C	1	5	80	15
+Own curve, heating P5	MODBUS_HOLDING_REGISTER	41	1	°C	1	5	80	26
+Own curve, heating P4	MODBUS_HOLDING_REGISTER	42	1	°C	1	5	80	32
+Own curve, heating P3	MODBUS_HOLDING_REGISTER	43	1	°C	1	5	80	35
+Own curve, heating P2	MODBUS_HOLDING_REGISTER	44	1	°C	1	5	80	40
+Own curve, heating P1	MODBUS_HOLDING_REGISTER	45	1	°C	1	5	80	45
+Point offset outdoor temperature	MODBUS_HOLDING_REGISTER	46	1	°C	1	-40	30	0
+Point offset	MODBUS_HOLDING_REGISTER	47	1	°C	1	-10	10	0
+External adjustment climate system 1	MODBUS_HOLDING_REGISTER	51	1		1	-10	10	0
+External adjustment with room sensor climate system 1	MODBUS_HOLDING_REGISTER	55	10	°C	2	50	300	200
+Hot water demand mode	MODBUS_HOLDING_REGISTER	56	1		1	0	4	1
+Start temperature HW high temperature	MODBUS_HOLDING_REGISTER	58	10	°C	2	50	700	440
+Start temperature HW normal temperature	MODBUS_HOLDING_REGISTER	59	10	°C	2	50	700	410
+Start temperature HW low temperature	MODBUS_HOLDING_REGISTER	60	10	°C	2	50	700	380
+Stop temperature HW periodic increase	MODBUS_HOLDING_REGISTER	61	10	°C	2	550	700	550
+Stop temperature HW high temperature	MODBUS_HOLDING_REGISTER	62	10	°C	2	50	700	480
+Stop temperature HW normal temperature	MODBUS_HOLDING_REGISTER	63	10	°C	2	50	700	450
+Stop temperature HW low temperature	MODBUS_HOLDING_REGISTER	64	10	°C	2	50	700	420
+Periodic hot water	MODBUS_HOLDING_REGISTER	65	1		1	0	1	1
+Periodic hot water interval	MODBUS_HOLDING_REGISTER	66	1	days	1	1	90	7
+Start time periodic hot water	MODBUS_HOLDING_REGISTER	67	1		-	-	-	-
+Language	MODBUS_HOLDING_REGISTER	91	1		1	0	22	0
+Period time hot water	MODBUS_HOLDING_REGISTER	92	1	min	4	0	180	30
+Period time heating	MODBUS_HOLDING_REGISTER	93	1	min	4	0	180	30
+Operating mode	MODBUS_HOLDING_REGISTER	2743	1		4	0	2	0
+Operating mode heating medium pump	MODBUS_HOLDING_REGISTER	95	1		4	10	40	40
+Activate forced control	MODBUS_HOLDING_REGISTER	5000	1		4	0	0	0
+Max. internal additional heat	MODBUS_HOLDING_REGISTER	102	100	kW	2	0	4500	900
+Fuse	MODBUS_HOLDING_REGISTER	103	1	A	5	1	400	16
+id:3826	MODBUS_HOLDING_REGISTER	2747	1		4	1	128	4
+id:3827	MODBUS_HOLDING_REGISTER	2746	1		4	1	128	2
+id:3828	MODBUS_HOLDING_REGISTER	2745	1		4	1	128	1
+Ventilation mode	MODBUS_HOLDING_REGISTER	104	1		4	0	4	0
+Return time fan 4	MODBUS_HOLDING_REGISTER	115	1	h	4	1	24	4
+Return time fan 3	MODBUS_HOLDING_REGISTER	116	1	h	4	1	24	4
+Return time fan 2	MODBUS_HOLDING_REGISTER	117	1	h	4	1	24	4
+Return time fan 1	MODBUS_HOLDING_REGISTER	118	1	h	4	1	24	4
+Time between filter replacement	MODBUS_HOLDING_REGISTER	119	1		4	1	24	3
+Floor drying	MODBUS_HOLDING_REGISTER	120	1		4	0	1	0
+Floor drying period 7	MODBUS_HOLDING_REGISTER	121	1	days	4	0	30	2
+Floor drying period 6	MODBUS_HOLDING_REGISTER	122	1	days	4	0	30	2
+Floor drying period 5	MODBUS_HOLDING_REGISTER	123	1	days	4	0	30	2
+Floor drying period 4	MODBUS_HOLDING_REGISTER	124	1	days	4	0	30	3
+Floor drying period 3	MODBUS_HOLDING_REGISTER	125	1	days	4	0	30	2
+Floor drying period 2	MODBUS_HOLDING_REGISTER	126	1	days	4	0	30	2
+Floor drying period 1	MODBUS_HOLDING_REGISTER	127	1	days	4	0	30	2
+Floor drying temp. 7	MODBUS_HOLDING_REGISTER	128	1	°C	4	15	70	20
+Floor drying temp. 6	MODBUS_HOLDING_REGISTER	129	1	°C	4	15	70	30
+Floor drying temp. 5	MODBUS_HOLDING_REGISTER	130	1	°C	4	15	70	40
+Floor drying temp. 4	MODBUS_HOLDING_REGISTER	131	1	°C	4	15	70	45
+Floor drying temp. 3	MODBUS_HOLDING_REGISTER	132	1	°C	4	15	70	40
+Floor drying temp. 2	MODBUS_HOLDING_REGISTER	133	1	°C	4	15	70	30
+Floor drying temp. 1	MODBUS_HOLDING_REGISTER	134	1	°C	4	15	70	20
+Floor drying ongoing time.	MODBUS_INPUT_REGISTER	1977	1		5	0	10000	0
+Dimensioned outdoor temperature	MODBUS_HOLDING_REGISTER	140	10	°C	2	-400	200	-180
+Delta T for DOT	MODBUS_HOLDING_REGISTER	141	10	°C	2	10	250	100
+Climate system 2	MODBUS_HOLDING_REGISTER	142	1		4	0	1	0
+Climate system 3	MODBUS_HOLDING_REGISTER	143	1		4	0	1	0
+Climate system 4	MODBUS_HOLDING_REGISTER	144	1		4	0	1	0
+Shunt controlled additional heat	MODBUS_HOLDING_REGISTER	153	1		4	0	1	0
+Wait time shunt, shunt controlled additional heat	MODBUS_HOLDING_REGISTER	157	1	s	2	10	300	30
+Step controlled additional heat accessory	MODBUS_HOLDING_REGISTER	158	1		4	0	1	0
+Waiting time cooling/heating	MODBUS_HOLDING_REGISTER	165	1	h	1	0	48	2
+Heating start at under temp.	MODBUS_HOLDING_REGISTER	166	10	°C	1	5	100	10
+Cooling start at over temp.	MODBUS_HOLDING_REGISTER	167	10	°C	1	5	100	30
+Cooling with room sensors	MODBUS_HOLDING_REGISTER	170	10		4	0	41	0
+Start active cooling DM	MODBUS_HOLDING_REGISTER	173	1	DM	2	10	300	30
+Permit additional heat, heating	MODBUS_HOLDING_REGISTER	180	1		4	0	1	1
+Permit heating	MODBUS_HOLDING_REGISTER	181	1		4	0	1	1
+Permit cooling	MODBUS_HOLDING_REGISTER	182	1		4	0	1	1
+Auto mode, start temperature for cooling	MODBUS_HOLDING_REGISTER	183	10	°C	2	150	400	250
+Auto mode, stop temperature for heating	MODBUS_HOLDING_REGISTER	184	10	°C	2	-200	400	170
+Auto mode, additional heat stop temperature	MODBUS_HOLDING_REGISTER	185	10	°C	2	-250	400	50
+Auto mode filter time	MODBUS_HOLDING_REGISTER	186	1	h	4	0	48	24
+Max difference supply, compressor	MODBUS_HOLDING_REGISTER	187	10	°C	2	10	250	100
+Max difference supply, additional heat	MODBUS_HOLDING_REGISTER	188	10	°C	2	10	240	70
+Time format	MODBUS_HOLDING_REGISTER	194	1		4	0	1	1
+Alarm action, lower room temperature	MODBUS_HOLDING_REGISTER	196	1		4	0	1	0
+Alarm action lower HW temperature	MODBUS_HOLDING_REGISTER	197	1		4	0	1	1
+Auxiliary operation on alarm	MODBUS_HOLDING_REGISTER	198	1		4	0	0	0
+Use room sensor climate system 4	MODBUS_HOLDING_REGISTER	199	1		4	0	1	0
+Use room sensor climate system 3	MODBUS_HOLDING_REGISTER	200	1		4	0	1	0
+Use room sensor climate system 2	MODBUS_HOLDING_REGISTER	201	1		4	0	1	0
+Use room sensor climate system 1	MODBUS_HOLDING_REGISTER	202	1		4	0	1	0
+Room sensor set point value climate system 4	MODBUS_HOLDING_REGISTER	203	10	°C	2	50	300	200
+Room sensor set point value climate system 3	MODBUS_HOLDING_REGISTER	204	10	°C	2	50	300	200
+Room sensor set point value climate system 2	MODBUS_HOLDING_REGISTER	205	10	°C	2	50	300	200
+Room sensor set point value climate system 1	MODBUS_HOLDING_REGISTER	206	10	°C	2	50	300	200
+Room sensor factor climate system 4	MODBUS_HOLDING_REGISTER	207	10		4	0	60	20
+Room sensor factor climate system 3	MODBUS_HOLDING_REGISTER	208	10		4	0	60	20
+Room sensor factor climate system 2	MODBUS_HOLDING_REGISTER	209	10		4	0	60	20
+Room sensor factor climate system 1	MODBUS_HOLDING_REGISTER	210	10		4	0	60	20
+Input AUX5	MODBUS_HOLDING_REGISTER	211	1		4	0	65	0
+Input AUX4	MODBUS_HOLDING_REGISTER	212	1		4	0	65	0
+Input AUX3	MODBUS_HOLDING_REGISTER	213	1		4	0	65	0
+Input AUX2	MODBUS_HOLDING_REGISTER	214	1		4	0	65	0
+Input AUX1	MODBUS_HOLDING_REGISTER	215	1		4	0	65	0
+Output AUX1	MODBUS_HOLDING_REGISTER	216	1		4	0	28	0
+id:3968	MODBUS_HOLDING_REGISTER	2752	1		5	1	3600	5
+Preset flow setting for climate system	MODBUS_HOLDING_REGISTER	223	1		4	0	3	1
+id:3977	MODBUS_HOLDING_REGISTER	2753	1		4	21	22	22
+More hot water	MODBUS_HOLDING_REGISTER	225	10		-	-	-	-
+Night cooling 1	MODBUS_HOLDING_REGISTER	227	1		4	0	1	0
+id:4045	MODBUS_HOLDING_REGISTER	4041	1	°C	1	1	40	8
+id:4046	MODBUS_HOLDING_REGISTER	4043	1	°C	1	0	40	4
+id:4049	MODBUS_HOLDING_REGISTER	4045	1		4	0	1	0
+id:4050	MODBUS_HOLDING_REGISTER	4046	1		4	0	1	0
+id:4051	MODBUS_HOLDING_REGISTER	4047	1		4	0	1	0
+Oper. mode	MODBUS_HOLDING_REGISTER	237	1		4	0	0	0
+Cooling heat sensor set point value	MODBUS_HOLDING_REGISTER	681	10		2	50	400	210
+Pool 1 accessory	MODBUS_HOLDING_REGISTER	685	1		4	0	1	0
+Hot water comfort	MODBUS_HOLDING_REGISTER	694	1		4	0	1	0
+More hot water	MODBUS_HOLDING_REGISTER	697	1		1	0	0	0
+Start diff. DM, step-controlled add. heat	MODBUS_HOLDING_REGISTER	703	1	DM	2	0	2000	400
+HW comfort shunt on/off	MODBUS_HOLDING_REGISTER	705	1		4	0	1	0
+External cooling accessory	MODBUS_HOLDING_REGISTER	709	1		4	0	1	0
+id:4591	MODBUS_HOLDING_REGISTER	4052	1		1	5	80	30
+Min. supply temp. cooling climate system 1	MODBUS_HOLDING_REGISTER	720	1	°C	1	18	30	18
+Own curve, cooling P3	MODBUS_HOLDING_REGISTER	721	1	°C	1	7	40	20
+Own curve, cooling P5	MODBUS_HOLDING_REGISTER	722	1	°C	1	7	40	20
+Cooling connected, climate system 1	MODBUS_HOLDING_REGISTER	726	1		4	0	1	1
+id:4617	MODBUS_HOLDING_REGISTER	4053	1		1	0	1	0
+Period time cooling	MODBUS_HOLDING_REGISTER	736	1	min	4	0	180	30
+Cooling delta temp. 20°C	MODBUS_HOLDING_REGISTER	738	1	°C	1	3	10	3
+Cooling delta temp. 40°C	MODBUS_HOLDING_REGISTER	739	1	°C	1	3	20	6
+Operating mode charge pump climate system 1	MODBUS_HOLDING_REGISTER	748	1		4	0	1	1
+id:4660	MODBUS_HOLDING_REGISTER	4063	1		4	0	0	0
+Shunted brine, accessory	MODBUS_HOLDING_REGISTER	4064	1		4	0	1	0
+Shunted brine max. temp.	MODBUS_HOLDING_REGISTER	4067	1	°C	4	0	30	20
+Heating (SG Ready)	MODBUS_HOLDING_REGISTER	760	1		4	0	1	1
+id:4703	MODBUS_HOLDING_REGISTER	4068	1		4	0	1	0
+id:4704	MODBUS_HOLDING_REGISTER	4069	1		4	0	1	0
+id:4705	MODBUS_HOLDING_REGISTER	4070	1		4	0	1	0
+id:4706	MODBUS_HOLDING_REGISTER	4071	1		4	0	1	0
+id:4707	MODBUS_HOLDING_REGISTER	4072	1		4	0	1	0
+id:4708	MODBUS_HOLDING_REGISTER	4073	1		4	0	1	0
+id:4709	MODBUS_HOLDING_REGISTER	4074	1		4	0	1	0
+id:4710	MODBUS_HOLDING_REGISTER	4075	1		4	0	1	0
+id:4711	MODBUS_HOLDING_REGISTER	0	1		4	0	1	0
+Input AUX5	MODBUS_HOLDING_REGISTER	767	1		4	0	65	0
+Operating mode circulation pump heating heat pump 1	MODBUS_HOLDING_REGISTER	783	1		4	0	1	1
+Operating mode circulation pump hot water heat pump 1	MODBUS_HOLDING_REGISTER	799	1		4	0	1	1
+Speed circulation pump cooling heat pump 1	MODBUS_HOLDING_REGISTER	823	1	%	4	1	100	70
+Operating mode circulation pump cooling heat pump 1	MODBUS_HOLDING_REGISTER	832	1		4	0	1	1
+Speed circulation pump waiting mode heat pump 1	MODBUS_HOLDING_REGISTER	841	1	%	4	1	100	30
+Speed, circulation pump, standby mode (EB100)	MODBUS_HOLDING_REGISTER	842	1	%	4	1	100	30
+Activated (Smart Price Adaption)	MODBUS_HOLDING_REGISTER	843	1		4	0	1	0
+(SPA), cooling activated	MODBUS_HOLDING_REGISTER	849	1		4	0	1	1
+(SPA), area	MODBUS_HOLDING_REGISTER	851	1		4	0	254	23
+Max. speed controlled charge pump (EB101)	MODBUS_HOLDING_REGISTER	867	1	%	4	80	100	100
+External adjustment climate system 8	MODBUS_HOLDING_REGISTER	893	1		1	-10	10	0
+External adjustment climate system 7	MODBUS_HOLDING_REGISTER	894	1		1	-10	10	0
+External adjustment climate system 6	MODBUS_HOLDING_REGISTER	895	1		1	-10	10	0
+External adjustment climate system 5	MODBUS_HOLDING_REGISTER	896	1		1	-10	10	0
+External adjustment with room sensor climate system 8	MODBUS_HOLDING_REGISTER	897	10	°C	2	50	300	200
+External adjustment with room sensor climate system 7	MODBUS_HOLDING_REGISTER	898	10	°C	2	50	300	200
+External adjustment with room sensor climate system 6	MODBUS_HOLDING_REGISTER	899	10	°C	2	50	300	200
+External adjustment with room sensor climate system 5	MODBUS_HOLDING_REGISTER	900	10	°C	2	50	300	200
+Forced control (AZ30-QN37) (close)	MODBUS_HOLDING_REGISTER	5028	1		4	0	0	0
+Forced control (AZ30-QN37) (open)	MODBUS_HOLDING_REGISTER	5027	1		4	0	0	0
+Forced control (AZ30-EB17)	MODBUS_HOLDING_REGISTER	5026	1		4	0	0	0
+Climate system 5	MODBUS_HOLDING_REGISTER	905	1		4	0	1	0
+Climate system 6	MODBUS_HOLDING_REGISTER	906	1		4	0	1	0
+Climate system 7	MODBUS_HOLDING_REGISTER	907	1		4	0	1	0
+Climate system 8	MODBUS_HOLDING_REGISTER	908	1		4	0	1	0
+Heating connected, climate system 1	MODBUS_HOLDING_REGISTER	932	1		4	0	1	1
+ERS 1	MODBUS_HOLDING_REGISTER	933	1		4	0	1	0
+id:4969	MODBUS_HOLDING_REGISTER	4091	1		4	0	1	0
+id:4970	MODBUS_HOLDING_REGISTER	4092	1		4	0	1	0
+id:4971	MODBUS_HOLDING_REGISTER	4093	1	Hz	4	20	117	20
+id:4972	MODBUS_HOLDING_REGISTER	4094	1	Hz	4	20	117	20
+id:4973	MODBUS_HOLDING_REGISTER	4095	1	Hz	4	23	120	23
+id:4974	MODBUS_HOLDING_REGISTER	4096	1	Hz	4	23	120	23
+Use room sensor climate system 8	MODBUS_HOLDING_REGISTER	948	1		4	0	1	0
+Use room sensor climate system 7	MODBUS_HOLDING_REGISTER	949	1		4	0	1	0
+Use room sensor climate system 6	MODBUS_HOLDING_REGISTER	950	1		4	0	1	0
+Use room sensor climate system 5	MODBUS_HOLDING_REGISTER	951	1		4	0	1	0
+Room sensor set point value climate system 8	MODBUS_HOLDING_REGISTER	952	10	°C	2	50	300	200
+Room sensor set point value climate system 7	MODBUS_HOLDING_REGISTER	953	10	°C	2	50	300	200
+Room sensor set point value climate system 6	MODBUS_HOLDING_REGISTER	954	10	°C	2	50	300	200
+Room sensor set point value climate system 5	MODBUS_HOLDING_REGISTER	955	10	°C	2	50	300	200
+Room sensor factor climate system 8	MODBUS_HOLDING_REGISTER	956	10		4	0	60	20
+Room sensor factor climate system 7	MODBUS_HOLDING_REGISTER	957	10		4	0	60	20
+Room sensor factor climate system 6	MODBUS_HOLDING_REGISTER	958	10		4	0	60	20
+Room sensor factor climate system 5	MODBUS_HOLDING_REGISTER	959	10		4	0	60	20
+Cooling curve climate system 1	MODBUS_HOLDING_REGISTER	967	1		1	0	9	0
+Cooling offset climate system 1	MODBUS_HOLDING_REGISTER	975	1		1	-10	10	0
+Own curve, cooling P4	MODBUS_HOLDING_REGISTER	976	1	°C	1	7	40	20
+Own curve, cooling P2	MODBUS_HOLDING_REGISTER	977	1	°C	1	7	40	20
+Own curve, cooling P1	MODBUS_HOLDING_REGISTER	978	1	°C	1	7	40	20
+Current transformer ratio	MODBUS_HOLDING_REGISTER	980	1		5	300	3000	300
+Room sensor set point value climate system 8, cooling	MODBUS_HOLDING_REGISTER	981	10	°C	2	50	350	250
+Room sensor set point value climate system 7, cooling	MODBUS_HOLDING_REGISTER	982	10	°C	2	50	350	250
+Room sensor set point value climate system 6, cooling	MODBUS_HOLDING_REGISTER	983	10	°C	2	50	350	250
+Room sensor set point value climate system 5, cooling	MODBUS_HOLDING_REGISTER	984	10	°C	2	50	350	250
+Room sensor set point value climate system 4, cooling	MODBUS_HOLDING_REGISTER	985	10	°C	2	50	350	250
+Room sensor set point value climate system 3, cooling	MODBUS_HOLDING_REGISTER	986	10	°C	2	50	350	250
+Room sensor set point value climate system 2, cooling	MODBUS_HOLDING_REGISTER	987	10	°C	2	50	350	250
+Room sensor set point value climate system 1, cooling	MODBUS_HOLDING_REGISTER	988	10	°C	2	50	350	250
+Room sensor factor climate system 8, cooling	MODBUS_HOLDING_REGISTER	989	10		4	0	60	10
+Room sensor factor climate system 7, cooling	MODBUS_HOLDING_REGISTER	990	10		4	0	60	10
+Room sensor factor climate system 6, cooling	MODBUS_HOLDING_REGISTER	991	10		4	0	60	10
+Room sensor factor climate system 5, cooling	MODBUS_HOLDING_REGISTER	992	10		4	0	60	10
+Room sensor factor climate system 4, cooling	MODBUS_HOLDING_REGISTER	993	10		4	0	60	10
+Room sensor factor climate system 3, cooling	MODBUS_HOLDING_REGISTER	994	10		4	0	60	10
+Room sensor factor climate system 2, cooling	MODBUS_HOLDING_REGISTER	995	10		4	0	60	10
+Room sensor factor climate system 1, cooling	MODBUS_HOLDING_REGISTER	996	10		4	0	60	10
+Set point value (RH)	MODBUS_HOLDING_REGISTER	997	1	%	1	30	90	60
+HTS 1	MODBUS_HOLDING_REGISTER	998	1		4	0	1	0
+OPT	MODBUS_HOLDING_REGISTER	1015	1		4	0	1	0
+DM start difference (OPT)	MODBUS_HOLDING_REGISTER	1016	1	DM	2	10	2000	700
+Exhaust air fan speed 4 (ERS 1)	MODBUS_HOLDING_REGISTER	1021	1	%	4	0	100	100
+Exhaust air fan speed 3 (ERS 1)	MODBUS_HOLDING_REGISTER	1022	1	%	4	0	100	80
+Exhaust air fan speed 2 (ERS 1)	MODBUS_HOLDING_REGISTER	1023	1	%	4	0	100	30
+Exhaust air fan speed 1 (ERS 1)	MODBUS_HOLDING_REGISTER	1024	1	%	4	0	100	0
+Exhaust air fan speed normal (ERS 1)	MODBUS_HOLDING_REGISTER	1025	1	%	4	1	100	75
+S135	MODBUS_HOLDING_REGISTER	1035	1		4	0	1	0
+Pump speed (S135)	MODBUS_HOLDING_REGISTER	1036	1	%	4	1	100	70
+Supply air fan speed 4 (ERS 1)	MODBUS_HOLDING_REGISTER	1038	1	%	4	0	100	100
+Supply air fan speed 3 (ERS 1)	MODBUS_HOLDING_REGISTER	1039	1	%	4	0	100	80
+Supply air fan speed 2 (ERS 1)	MODBUS_HOLDING_REGISTER	1040	1	%	4	0	100	30
+Supply air fan speed 1 (ERS 1)	MODBUS_HOLDING_REGISTER	1041	1	%	4	0	100	0
+Supply air fan speed normal (ERS 1)	MODBUS_HOLDING_REGISTER	1042	1	%	4	1	100	60
+Min. vent temp. (ERS 1)	MODBUS_HOLDING_REGISTER	1043	1	°C	4	0	10	3
+Bypass temp. (ERS 1)	MODBUS_HOLDING_REGISTER	1044	1	°C	4	2	10	4
+Pool pump type	MODBUS_HOLDING_REGISTER	1045	1		4	0	1	1
+External cooling accessory pump type	MODBUS_HOLDING_REGISTER	1046	1		4	0	1	1
+Flow sensor activated X22	MODBUS_HOLDING_REGISTER	1049	1		4	0	1	0
+Max. internal additional heat SG Ready	MODBUS_HOLDING_REGISTER	1052	100	kW	2	0	900	900
+Hysteresis (OPT)	MODBUS_HOLDING_REGISTER	1066	1		2	10	2000	100
+Activated (EME10)	MODBUS_HOLDING_REGISTER	1068	1		4	0	1	0
+PV panel affects heating (EME)	MODBUS_HOLDING_REGISTER	1069	1		4	0	1	0
+PV panel affects hot water (EME)	MODBUS_HOLDING_REGISTER	1070	1		4	0	1	0
+Delay timer EME	MODBUS_HOLDING_REGISTER	1071	1		5	0	0	0
+AUX blocking (OPT)	MODBUS_HOLDING_REGISTER	1095	1		4	0	0	0
+Outdoor air mixing	MODBUS_HOLDING_REGISTER	1096	1		4	0	1	0
+Smart home room control	MODBUS_HOLDING_REGISTER	1102	1		4	0	1	0
+Smart Energy Source	MODBUS_HOLDING_REGISTER	1105	1		4	0	1	0
+Control method, smart energy source	MODBUS_HOLDING_REGISTER	1106	1		4	0	1	0
+El. price, special, smart energy source	MODBUS_HOLDING_REGISTER	1107	1		4	0	2	0
+El. price, fixed, smart energy source	MODBUS_HOLDING_REGISTER	1108	1		5	0	10000	100
+El. price, smart energy source	MODBUS_HOLDING_REGISTER	1109	1		4	0	1	0
+El. price, fixed, smart energy source	MODBUS_HOLDING_REGISTER	1110	1		5	0	10000	100
+El. price, smart energy source	MODBUS_HOLDING_REGISTER	1111	1		4	0	1	0
+El. price, fixed, smart energy source	MODBUS_HOLDING_REGISTER	1112	1		5	0	10000	100
+El. price, smart energy source	MODBUS_HOLDING_REGISTER	1113	1		4	0	1	0
+El. price, fixed, smart energy source	MODBUS_HOLDING_REGISTER	1114	1		5	0	10000	100
+El. price, smart energy source	MODBUS_HOLDING_REGISTER	1115	1		4	0	1	0
+El. price, fixed, smart energy source	MODBUS_HOLDING_REGISTER	1116	1		5	0	10000	100
+Prim. factor, smart energy source	MODBUS_HOLDING_REGISTER	1117	10		4	0	50	25
+Prim. factor, shunt add. heat smart energy source	MODBUS_HOLDING_REGISTER	1118	10		4	0	50	10
+Prim. factor, ext. step add. heat smart energy source	MODBUS_HOLDING_REGISTER	1119	10		4	0	50	10
+Prim. factor, OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1120	10		4	0	50	10
+OPT10, high tariff price smart energy source	MODBUS_HOLDING_REGISTER	1121	1		5	1	10000	100
+OPT10, low tariff price smart energy source	MODBUS_HOLDING_REGISTER	1122	1		5	1	10000	100
+ext. step add. heat, high tariff price smart energy source	MODBUS_HOLDING_REGISTER	1123	1		5	1	10000	100
+ext. step add. heat, low tariff price smart energy source	MODBUS_HOLDING_REGISTER	1124	1		5	1	10000	100
+Shunt add. heat, high tariff price smart energy source	MODBUS_HOLDING_REGISTER	1125	1		5	1	10000	100
+Shunt add. heat, low tariff price smart energy source	MODBUS_HOLDING_REGISTER	1126	1		5	1	10000	100
+El. price, fixed, high tariff smart energy source	MODBUS_HOLDING_REGISTER	1127	1		5	1	10000	100
+El. price, fixed, low tariff smart energy source	MODBUS_HOLDING_REGISTER	1128	1		5	1	10000	100
+El. price, variable, high tariff smart energy source	MODBUS_HOLDING_REGISTER	1129	1		5	1	10000	100
+El. price, variable, low tariff smart energy source	MODBUS_HOLDING_REGISTER	1130	1		5	1	10000	100
+DM start source, priority 5 smart energy source	MODBUS_HOLDING_REGISTER	1131	1		2	100	2000	400
+DM start source, priority 4 smart energy source	MODBUS_HOLDING_REGISTER	1132	1		2	100	2000	400
+DM start source, priority 3 smart energy source	MODBUS_HOLDING_REGISTER	1133	1		2	100	2000	400
+DM start source, priority 2 smart energy source	MODBUS_HOLDING_REGISTER	1134	1		2	100	2000	400
+DM start source, priority 1 smart energy source	MODBUS_HOLDING_REGISTER	1135	1		2	-2000	-10	-60
+Start day, tariff smart energy source	MODBUS_HOLDING_REGISTER	1136	1		4	1	31	1
+End day, tariff smart energy source	MODBUS_HOLDING_REGISTER	1137	1		4	1	31	31
+Start month, tariff smart energy source	MODBUS_HOLDING_REGISTER	1138	1		4	1	12	1
+End month, tariff smart energy source	MODBUS_HOLDING_REGISTER	1139	1		4	1	12	12
+Start day, fixed tariff smart energy source	MODBUS_HOLDING_REGISTER	1172	1		4	1	31	1
+End day, fixed tariff smart energy source	MODBUS_HOLDING_REGISTER	1173	1		4	1	31	31
+Start month, fixed tariff smart energy source	MODBUS_HOLDING_REGISTER	1174	1		4	1	12	1
+End month, fixed tariff smart energy source	MODBUS_HOLDING_REGISTER	1175	1		4	1	12	12
+Start day, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1208	1		4	1	31	1
+End day, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1209	1		4	1	31	31
+Start month, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1210	1		4	1	12	1
+End month, tariff OPT10 smart energy source	MODBUS_HOLDING_REGISTER	1211	1		4	1	12	12
+Start day tariff, shunt additional heat smart energy source	MODBUS_HOLDING_REGISTER	1244	1		4	1	31	1
+End day tariff, shunt additional heat  smart energy source	MODBUS_HOLDING_REGISTER	1245	1		4	1	31	31
+Start month tariff, shunt additional heat smart energy source	MODBUS_HOLDING_REGISTER	1246	1		4	1	12	1
+End month tariff, shunt additional heat smart energy source	MODBUS_HOLDING_REGISTER	1247	1		4	1	12	12
+Start day tariff, ext. step add. heat smart energy source	MODBUS_HOLDING_REGISTER	1280	1		4	1	31	1
+End day tariff, ext. step add. heat  smart energy source	MODBUS_HOLDING_REGISTER	1281	1		4	1	31	31
+Start month tariff, ext. step add. heat smart energy source	MODBUS_HOLDING_REGISTER	1282	1		4	1	12	1
+End month tariff, ext. step add. heat smart energy source	MODBUS_HOLDING_REGISTER	1283	1		4	1	12	12
+Prioritise additional heat (AXC40)	MODBUS_HOLDING_REGISTER	1320	1		4	0	1	0
+Max difference, SES priority 1 energy source	MODBUS_HOLDING_REGISTER	1326	10	°C	2	10	250	100
+Max difference, SES lower priority energy source	MODBUS_HOLDING_REGISTER	1327	10	°C	2	10	250	70
+Forced control (AZ30-GQ2)	MODBUS_HOLDING_REGISTER	5029	1	%	4	0	100	50
+Forced control (AZ30-GQ3)	MODBUS_HOLDING_REGISTER	5030	1	%	4	0	100	50
+Installed (EB101)	MODBUS_HOLDING_REGISTER	1550	1		4	0	1	1
+EME20	MODBUS_HOLDING_REGISTER	4000	1		4	0	1	0
+Current power	MODBUS_INPUT_REGISTER	2176	1	W	6	0	0	0
+id:6012	MODBUS_HOLDING_REGISTER	4008	1	%	4	1	100	70
+id:6028	MODBUS_INPUT_REGISTER	1993	1		4	0	0	0
+id:6029	MODBUS_INPUT_REGISTER	1994	1		5	0	0	0
+Total average power (EME 20)	MODBUS_INPUT_REGISTER	2178	100	kW	6	0	0	0
+Total energy	MODBUS_INPUT_REGISTER	2180	10	kWh	3	0	0	0
+ERS 2	MODBUS_HOLDING_REGISTER	4076	1		4	0	1	0
+ERS 3	MODBUS_HOLDING_REGISTER	4077	1		4	0	1	0
+ERS 4	MODBUS_HOLDING_REGISTER	4078	1		4	0	1	0
+Bypass set point value (ERS 1)	MODBUS_HOLDING_REGISTER	4085	1	°C	4	5	30	25
+Bypass during heating (ERS 1)	MODBUS_HOLDING_REGISTER	4089	1		4	0	1	0
+id:6486	MODBUS_HOLDING_REGISTER	4135	1		4	0	1	0
+id:6756	MODBUS_INPUT_REGISTER	2004	10	%RH	2	0	0	0
+id:6757	MODBUS_INPUT_REGISTER	2005	10	%RH	2	0	0	0
+id:6758	MODBUS_INPUT_REGISTER	2006	10	%RH	2	0	0	0
+HTS 2	MODBUS_HOLDING_REGISTER	1981	1		4	0	1	0
+HTS 3	MODBUS_HOLDING_REGISTER	1982	1		4	0	1	0
+HTS 4	MODBUS_HOLDING_REGISTER	1983	1		4	0	1	0
+External adjustment, cooling climate system 8	MODBUS_HOLDING_REGISTER	4138	1		1	-10	10	0
+External adjustment, cooling climate system 7	MODBUS_HOLDING_REGISTER	4139	1		1	-10	10	0
+External adjustment, cooling climate system 6	MODBUS_HOLDING_REGISTER	4140	1		1	-10	10	0
+External adjustment, cooling climate system 5	MODBUS_HOLDING_REGISTER	4141	1		1	-10	10	0
+External adjustment, cooling climate system 4	MODBUS_HOLDING_REGISTER	4142	1		1	-10	10	0
+External adjustment, cooling climate system 3	MODBUS_HOLDING_REGISTER	4143	1		1	-10	10	0
+External adjustment, cooling climate system 2	MODBUS_HOLDING_REGISTER	4144	1		1	-10	10	0
+External adjustment, cooling climate system 1	MODBUS_HOLDING_REGISTER	4145	1		1	-10	10	0
+External adjustment with room sensor, cooling climate system 8	MODBUS_HOLDING_REGISTER	4146	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 7	MODBUS_HOLDING_REGISTER	4147	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 6	MODBUS_HOLDING_REGISTER	4148	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 5	MODBUS_HOLDING_REGISTER	4149	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 4	MODBUS_HOLDING_REGISTER	4150	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 3	MODBUS_HOLDING_REGISTER	4151	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 2	MODBUS_HOLDING_REGISTER	4152	10	°C	2	50	300	200
+External adjustment with room sensor, cooling climate system 1	MODBUS_HOLDING_REGISTER	4153	10	°C	2	50	300	200
+Demand controlled ventilation	MODBUS_HOLDING_REGISTER	4067	1		4	0	1	0
+Current power	MODBUS_INPUT_REGISTER	2177	100	kW	6	0	0	0
+id:6917	MODBUS_HOLDING_REGISTER	4072	1		4	0	200	1
+id:6918	MODBUS_HOLDING_REGISTER	4073	1		4	0	20	1
+id:6920	MODBUS_HOLDING_REGISTER	4074	1		4	0	20	0
+id:6921	MODBUS_HOLDING_REGISTER	4075	1		4	1	100	15
+id:6922	MODBUS_HOLDING_REGISTER	4154	1		4	0	20	3
+id:6923	MODBUS_HOLDING_REGISTER	4155	1		4	0	20	2
+blockFreq 1 (EB102)	MODBUS_HOLDING_REGISTER	4164	1		4	0	1	0
+blockFreq 1 (EB103)	MODBUS_HOLDING_REGISTER	4165	1		4	0	1	0
+blockFreq 1 (EB104)	MODBUS_HOLDING_REGISTER	4166	1		4	0	1	0
+blockFreq 1 (EB105)	MODBUS_HOLDING_REGISTER	4167	1		4	0	1	0
+blockFreq 1 (EB106)	MODBUS_HOLDING_REGISTER	4168	1		4	0	1	0
+blockFreq 1 (EB107)	MODBUS_HOLDING_REGISTER	4169	1		4	0	1	0
+blockFreq 1 (EB108)	MODBUS_HOLDING_REGISTER	4170	1		4	0	1	0
+id:6977	MODBUS_HOLDING_REGISTER	4201	1		4	0	100	0
+Power at DOT, manual value	MODBUS_HOLDING_REGISTER	4200	1		4	0	1	0
+ERS 1	MODBUS_HOLDING_REGISTER	4094	1		4	0	1	1
+Blocking actions (ERS 3)	MODBUS_HOLDING_REGISTER	4100	1		4	0	2	2
+Blocking actions (ERS 4)	MODBUS_HOLDING_REGISTER	4101	1		4	0	2	2
+id:7048	MODBUS_HOLDING_REGISTER	3987	1		4	0	1	0
+id:7138	MODBUS_HOLDING_REGISTER	4009	1	%	4	0	100	70
+id:7139	MODBUS_HOLDING_REGISTER	4010	1		4	0	1	0
+id:7140	MODBUS_HOLDING_REGISTER	4011	1		4	0	1	0
+id:7141	MODBUS_HOLDING_REGISTER	4012	1	%	4	0	100	70
+id:7142	MODBUS_HOLDING_REGISTER	4013	1		4	0	1	0
+id:7143	MODBUS_HOLDING_REGISTER	4014	1		4	0	1	0
+id:7144	MODBUS_HOLDING_REGISTER	4015	1	%	4	0	100	70
+id:7145	MODBUS_HOLDING_REGISTER	4016	1		4	0	1	0
+id:7146	MODBUS_HOLDING_REGISTER	4017	1		4	0	1	0
+id:7147	MODBUS_HOLDING_REGISTER	4018	1	%	4	0	100	70
+id:7148	MODBUS_HOLDING_REGISTER	4019	1		4	0	1	0
+id:7149	MODBUS_HOLDING_REGISTER	4020	1		4	0	1	0
+id:7150	MODBUS_HOLDING_REGISTER	4021	1	%	4	0	100	70
+id:7176	MODBUS_HOLDING_REGISTER	4023	1		4	0	1	0
+Night cooling 1	MODBUS_HOLDING_REGISTER	2955	1		4	0	1	0
+Start temperature night cooling 1	MODBUS_HOLDING_REGISTER	2942	1	°C	4	20	30	25
+Night cooling diff	MODBUS_HOLDING_REGISTER	2943	1	°C	4	3	10	6
+id:8002	MODBUS_HOLDING_REGISTER	1996	1	%	4	-15	10	-3
+id:8003	MODBUS_HOLDING_REGISTER	1997	1	%	4	1	254	65
+Minimum permitted speed (EB101 GP12)	MODBUS_HOLDING_REGISTER	3243	1	%	4	1	50	1
+Start fan de-icing (EB101)	MODBUS_HOLDING_REGISTER	3251	1		1	0	1	0
+id:8060	MODBUS_HOLDING_REGISTER	3259	1		1	0	1	0
+id:8061	MODBUS_HOLDING_REGISTER	3260	1		1	0	1	0
+id:8062	MODBUS_HOLDING_REGISTER	3261	1		1	0	1	0
+id:8063	MODBUS_HOLDING_REGISTER	3262	1		1	0	1	0
+id:8064	MODBUS_HOLDING_REGISTER	3263	1		1	0	1	0
+id:8065	MODBUS_HOLDING_REGISTER	3264	1		1	0	1	0
+id:8066	MODBUS_HOLDING_REGISTER	3265	1		1	0	1	0
+id:8067	MODBUS_HOLDING_REGISTER	3266	1		1	0	1	0
+Increased ventilation 1	MODBUS_HOLDING_REGISTER	3627	1		4	0	0	0
+System 1 (RMU)	MODBUS_HOLDING_REGISTER	176	1		4	0	1	0
+System 2 (RMU)	MODBUS_HOLDING_REGISTER	177	1		4	0	1	0
+System 3 (RMU)	MODBUS_HOLDING_REGISTER	178	1		4	0	1	0
+System 4 (RMU)	MODBUS_HOLDING_REGISTER	179	1		4	0	1	0
+System 4 (RMU)	MODBUS_HOLDING_REGISTER	1998	1		4	0	1	0
+System 4 (RMU)	MODBUS_HOLDING_REGISTER	1999	1		4	0	1	0
+System 4 (RMU)	MODBUS_HOLDING_REGISTER	2000	1		4	0	1	0
+System 4 (RMU)	MODBUS_HOLDING_REGISTER	2001	1		4	0	1	0
+id:8982	MODBUS_HOLDING_REGISTER	3346	1		4	0	0	0
+The start guide has been run	MODBUS_HOLDING_REGISTER	2742	1		4	0	1	1
+Audio signal on alarm	MODBUS_HOLDING_REGISTER	3232	1		4	0	1	1
+Sound when pressing button	MODBUS_HOLDING_REGISTER	3233	1		4	0	1	1
+BT12 offset, heat pump 1	MODBUS_HOLDING_REGISTER	3234	10	°C	1	-50	50	0
+Heating, auto	MODBUS_HOLDING_REGISTER	3059	1		4	0	1	1
+Cooling, auto	MODBUS_HOLDING_REGISTER	3060	1		4	0	1	1
+Factor	MODBUS_HOLDING_REGISTER	3033	1		4	1	10	5
+Fan speed ERS1 (GQ2)	MODBUS_INPUT_REGISTER	2251	1	%	4	0	0	0
+Fan speed ERS1 (GQ3)	MODBUS_INPUT_REGISTER	2252	1	%	4	0	0	0
+id:10881	MODBUS_HOLDING_REGISTER	3062	1		4	0	1	0
+id:10890	MODBUS_HOLDING_REGISTER	3063	1		4	0	1	0
+Pump: Heating medium (GP6)	MODBUS_INPUT_REGISTER	2128	1		4	0	0	0
+id:12332	MODBUS_HOLDING_REGISTER	2767	1		2	-600	600	-32768
+id:12333	MODBUS_HOLDING_REGISTER	2768	1		2	-600	600	-32768
+id:12334	MODBUS_HOLDING_REGISTER	2769	1		2	-600	600	-32768
+id:12335	MODBUS_HOLDING_REGISTER	2770	1		2	-600	600	-32768
+id:12336	MODBUS_HOLDING_REGISTER	2771	1		2	-600	600	-32768
+id:12337	MODBUS_HOLDING_REGISTER	2772	1		2	-600	600	-32768
+id:12338	MODBUS_HOLDING_REGISTER	2773	1		2	-600	600	-32768
+id:12339	MODBUS_HOLDING_REGISTER	2774	1		2	-600	600	-32768
+id:12340	MODBUS_HOLDING_REGISTER	2775	1		2	-600	600	-32768
+id:12341	MODBUS_HOLDING_REGISTER	2776	1		2	-600	600	-32768
+id:12342	MODBUS_HOLDING_REGISTER	2777	1		2	-600	600	-32768
+id:12343	MODBUS_HOLDING_REGISTER	2778	1		2	-600	600	-32768
+id:12344	MODBUS_HOLDING_REGISTER	2779	1		2	-600	600	-32768
+id:12345	MODBUS_HOLDING_REGISTER	2780	1		2	-600	600	-32768
+id:12346	MODBUS_HOLDING_REGISTER	2781	1		2	-600	600	-32768
+id:12347	MODBUS_HOLDING_REGISTER	2782	1		2	-600	600	-32768
+id:12348	MODBUS_HOLDING_REGISTER	2783	1		2	-600	600	-32768
+id:12349	MODBUS_HOLDING_REGISTER	2784	1		2	-600	600	-32768
+id:12350	MODBUS_HOLDING_REGISTER	2785	1		2	-600	600	-32768
+id:12351	MODBUS_HOLDING_REGISTER	2786	1		2	-600	600	-32768
+id:12352	MODBUS_HOLDING_REGISTER	2787	1		2	-600	600	-32768
+id:12353	MODBUS_HOLDING_REGISTER	2788	1		2	-600	600	-32768
+id:12354	MODBUS_HOLDING_REGISTER	2789	1		2	-600	600	-32768
+id:12355	MODBUS_HOLDING_REGISTER	2790	1		2	-600	600	-32768
+id:12356	MODBUS_HOLDING_REGISTER	2791	1		2	-600	600	-32768
+id:12357	MODBUS_HOLDING_REGISTER	2792	1		2	-600	600	-32768
+id:12358	MODBUS_HOLDING_REGISTER	2793	1		2	-600	600	-32768
+id:12359	MODBUS_HOLDING_REGISTER	2794	1		2	-600	600	-32768
+id:12360	MODBUS_HOLDING_REGISTER	2795	1		2	-600	600	-32768
+id:12361	MODBUS_HOLDING_REGISTER	2796	1		2	-600	600	-32768
+id:12362	MODBUS_HOLDING_REGISTER	2797	1		2	-600	600	-32768
+id:12363	MODBUS_HOLDING_REGISTER	2798	1		2	-600	600	-32768
+id:12364	MODBUS_HOLDING_REGISTER	2799	1		2	-600	600	-32768
+id:12365	MODBUS_HOLDING_REGISTER	2800	1		2	-600	600	-32768
+id:12366	MODBUS_HOLDING_REGISTER	2801	1		2	-600	600	-32768
+id:12367	MODBUS_HOLDING_REGISTER	2802	1		2	-600	600	-32768
+id:12368	MODBUS_HOLDING_REGISTER	2803	1		2	-600	600	-32768
+id:12369	MODBUS_HOLDING_REGISTER	2804	1		2	-600	600	-32768
+id:12370	MODBUS_HOLDING_REGISTER	2805	1		2	-600	600	-32768
+id:12371	MODBUS_HOLDING_REGISTER	2806	1		2	-600	600	-32768
+id:12372	MODBUS_HOLDING_REGISTER	2807	1		2	-600	600	-32768
+id:12373	MODBUS_HOLDING_REGISTER	2808	1		2	-600	600	-32768
+id:12374	MODBUS_HOLDING_REGISTER	2809	1		2	-600	600	-32768
+id:12375	MODBUS_HOLDING_REGISTER	2810	1		2	-600	600	-32768
+id:12376	MODBUS_HOLDING_REGISTER	2811	1		2	-600	600	-32768
+id:12377	MODBUS_HOLDING_REGISTER	2812	1		2	-600	600	-32768
+id:12378	MODBUS_HOLDING_REGISTER	2813	1		2	-600	600	-32768
+id:12379	MODBUS_HOLDING_REGISTER	2814	1		2	-600	600	-32768
+id:12380	MODBUS_HOLDING_REGISTER	2815	1		2	-600	600	-32768
+id:12381	MODBUS_HOLDING_REGISTER	2816	1		2	-600	600	-32768
+id:12382	MODBUS_HOLDING_REGISTER	2817	1		2	-600	600	-32768
+id:12383	MODBUS_HOLDING_REGISTER	2818	1		2	-600	600	-32768
+id:12384	MODBUS_HOLDING_REGISTER	2819	1		2	-600	600	-32768
+Period	MODBUS_HOLDING_REGISTER	3088	1		4	0	1	0
+Number of years	MODBUS_HOLDING_REGISTER	3089	1		4	1	10	1
+Months	MODBUS_HOLDING_REGISTER	3090	1		6	0	4095	4095
+id:12388	MODBUS_HOLDING_REGISTER	3092	1		4	0	0	0
+id:12391	MODBUS_HOLDING_REGISTER	3095	1		4	0	0	0
+Show outdoor temperature	MODBUS_HOLDING_REGISTER	3096	1		4	0	0	0
+Show indoor temperature	MODBUS_HOLDING_REGISTER	3097	1		4	0	0	0
+Active days	MODBUS_HOLDING_REGISTER	3066	1		4	0	127	0
+Active days	MODBUS_HOLDING_REGISTER	3067	1		4	0	127	0
+Active days	MODBUS_HOLDING_REGISTER	3068	1		4	0	127	0
+Active days	MODBUS_HOLDING_REGISTER	3069	1		4	0	127	0
+Active days	MODBUS_HOLDING_REGISTER	3070	1		4	0	127	0
+Start time	MODBUS_HOLDING_REGISTER	3071	1		-	-	-	-
+Start time	MODBUS_HOLDING_REGISTER	3073	1		-	-	-	-
+Stop time	MODBUS_HOLDING_REGISTER	3075	1		-	-	-	-
+id:12650	MODBUS_HOLDING_REGISTER	3104	1		-	-	-	-
+id:12651	MODBUS_HOLDING_REGISTER	3144	1		-	-	-	-
+id:12652	MODBUS_HOLDING_REGISTER	3184	1		-	-	-	-
+id:12653	MODBUS_HOLDING_REGISTER	3224	1		-	-	-	-
+id:12654	MODBUS_HOLDING_REGISTER	3264	1		-	-	-	-
+id:12655	MODBUS_HOLDING_REGISTER	3304	1		-	-	-	-
+id:12656	MODBUS_HOLDING_REGISTER	3344	1		-	-	-	-
+id:12657	MODBUS_HOLDING_REGISTER	3384	1		-	-	-	-
+id:12658	MODBUS_HOLDING_REGISTER	3424	1		-	-	-	-
+id:12659	MODBUS_HOLDING_REGISTER	3464	1		-	-	-	-
+id:12660	MODBUS_HOLDING_REGISTER	3504	1		-	-	-	-
+id:12661	MODBUS_HOLDING_REGISTER	3544	1		-	-	-	-
+id:12662	MODBUS_HOLDING_REGISTER	3584	1		-	-	-	-
+id:12663	MODBUS_HOLDING_REGISTER	3624	1		-	-	-	-
+id:12664	MODBUS_HOLDING_REGISTER	3664	1		-	-	-	-
+id:12665	MODBUS_HOLDING_REGISTER	3704	1		-	-	-	-
+id:12666	MODBUS_HOLDING_REGISTER	3744	1		-	-	-	-
+id:12667	MODBUS_HOLDING_REGISTER	3784	1		-	-	-	-
+id:12668	MODBUS_HOLDING_REGISTER	3824	1		-	-	-	-
+id:12669	MODBUS_HOLDING_REGISTER	3864	1		-	-	-	-
+id:12670	MODBUS_HOLDING_REGISTER	3904	1		-	-	-	-
+id:12671	MODBUS_HOLDING_REGISTER	2978	1		4	0	3	0
+id:12672	MODBUS_HOLDING_REGISTER	2979	1		4	0	3	0
+id:12673	MODBUS_HOLDING_REGISTER	2980	1		4	0	3	0
+id:12674	MODBUS_HOLDING_REGISTER	2981	1		4	0	3	0
+id:12675	MODBUS_HOLDING_REGISTER	2982	1		4	0	3	0
+id:12676	MODBUS_HOLDING_REGISTER	2983	1		4	0	3	0
+id:12677	MODBUS_HOLDING_REGISTER	2984	1		4	0	3	0
+id:12678	MODBUS_HOLDING_REGISTER	2985	1		4	0	3	0
+id:12679	MODBUS_HOLDING_REGISTER	2986	1		4	0	15	0
+id:12680	MODBUS_HOLDING_REGISTER	2987	1		4	0	15	0
+id:12681	MODBUS_HOLDING_REGISTER	2988	1		4	0	15	0
+id:12682	MODBUS_HOLDING_REGISTER	2989	1		4	0	15	0
+id:12683	MODBUS_HOLDING_REGISTER	2990	1		4	0	15	0
+id:12684	MODBUS_HOLDING_REGISTER	2991	1		4	0	15	0
+id:12685	MODBUS_HOLDING_REGISTER	2992	1		4	0	15	0
+id:12686	MODBUS_HOLDING_REGISTER	2993	1		4	0	15	0
+id:12687	MODBUS_HOLDING_REGISTER	2994	1		4	0	15	0
+id:12688	MODBUS_HOLDING_REGISTER	2995	1		4	0	15	0
+id:12689	MODBUS_HOLDING_REGISTER	2996	1		4	0	15	0
+id:12690	MODBUS_HOLDING_REGISTER	2997	1		4	0	15	0
+id:12691	MODBUS_HOLDING_REGISTER	2998	1		4	0	3	0
+id:12692	MODBUS_HOLDING_REGISTER	3944	1		6	0	0	0
+id:12693	MODBUS_HOLDING_REGISTER	3946	1		6	0	0	0
+id:12694	MODBUS_HOLDING_REGISTER	3948	1		6	0	0	0
+id:12695	MODBUS_HOLDING_REGISTER	3950	1		6	0	0	0
+id:12696	MODBUS_HOLDING_REGISTER	3952	1		6	0	0	0
+id:12697	MODBUS_HOLDING_REGISTER	3954	1		6	0	0	0
+id:12698	MODBUS_HOLDING_REGISTER	3956	1		6	0	0	0
+id:12699	MODBUS_HOLDING_REGISTER	3958	1		6	0	0	0
+id:12700	MODBUS_HOLDING_REGISTER	3960	1		6	0	0	0
+id:12701	MODBUS_HOLDING_REGISTER	3962	1		6	0	0	0
+id:12702	MODBUS_HOLDING_REGISTER	3964	1		6	0	0	0
+id:12703	MODBUS_HOLDING_REGISTER	3966	1		6	0	0	0
+id:12704	MODBUS_HOLDING_REGISTER	3968	1		6	0	0	0
+id:12705	MODBUS_HOLDING_REGISTER	3970	1		6	0	0	0
+id:12706	MODBUS_HOLDING_REGISTER	3972	1		6	0	0	0
+id:12707	MODBUS_HOLDING_REGISTER	3974	1		6	0	0	0
+id:12708	MODBUS_HOLDING_REGISTER	3976	1		6	0	0	0
+id:12709	MODBUS_HOLDING_REGISTER	3978	1		6	0	0	0
+id:12710	MODBUS_HOLDING_REGISTER	3980	1		6	0	0	0
+id:12711	MODBUS_HOLDING_REGISTER	3982	1		6	0	0	0
+id:12712	MODBUS_HOLDING_REGISTER	3984	1		6	0	0	0
+id:12801	MODBUS_HOLDING_REGISTER	2505	10	°C	3	50	300	200
+id:12802	MODBUS_HOLDING_REGISTER	2507	10	°C	3	50	300	200
+id:12803	MODBUS_HOLDING_REGISTER	2509	10	°C	3	50	300	200
+id:12804	MODBUS_HOLDING_REGISTER	2511	10	°C	3	50	300	200
+id:12805	MODBUS_HOLDING_REGISTER	2513	10	°C	3	50	300	200
+id:12806	MODBUS_HOLDING_REGISTER	2515	10	°C	3	50	300	200
+id:12807	MODBUS_HOLDING_REGISTER	2517	10	°C	3	50	300	200
+id:12808	MODBUS_HOLDING_REGISTER	2519	10	°C	3	50	300	200
+id:12809	MODBUS_HOLDING_REGISTER	2521	10	°C	3	50	300	200
+id:12810	MODBUS_HOLDING_REGISTER	2523	10	°C	3	50	300	200
+id:12811	MODBUS_HOLDING_REGISTER	2525	10	°C	3	50	300	200
+id:12812	MODBUS_HOLDING_REGISTER	2527	10	°C	3	50	300	200
+id:12813	MODBUS_HOLDING_REGISTER	2529	10	°C	3	50	300	200
+id:12814	MODBUS_HOLDING_REGISTER	2531	10	°C	3	50	300	200
+id:12815	MODBUS_HOLDING_REGISTER	2533	10	°C	3	50	300	200
+id:12816	MODBUS_HOLDING_REGISTER	2535	10	°C	3	50	300	200
+id:12817	MODBUS_HOLDING_REGISTER	2537	10	°C	3	50	300	200
+id:12818	MODBUS_HOLDING_REGISTER	2539	10	°C	3	50	300	200
+id:12819	MODBUS_HOLDING_REGISTER	2541	10	°C	3	50	300	200
+id:12820	MODBUS_HOLDING_REGISTER	2543	10	°C	3	50	300	200
+id:12821	MODBUS_HOLDING_REGISTER	2545	10	°C	3	50	300	200
+id:12822	MODBUS_HOLDING_REGISTER	2547	10	°C	3	50	300	200
+id:12823	MODBUS_HOLDING_REGISTER	2549	10	°C	3	50	300	200
+id:12824	MODBUS_HOLDING_REGISTER	2551	10	°C	3	50	300	200
+id:12825	MODBUS_HOLDING_REGISTER	2553	10	°C	3	50	300	200
+id:12826	MODBUS_HOLDING_REGISTER	2555	10	°C	3	50	300	200
+id:12827	MODBUS_HOLDING_REGISTER	2557	10	°C	3	50	300	200
+id:12828	MODBUS_HOLDING_REGISTER	2559	10	°C	3	50	300	200
+id:12829	MODBUS_HOLDING_REGISTER	2561	10	°C	3	50	300	200
+id:12830	MODBUS_HOLDING_REGISTER	2563	10	°C	3	50	300	200
+id:12831	MODBUS_HOLDING_REGISTER	2565	10	°C	3	50	300	200
+id:12832	MODBUS_HOLDING_REGISTER	2567	10	°C	3	50	300	200
+id:12833	MODBUS_HOLDING_REGISTER	2569	10	°C	3	50	300	200
+id:12834	MODBUS_HOLDING_REGISTER	2571	10	°C	3	50	300	200
+id:12835	MODBUS_HOLDING_REGISTER	2573	10	°C	3	50	300	200
+id:12836	MODBUS_HOLDING_REGISTER	2575	10	°C	3	50	300	200
+id:12837	MODBUS_HOLDING_REGISTER	2577	10	°C	3	50	300	200
+id:12838	MODBUS_HOLDING_REGISTER	2579	10	°C	3	50	300	200
+id:12839	MODBUS_HOLDING_REGISTER	2581	10	°C	3	50	300	200
+id:12840	MODBUS_HOLDING_REGISTER	2583	10	°C	3	50	300	200
+id:12841	MODBUS_HOLDING_REGISTER	2585	10	°C	3	50	300	250
+id:12842	MODBUS_HOLDING_REGISTER	2587	10	°C	3	50	300	250
+id:12843	MODBUS_HOLDING_REGISTER	2589	10	°C	3	50	300	250
+id:12844	MODBUS_HOLDING_REGISTER	2591	10	°C	3	50	300	250
+id:12845	MODBUS_HOLDING_REGISTER	2593	10	°C	3	50	300	250
+id:12846	MODBUS_HOLDING_REGISTER	2595	10	°C	3	50	300	250
+id:12847	MODBUS_HOLDING_REGISTER	2597	10	°C	3	50	300	250
+id:12848	MODBUS_HOLDING_REGISTER	2599	10	°C	3	50	300	250
+id:12849	MODBUS_HOLDING_REGISTER	2601	10	°C	3	50	300	250
+id:12850	MODBUS_HOLDING_REGISTER	2603	10	°C	3	50	300	250
+id:12851	MODBUS_HOLDING_REGISTER	2605	10	°C	3	50	300	250
+id:12852	MODBUS_HOLDING_REGISTER	2607	10	°C	3	50	300	250
+id:12853	MODBUS_HOLDING_REGISTER	2609	10	°C	3	50	300	250
+id:12854	MODBUS_HOLDING_REGISTER	2611	10	°C	3	50	300	250
+id:12855	MODBUS_HOLDING_REGISTER	2613	10	°C	3	50	300	250
+id:12856	MODBUS_HOLDING_REGISTER	2615	10	°C	3	50	300	250
+id:12857	MODBUS_HOLDING_REGISTER	2617	10	°C	3	50	300	250
+id:12858	MODBUS_HOLDING_REGISTER	2619	10	°C	3	50	300	250
+id:12859	MODBUS_HOLDING_REGISTER	2621	10	°C	3	50	300	250
+id:12860	MODBUS_HOLDING_REGISTER	2623	10	°C	3	50	300	250
+id:12861	MODBUS_HOLDING_REGISTER	2625	10	°C	3	50	300	250
+id:12862	MODBUS_HOLDING_REGISTER	2627	10	°C	3	50	300	250
+id:12863	MODBUS_HOLDING_REGISTER	2629	10	°C	3	50	300	250
+id:12864	MODBUS_HOLDING_REGISTER	2631	10	°C	3	50	300	250
+id:12865	MODBUS_HOLDING_REGISTER	2633	10	°C	3	50	300	250
+id:12866	MODBUS_HOLDING_REGISTER	2635	10	°C	3	50	300	250
+id:12867	MODBUS_HOLDING_REGISTER	2637	10	°C	3	50	300	250
+id:12868	MODBUS_HOLDING_REGISTER	2639	10	°C	3	50	300	250
+id:12869	MODBUS_HOLDING_REGISTER	2641	10	°C	3	50	300	250
+id:12870	MODBUS_HOLDING_REGISTER	2643	10	°C	3	50	300	250
+id:12871	MODBUS_HOLDING_REGISTER	2645	10	°C	3	50	300	250
+id:12872	MODBUS_HOLDING_REGISTER	2647	10	°C	3	50	300	250
+id:12873	MODBUS_HOLDING_REGISTER	2649	10	°C	3	50	300	250
+id:12874	MODBUS_HOLDING_REGISTER	2651	10	°C	3	50	300	250
+id:12875	MODBUS_HOLDING_REGISTER	2653	10	°C	3	50	300	250
+id:12876	MODBUS_HOLDING_REGISTER	2655	10	°C	3	50	300	250
+id:12877	MODBUS_HOLDING_REGISTER	2657	10	°C	3	50	300	250
+id:12878	MODBUS_HOLDING_REGISTER	2659	10	°C	3	50	300	250
+id:12879	MODBUS_HOLDING_REGISTER	2661	10	°C	3	50	300	250
+id:12880	MODBUS_HOLDING_REGISTER	2663	10	°C	3	50	300	250
+id:13796	MODBUS_INPUT_REGISTER	2243	1		4	0	0	0
+id:13797	MODBUS_INPUT_REGISTER	2244	1		4	0	0	0
+id:13798	MODBUS_INPUT_REGISTER	2245	1		4	0	0	0
+id:13799	MODBUS_INPUT_REGISTER	2246	1		4	0	0	0
+id:13800	MODBUS_INPUT_REGISTER	2247	1		4	0	0	0
+id:13801	MODBUS_INPUT_REGISTER	2248	1		4	0	0	0
+id:13802	MODBUS_INPUT_REGISTER	2249	1		4	0	0	0
+id:13803	MODBUS_INPUT_REGISTER	2250	1		4	0	0	0
+Offset cooling (EME20)	MODBUS_HOLDING_REGISTER	2667	1		1	-10	0	-1
+Offset heating (EME20)	MODBUS_HOLDING_REGISTER	2668	1		4	0	10	1
+Offset pool (EME20)	MODBUS_HOLDING_REGISTER	2669	1	°C	4	0	10	10
+Cooling (EME20)	MODBUS_HOLDING_REGISTER	2666	1		4	0	1	0
+AUX (EME20)	MODBUS_HOLDING_REGISTER	2675	1		4	0	1	0
+id:14052	MODBUS_HOLDING_REGISTER	2670	1	kW	6	1	999	1
+id:14061	MODBUS_HOLDING_REGISTER	2672	1		4	0	1	0
+Temperature, Overload, pool	MODBUS_HOLDING_REGISTER	0	1	°C	4	1	50	1
+EME20 API	MODBUS_HOLDING_REGISTER	2107	1		4	0	1	0
+EME20 API Include own consumption	MODBUS_HOLDING_REGISTER	2108	1		4	0	1	0
+EME20 API Available power	MODBUS_HOLDING_REGISTER	2109	1		5	0	65535	0
+External adjustment input, main unit (ECS1)	MODBUS_HOLDING_REGISTER	2111	1		4	0	1	0
+External adjustment input (ECS2)	MODBUS_HOLDING_REGISTER	2112	1		4	0	1	0
+External adjustment input (ECS3)	MODBUS_HOLDING_REGISTER	2113	1		4	0	1	0
+External adjustment input (ECS4)	MODBUS_HOLDING_REGISTER	2114	1		4	0	1	0
+External adjustment input (ECS5)	MODBUS_HOLDING_REGISTER	2115	1		4	0	1	0
+External adjustment input (ECS6)	MODBUS_HOLDING_REGISTER	2116	1		4	0	1	0
+External adjustment input (ECS7)	MODBUS_HOLDING_REGISTER	2117	1		4	0	1	0
+External adjustment input (ECS8)	MODBUS_HOLDING_REGISTER	2118	1		4	0	1	0
+Zone 1 affected by ECS1	MODBUS_HOLDING_REGISTER	2119	1		4	0	1	0
+Zone 2 affected by ECS1	MODBUS_HOLDING_REGISTER	2120	1		4	0	1	0
+Zone 3 affected by ECS1	MODBUS_HOLDING_REGISTER	2121	1		4	0	1	0
+Zone 4 affected by ECS1	MODBUS_HOLDING_REGISTER	2122	1		4	0	1	0
+Zone 5 affected by ECS1	MODBUS_HOLDING_REGISTER	2123	1		4	0	1	0
+Zone 6 affected by ECS1	MODBUS_HOLDING_REGISTER	2124	1		4	0	1	0
+Zone 7 affected by ECS1	MODBUS_HOLDING_REGISTER	2125	1		4	0	1	0
+Zone 8 affected by ECS1	MODBUS_HOLDING_REGISTER	2126	1		4	0	1	0
+Zone 9 affected by ECS1	MODBUS_HOLDING_REGISTER	2127	1		4	0	1	0
+Zone 10 affected by ECS1	MODBUS_HOLDING_REGISTER	2128	1		4	0	1	0
+Zone 11 affected by ECS1	MODBUS_HOLDING_REGISTER	2129	1		4	0	1	0
+Zone 12 affected by ECS1	MODBUS_HOLDING_REGISTER	2130	1		4	0	1	0
+Zone 13 affected by ECS1	MODBUS_HOLDING_REGISTER	2131	1		4	0	1	0
+Zone 14 affected by ECS1	MODBUS_HOLDING_REGISTER	2132	1		4	0	1	0
+Zone 15 affected by ECS1	MODBUS_HOLDING_REGISTER	2133	1		4	0	1	0
+Zone 16 affected by ECS1	MODBUS_HOLDING_REGISTER	2134	1		4	0	1	0
+Zone 17 affected by ECS1	MODBUS_HOLDING_REGISTER	2135	1		4	0	1	0
+Zone 18 affected by ECS1	MODBUS_HOLDING_REGISTER	2136	1		4	0	1	0
+Zone 19 affected by ECS1	MODBUS_HOLDING_REGISTER	2137	1		4	0	1	0
+Zone 20 affected by ECS1	MODBUS_HOLDING_REGISTER	2138	1		4	0	1	0
+Zone 21 affected by ECS1	MODBUS_HOLDING_REGISTER	2139	1		4	0	1	0
+Zone 22 affected by ECS1	MODBUS_HOLDING_REGISTER	2140	1		4	0	1	0
+Zone 23 affected by ECS1	MODBUS_HOLDING_REGISTER	2141	1		4	0	1	0
+Zone 24 affected by ECS1	MODBUS_HOLDING_REGISTER	2142	1		4	0	1	0
+Zone 25 affected by ECS1	MODBUS_HOLDING_REGISTER	2143	1		4	0	1	0
+Zone 26 affected by ECS1	MODBUS_HOLDING_REGISTER	2144	1		4	0	1	0
+Zone 27 affected by ECS1	MODBUS_HOLDING_REGISTER	2145	1		4	0	1	0
+Zone 28 affected by ECS1	MODBUS_HOLDING_REGISTER	2146	1		4	0	1	0
+Zone 29 affected by ECS1	MODBUS_HOLDING_REGISTER	2147	1		4	0	1	0
+Zone 30 affected by ECS1	MODBUS_HOLDING_REGISTER	2148	1		4	0	1	0
+Zone 31 affected by ECS1	MODBUS_HOLDING_REGISTER	2149	1		4	0	1	0
+Zone 32 affected by ECS1	MODBUS_HOLDING_REGISTER	2150	1		4	0	1	0
+Zone 33 affected by ECS1	MODBUS_HOLDING_REGISTER	2151	1		4	0	1	0
+Zone 34 affected by ECS1	MODBUS_HOLDING_REGISTER	2152	1		4	0	1	0
+Zone 35 affected by ECS1	MODBUS_HOLDING_REGISTER	2153	1		4	0	1	0
+Zone 36 affected by ECS1	MODBUS_HOLDING_REGISTER	2154	1		4	0	1	0
+Zone 37 affected by ECS1	MODBUS_HOLDING_REGISTER	2155	1		4	0	1	0
+Zone 38 affected by ECS1	MODBUS_HOLDING_REGISTER	2156	1		4	0	1	0
+Zone 39 affected by ECS1	MODBUS_HOLDING_REGISTER	2157	1		4	0	1	0
+Zone 40 affected by ECS1	MODBUS_HOLDING_REGISTER	2158	1		4	0	1	0
+Input on ECS1 affects ECS1	MODBUS_HOLDING_REGISTER	2439	1		4	0	1	0
+Input on ECS1 affects ECS2	MODBUS_HOLDING_REGISTER	2440	1		4	0	1	0
+Input on ECS1 affects ECS3	MODBUS_HOLDING_REGISTER	2441	1		4	0	1	0
+Input on ECS1 affects ECS4	MODBUS_HOLDING_REGISTER	2442	1		4	0	1	0
+Input on ECS1 affects ECS5	MODBUS_HOLDING_REGISTER	2443	1		4	0	1	0
+Input on ECS1 affects ECS6	MODBUS_HOLDING_REGISTER	2444	1		4	0	1	0
+Input on ECS1 affects ECS7	MODBUS_HOLDING_REGISTER	2445	1		4	0	1	0
+Input on ECS1 affects ECS8	MODBUS_HOLDING_REGISTER	2446	1		4	0	1	0
+External setting for adjustment migrated	MODBUS_HOLDING_REGISTER	2503	1		4	0	1	0
+Version, inverter (EB101)	MODBUS_INPUT_REGISTER	2147	1		4	0	0	0
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2676	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2677	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2678	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2679	1		4	1	24	3
+id:21077	MODBUS_HOLDING_REGISTER	3020	1		4	0	0	0
+id:21078	MODBUS_HOLDING_REGISTER	3021	1		4	0	0	0
+id:21079	MODBUS_HOLDING_REGISTER	3022	1		4	0	0	0
+id:21080	MODBUS_HOLDING_REGISTER	3023	1		4	0	0	0
+id:21081	MODBUS_HOLDING_REGISTER	3024	1		4	0	0	0
+id:21082	MODBUS_HOLDING_REGISTER	3025	1		4	0	0	0
+id:21083	MODBUS_HOLDING_REGISTER	3026	1		4	0	0	0
+id:21084	MODBUS_HOLDING_REGISTER	3027	1		4	0	0	0
+Return time fan 4	MODBUS_HOLDING_REGISTER	2700	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2701	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2702	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2703	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2704	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2705	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2706	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2707	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2708	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2709	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2710	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2711	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2712	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2713	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2714	1	h	4	1	24	4
+Return time fan 4	MODBUS_HOLDING_REGISTER	2715	1	h	4	1	24	4
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2728	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2729	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2730	1		4	1	24	3
+Time between filter replacement	MODBUS_HOLDING_REGISTER	2731	1		4	1	24	3
+AUX from Modbus	MODBUS_HOLDING_REGISTER	2740	1		4	0	65	0
+AUX from Modbus	MODBUS_HOLDING_REGISTER	2741	1		2	0	0	0
+Heat pump test - Silent mode (EB101/EB102)	MODBUS_HOLDING_REGISTER	5101	1		4	0	1	0
+Last defrost, heat pump 1	MODBUS_INPUT_REGISTER	2158	1		4	0	255	255
+ERS 2	MODBUS_HOLDING_REGISTER	2820	1		4	0	1	0
+ERS 3	MODBUS_HOLDING_REGISTER	2821	1		4	0	1	0
+ERS 4	MODBUS_HOLDING_REGISTER	2822	1		4	0	1	0
+ERS 4	MODBUS_HOLDING_REGISTER	2823	1		4	0	1	0
+ERS 4	MODBUS_HOLDING_REGISTER	2824	1		4	0	1	1
+ERS 4	MODBUS_HOLDING_REGISTER	2825	1		4	0	1	1
+ERS 4	MODBUS_HOLDING_REGISTER	2826	1		4	0	1	1
+ERS 4	MODBUS_HOLDING_REGISTER	2827	1		4	0	1	1
+Min. vent temp. (ERS 4)	MODBUS_HOLDING_REGISTER	2857	1	°C	4	0	10	3
+Min. vent temp. (ERS 4)	MODBUS_HOLDING_REGISTER	2858	1	°C	4	0	10	3
+Min. vent temp. (ERS 4)	MODBUS_HOLDING_REGISTER	2859	1	°C	4	0	10	3
+Min. vent temp. (ERS 4)	MODBUS_HOLDING_REGISTER	2860	1	°C	4	0	10	3
+Blocking actions (ERS 4)	MODBUS_HOLDING_REGISTER	2828	1		4	0	2	2
+Blocking actions (ERS 4)	MODBUS_HOLDING_REGISTER	2829	1		4	0	2	2
+Blocking actions (ERS 4)	MODBUS_HOLDING_REGISTER	2830	1		4	0	2	2
+Blocking actions (ERS 4)	MODBUS_HOLDING_REGISTER	2831	1		4	0	2	2
+id:23145	MODBUS_HOLDING_REGISTER	2921	1		4	0	1	0
+id:23146	MODBUS_HOLDING_REGISTER	2922	1		4	0	1	0
+id:23147	MODBUS_HOLDING_REGISTER	2923	1		4	0	1	0
+id:23148	MODBUS_HOLDING_REGISTER	2924	1		4	0	1	0
+id:23149	MODBUS_HOLDING_REGISTER	2836	10	°C	2	-200	410	190
+id:23150	MODBUS_HOLDING_REGISTER	2837	10	°C	2	-200	410	190
+id:23151	MODBUS_HOLDING_REGISTER	2838	10	°C	2	-200	410	190
+id:23152	MODBUS_HOLDING_REGISTER	2839	10	°C	2	-200	410	190
+id:23153	MODBUS_HOLDING_REGISTER	2832	10	°C	2	30	100	30
+id:23154	MODBUS_HOLDING_REGISTER	2833	10	°C	2	30	100	30
+id:23155	MODBUS_HOLDING_REGISTER	2834	10	°C	2	30	100	30
+id:23156	MODBUS_HOLDING_REGISTER	2835	10	°C	2	30	100	30
+Fan mode 5	MODBUS_INPUT_REGISTER	2168	1	%	4	0	0	0
+Fan mode 6	MODBUS_INPUT_REGISTER	2169	1	%	4	0	0	0
+Fan mode 7	MODBUS_INPUT_REGISTER	2170	1	%	4	0	0	0
+Fan mode 8	MODBUS_INPUT_REGISTER	2171	1	%	4	0	0	0
+Disable emergency restart GP1	MODBUS_HOLDING_REGISTER	3628	1		4	0	1	0
+Disable emergency restart GP1	MODBUS_HOLDING_REGISTER	5025	1		4	0	1	0
+id:24483	MODBUS_HOLDING_REGISTER	5008	1		4	0	1	0
+id:24484	MODBUS_HOLDING_REGISTER	5009	10	°C	2	50	800	450
+id:24485	MODBUS_HOLDING_REGISTER	5010	10	°C	2	50	800	450
+id:24486	MODBUS_HOLDING_REGISTER	5011	10	°C	2	50	800	450
+id:24487	MODBUS_HOLDING_REGISTER	5012	10	°C	2	50	800	450
+id:24488	MODBUS_HOLDING_REGISTER	5013	10	°C	2	50	800	450
+id:24489	MODBUS_HOLDING_REGISTER	5014	10	°C	2	50	800	450
+id:24490	MODBUS_HOLDING_REGISTER	5015	10	°C	2	50	800	450
+id:24491	MODBUS_HOLDING_REGISTER	5016	10	°C	2	50	800	450
+id:24492	MODBUS_HOLDING_REGISTER	5017	10	°C	2	-50	300	250
+id:24493	MODBUS_HOLDING_REGISTER	5018	10	°C	2	-50	300	250
+id:24494	MODBUS_HOLDING_REGISTER	5019	10	°C	2	-50	300	250
+id:24495	MODBUS_HOLDING_REGISTER	5020	10	°C	2	-50	300	250
+id:24496	MODBUS_HOLDING_REGISTER	5021	10	°C	2	-50	300	250
+id:24497	MODBUS_HOLDING_REGISTER	5022	10	°C	2	-50	300	250
+id:24498	MODBUS_HOLDING_REGISTER	5023	10	°C	2	-50	300	250
+id:24499	MODBUS_HOLDING_REGISTER	5024	10	°C	2	-50	300	250
+id:24634	MODBUS_HOLDING_REGISTER	5031	10	°C	2	50	800	200
+id:24635	MODBUS_HOLDING_REGISTER	5032	10	°C	2	50	800	200
+id:24636	MODBUS_HOLDING_REGISTER	5033	10	°C	2	50	800	200
+id:24637	MODBUS_HOLDING_REGISTER	5034	10	°C	2	50	800	200
+id:24638	MODBUS_HOLDING_REGISTER	5035	10	°C	2	50	800	200
+id:24639	MODBUS_HOLDING_REGISTER	5036	10	°C	2	50	800	200
+id:24640	MODBUS_HOLDING_REGISTER	5037	10	°C	2	50	800	200
+id:24641	MODBUS_HOLDING_REGISTER	5038	10	°C	2	50	800	200
+id:24642	MODBUS_HOLDING_REGISTER	5039	10	°C	2	50	800	600
+id:24643	MODBUS_HOLDING_REGISTER	5040	10	°C	2	50	800	600
+id:24644	MODBUS_HOLDING_REGISTER	5041	10	°C	2	50	800	600
+id:24645	MODBUS_HOLDING_REGISTER	5042	10	°C	2	50	800	600
+id:24646	MODBUS_HOLDING_REGISTER	5043	10	°C	2	50	800	600
+id:24647	MODBUS_HOLDING_REGISTER	5044	10	°C	2	50	800	600
+id:24648	MODBUS_HOLDING_REGISTER	5045	10	°C	2	50	800	600
+id:24649	MODBUS_HOLDING_REGISTER	5046	10	°C	2	50	800	600
+id:24650	MODBUS_HOLDING_REGISTER	5047	10	°C	2	50	800	180
+id:24651	MODBUS_HOLDING_REGISTER	5048	10	°C	2	50	800	180
+id:24652	MODBUS_HOLDING_REGISTER	5049	10	°C	2	50	800	180
+id:24653	MODBUS_HOLDING_REGISTER	5050	10	°C	2	50	800	180
+id:24654	MODBUS_HOLDING_REGISTER	5051	10	°C	2	50	800	180
+id:24655	MODBUS_HOLDING_REGISTER	5052	10	°C	2	50	800	180
+id:24656	MODBUS_HOLDING_REGISTER	5053	10	°C	2	50	800	180
+id:24657	MODBUS_HOLDING_REGISTER	5054	10	°C	2	50	800	180
+id:24681	MODBUS_HOLDING_REGISTER	5056	1		4	0	1	0
+id:24682	MODBUS_HOLDING_REGISTER	5057	1		4	0	1	0
+id:24683	MODBUS_HOLDING_REGISTER	5058	1		4	0	255	0
+id:24684	MODBUS_HOLDING_REGISTER	5059	1		4	0	1	0
+Relay status	MODBUS_INPUT_REGISTER	0	1		4	0	0	0
+id:24969	MODBUS_HOLDING_REGISTER	5060	1		4	0	1	0
+id:24970	MODBUS_HOLDING_REGISTER	5061	1		2	-100	10000	0
+id:24971	MODBUS_HOLDING_REGISTER	5062	1		4	0	1	0
+id:24972	MODBUS_HOLDING_REGISTER	5063	1		5	0	1000	0
+id:24973	MODBUS_HOLDING_REGISTER	5064	1		4	0	1	0
+id:24974	MODBUS_HOLDING_REGISTER	5065	1		4	0	1	0
+id:24975	MODBUS_HOLDING_REGISTER	5066	1		5	0	1000	0
+id:24976	MODBUS_HOLDING_REGISTER	5067	1		4	0	1	0
+id:24977	MODBUS_HOLDING_REGISTER	5068	1		4	0	1	0
+id:24978	MODBUS_HOLDING_REGISTER	5069	1		5	0	1000	0
+id:24979	MODBUS_HOLDING_REGISTER	5070	1		4	0	1	0
+id:24980	MODBUS_HOLDING_REGISTER	5071	1		5	0	1000	0
+Energy log - Energy produced for heat during past hour	MODBUS_INPUT_REGISTER	2283	100	kWh	6	0	0	0
+Energy log - Energy produced for hot water during past hour	MODBUS_INPUT_REGISTER	2285	100	kWh	6	0	0	0
+Energy log - Energy produced for cooling during past hour	MODBUS_INPUT_REGISTER	2289	100	kWh	6	0	0	0
+Energy log - Energy used for heat during past hour	MODBUS_INPUT_REGISTER	2291	100	kWh	6	0	0	0
+Energy log - Energy used for hot water during past hour	MODBUS_INPUT_REGISTER	2293	100	kWh	6	0	0	0
+Energy log - Energy used for cooling during past hour	MODBUS_INPUT_REGISTER	2297	100	kWh	6	0	0	0
+Energy log - Energy used by additional heater for heat during past hour	MODBUS_INPUT_REGISTER	2299	100	kWh	6	0	0	0
+Energy log - Energy used by additional heater for hot water during past hour	MODBUS_INPUT_REGISTER	2301	100	kWh	6	0	0	0
+Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kW	6	0	0	0
+Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2307	100	kW	6	0	0	0
+id:25407	MODBUS_HOLDING_REGISTER	0	1		4	0	0	0
+Compressor, total time energy storage, main unit (EP14)	MODBUS_INPUT_REGISTER	2335	1	h	6	-2147483648	2147483647	0
+Compressor, total time energy storage, main unit (EP15)	MODBUS_INPUT_REGISTER	2337	1	h	6	-2147483648	2147483647	0
+Compressor, total time energy storage, heat pump 1 (EP14)	MODBUS_INPUT_REGISTER	2339	1	h	6	-2147483648	2147483647	0
+Compressor, total time energy storage, heat pump 1 (EP15)	MODBUS_INPUT_REGISTER	2341	1	h	6	-2147483648	2147483647	0
+id:55035	MODBUS_HOLDING_REGISTER	1555	1		4	0	40	0
+id:55036	MODBUS_HOLDING_REGISTER	1556	1		4	0	40	0
+id:55037	MODBUS_HOLDING_REGISTER	1557	1		4	0	40	0
+id:55076	MODBUS_HOLDING_REGISTER	2877	1		4	0	1	0
+id:55077	MODBUS_HOLDING_REGISTER	2878	1		4	0	1	0
+id:55078	MODBUS_HOLDING_REGISTER	2879	1		4	0	1	0
+id:55079	MODBUS_HOLDING_REGISTER	2880	1		4	0	1	0
+id:55080	MODBUS_HOLDING_REGISTER	2881	1		4	0	1	0
+id:55081	MODBUS_HOLDING_REGISTER	2882	1		4	0	1	0
+id:55082	MODBUS_HOLDING_REGISTER	2883	1		4	0	1	0
+id:55083	MODBUS_HOLDING_REGISTER	2884	1		4	0	1	0
+Immersion heater power, emergency mode	MODBUS_HOLDING_REGISTER	3028	100	kW	2	0	4500	600
+Disable emergency restart GP1	MODBUS_HOLDING_REGISTER	3986	1		4	0	1	0


### PR DESCRIPTION
I finally found time to set my heatpump to English and export all Modbus registers, as discussed here: https://github.com/home-assistant/core/issues/85925.

The registers are for the following combination:

* **Indoor Unit**: [VVM S320](https://www.nibe.eu/en-gb/products/heat-pumps/air-source-heat-pumps/vvm-s320)
* **Outdoor Unit**: [F2120-8](https://www.nibe.eu/en-eu/products/products-for-larger-properties/F2120)
* **Ventilation Heat Exchanger**: [ERS 10-500](https://www.nibe.eu/assets/documents/18664/331807-1.pdf) (_which should be identical to the more common 10-400, albeit less efficient (but it was out of stock at the time)_)

Please let me know what else to do to get the registers included to Home Assistant eventually.