### PR TITLE
Separate write denied exception and consider that still a valid connection

### DIFF
--- a/nibe/connection/modbus.py
+++ b/nibe/connection/modbus.py
@@ -16,6 +16,7 @@ from nibe.exceptions import (
     ReadIOException,
     ReadTimeoutException,
     ValidationError,
+    WriteDeniedException,
     WriteIOException,
     WriteTimeoutException,
 )
@@ -153,7 +154,7 @@ class Modbus(Connection):
                     raise ReadIOException(f"Unsupported entity type {entity_type}")
 
             if not result:
-                raise WriteIOException(f"Heatpump denied writing {coil.name}")
+                raise WriteDeniedException(f"Heatpump denied writing {coil.name}")
             else:
                 logger.info(f"Write succeeded for {coil.name}")
         except ValidationError as exc:

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -65,7 +65,7 @@ from nibe.exceptions import (
     ReadIOException,
     ReadSendException,
     ReadTimeoutException,
-    WriteException,
+    WriteDeniedException,
     WriteIOException,
     WriteTimeoutException,
 )
@@ -369,7 +369,7 @@ class NibeGW(asyncio.DatagramProtocol, Connection, EventServer, ConnectionStatus
                 result = self._futures["write"].result()
 
                 if not result:
-                    raise WriteException(f"Heatpump denied writing {coil.name}")
+                    raise WriteDeniedException(f"Heatpump denied writing {coil.name}")
                 else:
                     logger.info(f"Write succeeded for {coil.name}")
             except asyncio.TimeoutError:

--- a/nibe/exceptions.py
+++ b/nibe/exceptions.py
@@ -33,6 +33,10 @@ class WriteException(NibeException):
     pass
 
 
+class WriteDeniedException(WriteException):
+    """Raised a write of a value was rejected by the pump."""
+
+
 class WriteIOException(WriteException):
     """Use this and child exceptions if IO has failed and you want to retry."""
 


### PR DESCRIPTION
Separate write denied exception and consider that still a valid connection

Some upgraded F-Series pump have started rejecting these writes, see issue https://github.com/home-assistant/core/issues/120023#

This changes to a denied write is still considered a valid connection.