### PR TITLE
Make sure read does not leak decode error

### DIFF
--- a/nibe/connection/modbus.py
+++ b/nibe/connection/modbus.py
@@ -11,6 +11,7 @@ from nibe.coil import Coil, CoilData
 from nibe.connection import DEFAULT_TIMEOUT, Connection
 from nibe.connection.encoders import CoilDataEncoder
 from nibe.exceptions import (
+    DecodeException,
     ModbusUrlException,
     ReadException,
     ReadIOException,
@@ -141,10 +142,12 @@ class Modbus(Connection):
             raise ReadIOException(
                 f"Error '{str(exc)}' reading {coil.name} starting: {entity_number} count: {entity_count} from: {self._slave_id}"
             ) from exc
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as exc:
             raise ReadTimeoutException(
                 f"Timeout waiting for read response for {coil.name}"
-            )
+            ) from exc
+        except DecodeException as e:
+            raise ReadException(f"Failed decoding response for {coil.name}: {e}") from e
 
         return coil_data
 

--- a/nibe/connection/modbus.py
+++ b/nibe/connection/modbus.py
@@ -146,8 +146,8 @@ class Modbus(Connection):
             raise ReadTimeoutException(
                 f"Timeout waiting for read response for {coil.name}"
             ) from exc
-        except DecodeException as e:
-            raise ReadException(f"Failed decoding response for {coil.name}: {e}") from e
+        except DecodeException as exc:
+            raise ReadException(f"Failed decoding response for {coil.name}") from exc
 
         return coil_data
 

--- a/nibe/exceptions.py
+++ b/nibe/exceptions.py
@@ -34,6 +34,8 @@ class WriteException(NibeException):
 
 
 class WriteIOException(WriteException):
+    """Use this and child exceptions if IO has failed and you want to retry."""
+
     pass
 
 
@@ -50,6 +52,8 @@ class ReadException(NibeException):
 
 
 class ReadIOException(ReadException):
+    """Use this and child exception if IO has failed and you want to retry."""
+
     pass
 
 

--- a/tests/connection/test_modbus.py
+++ b/tests/connection/test_modbus.py
@@ -6,6 +6,7 @@ import pytest
 
 from nibe.coil import Coil, CoilData
 from nibe.connection.modbus import Modbus
+from nibe.exceptions import ReadException
 from nibe.heatpump import HeatPump, Model
 
 
@@ -150,6 +151,16 @@ async def test_read_coil_coil(
     coil_data = await connection.read_coil(coil)
     assert coil_data.value == value
     modbus_client.read_coils.assert_called()
+
+
+async def test_read_coil_out_of_range(
+    connection: Modbus,
+    modbus_client: AsyncMock,
+):
+    coil = Coil(1, "test", "test", "u8", 1, min=1, max=2)
+    modbus_client.read_coils.return_value = bytes([0])
+    with pytest.raises(ReadException):
+        await connection.read_coil(coil)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

Leaking DecodeException from read_coil, causes accumulation of read faults to fail in read_coils.

See https://github.com/home-assistant/core/issues/100852 for some reference on how this disables all reads from device.