### PR TITLE
fix airflow units 40050,40051,41026 for f750 and f730

### DIFF
--- a/nibe/data/extensions.json
+++ b/nibe/data/extensions.json
@@ -104,6 +104,25 @@
     }
   },
   {
+    "description": "Corrections for airflow units",
+    "files": [
+      "f730.json",
+      "f750.json"
+    ],
+    "data": {
+      "40050": {
+        "unit": "m\u00b3/h"
+      },
+      "40051": {
+        "factor": 10,
+        "unit": "m\u00b3/h"
+      },
+      "41026": {
+        "unit": "m\u00b3/h"
+      }
+    }
+  },
+  {
     "files": [
       "f370_f470.json",
       "f730.json",

--- a/nibe/data/f730.json
+++ b/nibe/data/f730.json
@@ -170,14 +170,16 @@
     "title": "EB100-BS1 Air flow",
     "size": "s16",
     "factor": 10,
-    "name": "eb100-bs1-air-flow-40050"
+    "name": "eb100-bs1-air-flow-40050",
+    "unit": "m\u00b3/h"
   },
   "40051": {
     "title": "EB100-BS1 Air flow unfiltered",
     "info": "Unfiltered air flow value",
     "size": "s16",
-    "factor": 100,
-    "name": "eb100-bs1-air-flow-unfiltered-40051"
+    "factor": 10,
+    "name": "eb100-bs1-air-flow-unfiltered-40051",
+    "unit": "m\u00b3/h"
   },
   "40054": {
     "title": "EB100-FD1 Temperature limiter",
@@ -834,7 +836,8 @@
     "title": "EB100-Adjusted BS1 Air flow",
     "size": "s16",
     "factor": 10,
-    "name": "eb100-adjusted-bs1-air-flow-41026"
+    "name": "eb100-adjusted-bs1-air-flow-41026",
+    "unit": "m\u00b3/h"
   },
   "41027": {
     "title": "Humidity average",

--- a/nibe/data/f750.json
+++ b/nibe/data/f750.json
@@ -184,14 +184,16 @@
     "title": "EB100-BS1 Air flow",
     "size": "s16",
     "factor": 10,
-    "name": "eb100-bs1-air-flow-40050"
+    "name": "eb100-bs1-air-flow-40050",
+    "unit": "m\u00b3/h"
   },
   "40051": {
     "title": "EB100-BS1 Air flow unfiltered",
     "info": "Unfiltered air flow value",
     "size": "s16",
-    "factor": 100,
-    "name": "eb100-bs1-air-flow-unfiltered-40051"
+    "factor": 10,
+    "name": "eb100-bs1-air-flow-unfiltered-40051",
+    "unit": "m\u00b3/h"
   },
   "40054": {
     "title": "EB100-FD1 Temperature limiter",
@@ -923,7 +925,8 @@
     "title": "EB100-Adjusted BS1 Air flow",
     "size": "s16",
     "factor": 10,
-    "name": "eb100-adjusted-bs1-air-flow-41026"
+    "name": "eb100-adjusted-bs1-air-flow-41026",
+    "unit": "m\u00b3/h"
   },
   "41027": {
     "title": "Humidity average",


### PR DESCRIPTION
This PR fixes units of air flow sensors for Nibe F750 and F730.
![image](https://github.com/yozik04/nibe/assets/65893913/12d03d07-1181-4d68-89a4-bac1066302b5)

See #111 