### PR TITLE
Handle out of range values on rmu data

### DIFF
--- a/nibe/connection/encoders.py
+++ b/nibe/connection/encoders.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from binascii import hexlify
-from typing import Generic, List, Optional, SupportsInt, TypeVar, Union
+from typing import Generic, List, Optional, SupportsInt, TypeVar
 
 from construct import (
     Construct,
@@ -45,6 +45,13 @@ integer_limit = {
 }
 
 
+def is_hitting_integer_limit(size: str, int_value: int):
+    limit = integer_limit[size]
+    if limit < 0:
+        return int_value <= limit
+    return int_value >= limit
+
+
 _RawDataT = TypeVar("_RawDataT")
 
 
@@ -82,7 +89,7 @@ class CoilDataEncoder(Generic[_RawDataT]):
         :raises DecodeException: If decoding fails"""
         try:
             value = self.decode_raw_value(coil.size, raw)
-            if self._is_hitting_integer_limit(coil.size, value):
+            if is_hitting_integer_limit(coil.size, value):
                 value = None
 
             return CoilData.from_raw_value(coil, value)
@@ -91,12 +98,6 @@ class CoilDataEncoder(Generic[_RawDataT]):
             raise DecodeException(
                 f"Failed to decode {coil.name} coil from raw: {hexlify(raw).decode('utf-8')}, exception: {e}"
             ) from e
-
-    def _is_hitting_integer_limit(self, size: str, int_value: int):
-        limit = integer_limit[size]
-        if limit < 0:
-            return int_value <= limit
-        return int_value >= limit
 
 
 class CoilDataEncoderNibeGw(CoilDataEncoder[bytes]):

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -531,7 +531,7 @@ class FixedPointStrange(Adapter):
     be fixed.
     """
 
-    def __init__(self, subcon, scale, offset, ndigits=1, size=None) -> None:
+    def __init__(self, subcon, scale, offset, size, ndigits=1) -> None:
         super().__init__(subcon)
         self._offset = offset
         self._scale = scale
@@ -545,7 +545,7 @@ class FixedPointStrange(Adapter):
         else:
             value -= self._offset
 
-        if self._size and is_hitting_integer_limit(self._size, value):
+        if is_hitting_integer_limit(self._size, value):
             return None
 
         return round(value * self._scale, self._ndigits)
@@ -560,7 +560,7 @@ class FixedPointStrange(Adapter):
 
 
 class FixedPoint(Adapter):
-    def __init__(self, subcon, scale, offset, ndigits=1, size=None) -> None:
+    def __init__(self, subcon, scale, offset, size, ndigits=1) -> None:
         super().__init__(subcon)
         self._offset = offset
         self._scale = scale
@@ -570,7 +570,7 @@ class FixedPoint(Adapter):
     def _decode(self, obj, context, path):
         value = obj + self._offset
 
-        if self._size and is_hitting_integer_limit(self._size, value):
+        if is_hitting_integer_limit(self._size, value):
             return None
 
         return round(value * self._scale, self._ndigits)
@@ -608,33 +608,33 @@ RmuData = Struct(
             "hw_production" / Flag,
         ),
     ),
-    "bt1_outdoor_temperature" / FixedPointStrange(Int16sl, 0.1, -5, size="s16"),
-    "bt7_hw_top" / FixedPoint(Int16sl, 0.1, -5, size="s16"),
+    "bt1_outdoor_temperature" / FixedPointStrange(Int16sl, 0.1, -5, "s16"),
+    "bt7_hw_top" / FixedPoint(Int16sl, 0.1, -5, "s16"),
     "setpoint_or_offset_s1"
     / IfThenElse(
         lambda this: this.flags.use_room_sensor_s1,
-        FixedPoint(Int8ub, 0.1, 50, size="u8"),
-        FixedPoint(Int8sb, 1.0, 0, size="s8"),
+        FixedPoint(Int8ub, 0.1, 50, "u8"),
+        FixedPoint(Int8sb, 1.0, 0, "s8"),
     ),
     "setpoint_or_offset_s2"
     / IfThenElse(
         lambda this: this.flags.use_room_sensor_s2,
-        FixedPoint(Int8ub, 0.1, 50, size="u8"),
-        FixedPoint(Int8sb, 1.0, 0, size="s8"),
+        FixedPoint(Int8ub, 0.1, 50, "u8"),
+        FixedPoint(Int8sb, 1.0, 0, "s8"),
     ),
     "setpoint_or_offset_s3"
     / IfThenElse(
         lambda this: this.flags.use_room_sensor_s3,
-        FixedPoint(Int8ub, 0.1, 50, size="u8"),
-        FixedPoint(Int8sb, 1.0, 0, size="s8"),
+        FixedPoint(Int8ub, 0.1, 50, "u8"),
+        FixedPoint(Int8sb, 1.0, 0, "s8"),
     ),
     "setpoint_or_offset_s4"
     / IfThenElse(
         lambda this: this.flags.use_room_sensor_s4,
-        FixedPoint(Int8ub, 0.1, 50, size="u8"),
-        FixedPoint(Int8sb, 1.0, 0, size="s8"),
+        FixedPoint(Int8ub, 0.1, 50, "u8"),
+        FixedPoint(Int8sb, 1.0, 0, "s8"),
     ),
-    "bt50_room_temp_sX" / FixedPoint(Int16sl, 0.1, -5, size="s16"),
+    "bt50_room_temp_sX" / FixedPoint(Int16sl, 0.1, -5, "s16"),
     "temporary_lux" / Int8ub,
     "hw_time_hour" / Int8ub,
     "hw_time_min" / Int8ub,

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -533,7 +533,7 @@ class FixedPointStrange(Adapter):
 
     def __init__(self, subcon, scale, offset, ndigits=1, size=None) -> None:
         super().__init__(subcon)
-        self._offset = offset / scale
+        self._offset = offset
         self._scale = scale
         self._ndigits = ndigits
         self._size = size
@@ -562,7 +562,7 @@ class FixedPointStrange(Adapter):
 class FixedPoint(Adapter):
     def __init__(self, subcon, scale, offset, ndigits=1, size=None) -> None:
         super().__init__(subcon)
-        self._offset = offset / scale
+        self._offset = offset
         self._scale = scale
         self._ndigits = ndigits
         self._size = size
@@ -608,33 +608,33 @@ RmuData = Struct(
             "hw_production" / Flag,
         ),
     ),
-    "bt1_outdoor_temperature" / FixedPointStrange(Int16sl, 0.1, -0.5, size="s16"),
-    "bt7_hw_top" / FixedPoint(Int16sl, 0.1, -0.5),
+    "bt1_outdoor_temperature" / FixedPointStrange(Int16sl, 0.1, -5, size="s16"),
+    "bt7_hw_top" / FixedPoint(Int16sl, 0.1, -5),
     "setpoint_or_offset_s1"
     / IfThenElse(
         lambda this: this.flags.use_room_sensor_s1,
-        FixedPoint(Int8ub, 0.1, 5.0, size="u8"),
+        FixedPoint(Int8ub, 0.1, 50, size="u8"),
         FixedPoint(Int8sb, 1.0, 0, size="s8"),
     ),
     "setpoint_or_offset_s2"
     / IfThenElse(
         lambda this: this.flags.use_room_sensor_s2,
-        FixedPoint(Int8ub, 0.1, 5.0, size="u8"),
+        FixedPoint(Int8ub, 0.1, 50, size="u8"),
         FixedPoint(Int8sb, 1.0, 0, size="s8"),
     ),
     "setpoint_or_offset_s3"
     / IfThenElse(
         lambda this: this.flags.use_room_sensor_s3,
-        FixedPoint(Int8ub, 0.1, 5.0, size="u8"),
+        FixedPoint(Int8ub, 0.1, 50, size="u8"),
         FixedPoint(Int8sb, 1.0, 0, size="s8"),
     ),
     "setpoint_or_offset_s4"
     / IfThenElse(
         lambda this: this.flags.use_room_sensor_s4,
-        FixedPoint(Int8ub, 0.1, 5.0, size="u8"),
+        FixedPoint(Int8ub, 0.1, 50, size="u8"),
         FixedPoint(Int8sb, 1.0, 0, size="s8"),
     ),
-    "bt50_room_temp_sX" / FixedPoint(Int16sl, 0.1, -0.5, size="s16"),
+    "bt50_room_temp_sX" / FixedPoint(Int16sl, 0.1, -5, size="s16"),
     "temporary_lux" / Int8ub,
     "hw_time_hour" / Int8ub,
     "hw_time_min" / Int8ub,
@@ -767,7 +767,7 @@ RequestData = Switch(
                 lambda this: this.index,
                 {
                     "TEMPORARY_LUX": Int8ub,
-                    "TEMPERATURE": FixedPoint(Int16ul, 0.1, -0.7),
+                    "TEMPERATURE": FixedPoint(Int16ul, 0.1, -7.0, size="s16"),
                     "FUNCTIONS": FlagsEnum(
                         Int8ub,
                         allow_additive_heating=0x01,
@@ -775,10 +775,10 @@ RequestData = Switch(
                         allow_cooling=0x04,
                     ),
                     "OPERATIONAL_MODE": Int8ub,
-                    "SETPOINT_S1": FixedPoint(Int16sl, 0.1, 0.0),
-                    "SETPOINT_S2": FixedPoint(Int16sl, 0.1, 0.0),
-                    "SETPOINT_S3": FixedPoint(Int16sl, 0.1, 0.0),
-                    "SETPOINT_S4": FixedPoint(Int16sl, 0.1, 0.0),
+                    "SETPOINT_S1": FixedPoint(Int16sl, 0.1, 0.0, size="s16"),
+                    "SETPOINT_S2": FixedPoint(Int16sl, 0.1, 0.0, size="s16"),
+                    "SETPOINT_S3": FixedPoint(Int16sl, 0.1, 0.0, size="s16"),
+                    "SETPOINT_S4": FixedPoint(Int16sl, 0.1, 0.0, size="s16"),
                 },
                 default=Select(
                     Int16ul,

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -609,7 +609,7 @@ RmuData = Struct(
         ),
     ),
     "bt1_outdoor_temperature" / FixedPointStrange(Int16sl, 0.1, -5, size="s16"),
-    "bt7_hw_top" / FixedPoint(Int16sl, 0.1, -5),
+    "bt7_hw_top" / FixedPoint(Int16sl, 0.1, -5, size="s16"),
     "setpoint_or_offset_s1"
     / IfThenElse(
         lambda this: this.flags.use_room_sensor_s1,

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -545,8 +545,10 @@ class FixedPointStrange(Adapter):
         else:
             value -= self._offset
 
-        if is_hitting_integer_limit(self._size, value):
-            return None
+        # For now skip limit checks, since we don't know
+        # how the pump handles these for this special case
+        # for negative offsets, we could never reach the
+        # integer limits after offset has been applied.
 
         return round(value * self._scale, self._ndigits)
 
@@ -570,6 +572,10 @@ class FixedPoint(Adapter):
     def _decode(self, obj, context, path):
         value = obj + self._offset
 
+        # Limits seem to be applied after offset
+        # have been applied. This may possible depend
+        # on the sign of the offset, but that is unknown
+        # at the moment.
         if is_hitting_integer_limit(self._size, value):
             return None
 

--- a/tests/connection/test_nibegw_message_parsing.py
+++ b/tests/connection/test_nibegw_message_parsing.py
@@ -329,9 +329,54 @@ class MessageRmuDataParsingTestCase(unittest.TestCase):
             unknown5=b"\x01\x00",
         )
 
+    def test_invalid_values(self):
+        data = self.parse(
+            "0500 0080 9b 9b 9b ff 0080 00 00 00 00 00 03 79 15 34 00 03 00 00 01 00"
+        )
+
+        assert data == Container(
+            bt1_outdoor_temperature=0.0,
+            bt7_hw_top=None,
+            setpoint_or_offset_s1=20.5,
+            setpoint_or_offset_s2=20.5,
+            setpoint_or_offset_s3=20.5,
+            setpoint_or_offset_s4=-1.0,
+            bt50_room_temp_sX=None,
+            temporary_lux=0,
+            hw_time_hour=0,
+            hw_time_min=0,
+            fan_mode=0,
+            operational_mode=0,
+            flags=Container(
+                unknown_8000=False,
+                unknown_4000=False,
+                unknown_2000=False,
+                unknown_1000=False,
+                unknown_0800=False,
+                allow_cooling=False,
+                allow_heating=True,
+                allow_additive_heating=True,
+                use_room_sensor_s4=False,
+                use_room_sensor_s3=True,
+                use_room_sensor_s2=True,
+                use_room_sensor_s1=True,
+                unknown_0008=True,
+                unknown_0004=False,
+                unknown_0002=False,
+                hw_production=True,
+            ),
+            clock_time_hour=21,
+            clock_time_min=52,
+            alarm=0,
+            unknown4=b"\x03",
+            fan_time_hour=0,
+            fan_time_min=0,
+            unknown5=b"\x01\x00",
+        )
+
     @staticmethod
     def parse(txt_raw):
-        raw = binascii.unhexlify(txt_raw)
+        raw = binascii.unhexlify(txt_raw.replace(" ", ""))
         return RmuData.parse(raw)
 
 


### PR DESCRIPTION
We need to apply the same out of range checks for RMU data, since these fields also send out range data on error values.

Swapping scale and offset and applying same range checks for RMU data.