### PR TITLE
Handle all construct parse errors the same

### DIFF
--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -19,8 +19,8 @@ from construct import (
     BitStruct,
     Bytes,
     Checksum,
-    ChecksumError,
     Const,
+    ConstructError,
     Container,
     Enum,
     EnumIntegerString,
@@ -210,16 +210,15 @@ class NibeGW(asyncio.DatagramProtocol, Connection, EventServer, ConnectionStatus
                 )
             elif not isinstance(cmd, EnumIntegerString):
                 logger.debug(f"Unknown command {cmd}")
-        except ChecksumError:
+        except ConstructError as e:
             logger.warning(
-                f"Ignoring packet from {addr} due to checksum error: {hexlify(data).decode('utf-8')}"
+                f"Ignoring packet from {addr} due to parse error: {hexlify(data).decode('utf-8')}: {e}"
             )
         except NibeException as e:
             logger.error(f"Failed handling packet from {addr}: {e}")
-        except Exception as e:
+        except Exception:
             logger.exception(
-                f"Unexpected exception during parsing packet data '{hexlify(data).decode('utf-8')}' from {addr}",
-                e,
+                f"Unexpected exception during parsing packet data '{hexlify(data).decode('utf-8')}' from {addr}"
             )
 
     async def read_product_info(

--- a/nibe/console_scripts/cli.py
+++ b/nibe/console_scripts/cli.py
@@ -9,7 +9,16 @@ import re
 from typing import IO
 
 import asyncclick as click
-from construct import Const, GreedyRange, Int8ul, RawCopy, Select, Struct, Terminated
+from construct import (
+    Const,
+    ConstructError,
+    GreedyRange,
+    Int8ul,
+    RawCopy,
+    Select,
+    Struct,
+    Terminated,
+)
 
 from ..coil import CoilData
 from ..connection import Connection
@@ -191,8 +200,12 @@ async def parse_data(data: str, type: str):
         raw = bytes.fromhex(data)
     elif type == "bytes":
         raw = bytes(literal_eval(data))
-    request = Block.parse(raw)
-    click.echo(request)
+
+    try:
+        request = Block.parse(raw)
+        click.echo(request)
+    except ConstructError as exception:
+        click.echo(f"Failed to parse: {exception}", err=True)
 
 
 def read_bytes_socat(file: IO):


### PR DESCRIPTION
Handle all construct parse errors the same

- Logs all parse errors without backtrace
- Adjust invalid logger format for standard exceptions