### PR TITLE
Updated parameter values for reversing-valve-hot-water s1155-s1255

### DIFF
--- a/nibe/data/extensions.json
+++ b/nibe/data/extensions.json
@@ -301,6 +301,18 @@
     }
   },
   {
+    "description": "Reversing valve hot water (QN10) - S1156/S1256 ",
+    "files": ["s1155_s1255.json"],
+    "data": {
+      "32197": {
+        "mappings": {
+          "0": "Off",
+          "1": "On"
+        }
+      }
+    }
+  },
+  {
     "description": "M12676EN-1 - SMOS40 Mappings",
     "files": ["smos40.json"],
     "data": {

--- a/nibe/data/s1155_s1255.json
+++ b/nibe/data/s1155_s1255.json
@@ -3762,7 +3762,11 @@
     "title": "Reversing valve hot water (QN10)",
     "factor": 1,
     "size": "u8",
-    "name": "reversing-valve-hot-water-qn10-32197"
+    "name": "reversing-valve-hot-water-qn10-32197",
+    "mappings": {
+      "0": "Off",
+      "1": "On"
+    }
   },
   "31112": {
     "title": "Cooling activated (FLM 4)",


### PR DESCRIPTION
Value mapping for sensor reversing-valve-hot-water (qn10) 32197 updated from 0/1 to on/off for Nibe s1155 and s1255. 

Under current github structure this is also applicable to Nibe s1256. 