### PR TITLE
Catch incomplete read and log which coil failed

### DIFF
--- a/nibe/connection/modbus.py
+++ b/nibe/connection/modbus.py
@@ -160,7 +160,7 @@ class Modbus(Connection):
             raise WriteIOException(
                 f"Error validating {coil.name} coil value: {str(exc)}"
             ) from exc
-        except ModbusError as exc:
+        except (ModbusError, asyncio.IncompleteReadError) as exc:
             raise WriteIOException(
                 f"Error '{str(exc)}' writing {coil.name} starting: {entity_number} count: {entity_count} to: {self._slave_id}"
             ) from exc

--- a/nibe/connection/modbus.py
+++ b/nibe/connection/modbus.py
@@ -112,7 +112,7 @@ class Modbus(Connection):
 
             logger.info(coil_data)
             self._heatpump.notify_coil_update(coil_data)
-        except ModbusError as exc:
+        except (ModbusError, asyncio.IncompleteReadError) as exc:
             raise ReadIOException(
                 f"Error '{str(exc)}' reading {coil.name} starting: {entity_number} count: {entity_count} from: {self._slave_id}"
             ) from exc


### PR DESCRIPTION
This should allow easier fault tracing of issues with pumps crashing

See: https://github.com/home-assistant/core/issues/118598
