### PR TITLE
Add extension for coil 47377 to F1245

### DIFF
--- a/nibe/data/extensions.json
+++ b/nibe/data/extensions.json
@@ -247,7 +247,8 @@
   {
     "description": "Allow for numerical selection for Outdoor Filter Time",
     "files": [
-      "smo40.json"
+      "smo40.json",
+      "f1145_f1245.json"
     ],
     "data": {
      "47377": {

--- a/nibe/data/f1145_f1245.json
+++ b/nibe/data/f1145_f1245.json
@@ -9189,17 +9189,13 @@
     "title": "Outdoor Filter Time",
     "info": " 12=12 Hours 24=24 Hours",
     "unit": "h",
-    "size": "u8",
+    "size": "s16",
     "factor": 1,
     "min": 0.0,
     "max": 48.0,
     "default": 24.0,
     "name": "outdoor-filter-time-47377",
-    "write": true,
-    "mappings": {
-      "12": "12 Hours",
-      "24": "24 Hours"
-    }
+    "write": true
   },
   "47378": {
     "title": "Max diff. comp.",


### PR DESCRIPTION
This adds the F1145 and F1245 models to the 47377 extension, allowing any filter time to be set instead of using mapping

https://github.com/yozik04/nibe/issues/108