### PR TITLE
Make sure validation error also is a readexception

### DIFF
--- a/nibe/connection/modbus.py
+++ b/nibe/connection/modbus.py
@@ -146,7 +146,7 @@ class Modbus(Connection):
             raise ReadTimeoutException(
                 f"Timeout waiting for read response for {coil.name}"
             ) from exc
-        except DecodeException as exc:
+        except (DecodeException, ValidationError) as exc:
             raise ReadException(f"Failed decoding response for {coil.name}") from exc
 
         return coil_data


### PR DESCRIPTION
These occur if mapping is out of range, and can be handled as partial exceptions in read_coils