### PR TITLE
Support parsing 32 bit values log set

### DIFF
--- a/tests/connection/test_nibegw.py
+++ b/tests/connection/test_nibegw.py
@@ -2,7 +2,7 @@ import asyncio
 import binascii
 import time
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -140,14 +140,21 @@ class TestNibeGW(IsolatedAsyncioTestCase):
         self.heatpump.subscribe("coil_update", on_coil_update_mock)
         self.nibegw.datagram_received(
             binascii.unhexlify(
-                "5c00206850c9af0000889c7100a9a90a00a3a91400aba90000939c0000949c0000919c0000929c00008f9c0000909c00003ab95000ada94600a7a91400faa90200ffff0000ffff0000ffff0000ffff0000ffff0000cc"
+                "5c00206850c9af0000889c7100a9a90a00a3a91400aba90000939c0000949c0000919c3c00929c00008f9c0000909c00003ab95000ada94600a7a91400faa90200ffff0000ffff0000ffff0000ffff0000ffff0000f0"
             ),
             ("127.0.0.1", 12345),
         )
-
-        on_coil_update_mock.assert_any_call(
-            CoilData(self.heatpump.get_coil_by_address(45001), 0.0)
-        )
-        on_coil_update_mock.assert_any_call(
-            CoilData(self.heatpump.get_coil_by_address(43514), 2.0)
-        )
+        assert on_coil_update_mock.mock_calls == [
+            call(CoilData(self.heatpump.get_coil_by_address(40072), 11.3)),
+            call(CoilData(self.heatpump.get_coil_by_address(40079), 0.0)),
+            call(CoilData(self.heatpump.get_coil_by_address(40081), 6.0)),
+            call(CoilData(self.heatpump.get_coil_by_address(40083), 0.0)),
+            call(CoilData(self.heatpump.get_coil_by_address(43427), "STOPPED")),
+            call(CoilData(self.heatpump.get_coil_by_address(43431), "ON")),
+            call(CoilData(self.heatpump.get_coil_by_address(43433), "OFF")),
+            call(CoilData(self.heatpump.get_coil_by_address(43435), "OFF")),
+            call(CoilData(self.heatpump.get_coil_by_address(43437), 70)),
+            call(CoilData(self.heatpump.get_coil_by_address(43514), 2)),
+            call(CoilData(self.heatpump.get_coil_by_address(45001), 0)),
+            call(CoilData(self.heatpump.get_coil_by_address(47418), 80)),
+        ]

--- a/tests/connection/test_nibegw.py
+++ b/tests/connection/test_nibegw.py
@@ -135,7 +135,7 @@ class TestNibeGW(IsolatedAsyncioTestCase):
         assert isinstance(product, ProductInfo)
         assert "F1255-12 R" == product.model
 
-    async def test_read_multiple_with_u32(self):
+    async def test_read_multiple_with_u32_1(self):
         on_coil_update_mock = Mock()
         self.heatpump.subscribe("coil_update", on_coil_update_mock)
         self.nibegw.datagram_received(
@@ -144,17 +144,51 @@ class TestNibeGW(IsolatedAsyncioTestCase):
             ),
             ("127.0.0.1", 12345),
         )
+
+        def _call(address, value):
+            return call(CoilData(self.heatpump.get_coil_by_address(address), value))
+
         assert on_coil_update_mock.mock_calls == [
-            call(CoilData(self.heatpump.get_coil_by_address(40072), 11.3)),
-            call(CoilData(self.heatpump.get_coil_by_address(40079), 0.0)),
-            call(CoilData(self.heatpump.get_coil_by_address(40081), 6.0)),
-            call(CoilData(self.heatpump.get_coil_by_address(40083), 0.0)),
-            call(CoilData(self.heatpump.get_coil_by_address(43427), "STOPPED")),
-            call(CoilData(self.heatpump.get_coil_by_address(43431), "ON")),
-            call(CoilData(self.heatpump.get_coil_by_address(43433), "OFF")),
-            call(CoilData(self.heatpump.get_coil_by_address(43435), "OFF")),
-            call(CoilData(self.heatpump.get_coil_by_address(43437), 70)),
-            call(CoilData(self.heatpump.get_coil_by_address(43514), 2)),
-            call(CoilData(self.heatpump.get_coil_by_address(45001), 0)),
-            call(CoilData(self.heatpump.get_coil_by_address(47418), 80)),
+            _call(40072, 11.3),
+            _call(40079, 0.0),
+            _call(40081, 6.0),
+            _call(40083, 0.0),
+            _call(43427, "STOPPED"),
+            _call(43431, "ON"),
+            _call(43433, "OFF"),
+            _call(43435, "OFF"),
+            _call(43437, 70),
+            _call(43514, 2),
+            _call(45001, 0),
+            _call(47418, 80),
+        ]
+
+    async def test_read_multiple_with_u32_2(self):
+        on_coil_update_mock = Mock()
+        self.heatpump.subscribe("coil_update", on_coil_update_mock)
+        self.nibegw.datagram_received(
+            binascii.unhexlify(
+                "5c00206850489ce4004c9ce3004e9ca101889c4500d5a1ae00d6a1a300fda718f8c5a5ad98c6a50100cda5d897cea50100cfa51fb7d0a5060098a96d2399a90000a0a9cf05a1a900009ca9a01a9da90000449c4500e5"
+            ),
+            ("127.0.0.1", 12345),
+        )
+
+        def _call(address, value):
+            return call(CoilData(self.heatpump.get_coil_by_address(address), value))
+
+        assert on_coil_update_mock.mock_calls == [
+            _call(40004, 6.9),
+            _call(40008, 22.8),
+            _call(40012, 22.7),
+            _call(40014, 41.7),
+            _call(40072, 6.9),
+            _call(41429, 17.4),
+            _call(41430, 16.3),
+            _call(42437, 10462.1),
+            _call(42445, 10440.8),
+            _call(42447, 44009.5),
+            _call(43005, -202.4),
+            _call(43416, 9069),
+            _call(43420, 6816),
+            _call(43424, 1487),
         ]


### PR DESCRIPTION
The log set data for 32 bit values seem to come with a "virtual" address at the next index from the data. So re-combine the data at reception.
