### PR TITLE
Allow read of CoilData with missing mappings

### DIFF
--- a/nibe/coil.py
+++ b/nibe/coil.py
@@ -178,7 +178,10 @@ class CoilData:
     @staticmethod
     def from_mapping(coil: Coil, value: int) -> "CoilData":
         """Create CoilData from raw value using mappings."""
-        return CoilData(coil, coil.get_mapping_for(value))
+        try:
+            return CoilData(coil, coil.get_mapping_for(value))
+        except NoMappingException:
+            return CoilData(coil, f"UNKNOWN ({value})")
 
     @staticmethod
     def from_raw_value(coil: Coil, value: Union[int, None]) -> "CoilData":

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -469,9 +469,10 @@ class NibeGW(asyncio.DatagramProtocol, Connection, EventServer, ConnectionStatus
                 value = int(value)
 
             if coil.has_mappings and isinstance(value, int):
-                value = coil.get_mapping_for(value)
+                coil_data = CoilData.from_mapping(coil, value)
+            else:
+                coil_data = CoilData(coil, value)
 
-            coil_data = CoilData(coil, value)
             logger.info(coil_data)
             self._on_coil_read_success(coil_data)
         except NibeException as e:

--- a/tests/test_coil.py
+++ b/tests/test_coil.py
@@ -5,7 +5,12 @@ import pytest
 
 from nibe.coil import Coil, CoilData
 from nibe.connection.nibegw import CoilDataEncoderNibeGw
-from nibe.exceptions import DecodeException, EncodeException, ValidationError
+from nibe.exceptions import (
+    DecodeException,
+    EncodeException,
+    NoMappingException,
+    ValidationError,
+)
 from nibe.parsers import swapwords
 
 
@@ -447,8 +452,12 @@ def test_unsigned_u8_mapping_decode(
 def test_unsigned_u8_mapping_decode_exception(
     encoder_word_swap_false: CoilDataEncoderNibeGw, coil_unsigned_u8_mapping: Coil
 ):
-    with pytest.raises(DecodeException):
-        encoder_word_swap_false.decode(coil_unsigned_u8_mapping, b"\x00")
+    coil_data = encoder_word_swap_false.decode(coil_unsigned_u8_mapping, b"\x00")
+
+    assert coil_data.value == "UNKNOWN (0)"
+
+    with pytest.raises(NoMappingException):
+        coil_data.validate()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fallback to `UNKNOWN (int)`.

Writes should fail.