### PR TITLE
Clean up construct configuration for nibe gw

### DIFF
--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -760,7 +760,7 @@ ResponseData = Struct(
 )
 
 Response = Struct(
-    "start_byte" / Const(0x5C, Int8ub),
+    "start_byte" / Const("RESPONSE", StartCode),
     "fields" / RawCopy(ResponseData),
     "checksum" / Checksum(Int8ub, xor8, this.fields.data),
 )
@@ -824,7 +824,7 @@ RequestTypes = {
 }
 
 RequestData = Struct(
-    "start_byte" / Const(0xC0, Int8ub),
+    Const("REQUEST", StartCode),
     "cmd" / Command,
     "data" / Prefixed(Int8ub,
         Switch(
@@ -836,13 +836,22 @@ RequestData = Struct(
 )
 
 Request = Struct(
+    "start_byte" / Peek(StartCode),
     "fields" / RawCopy(RequestData),
     "checksum" / Checksum(Int8ub, xor8, this.fields.data),
 )
 
-Ack = Struct("fields" / RawCopy(Struct("Ack" / Const(0x06, Int8ub))))
+AckData = Struct(Const("ACK", StartCode))
+Ack = Struct(
+    "start_byte" / Peek(StartCode),
+    "fields" / RawCopy(AckData)
+)
 
-Nak = Struct("fields" / RawCopy(Struct("Nak" / Const(0x15, Int8ub))))
+NakData = Struct(Const("NAK", StartCode))
+Nak = Struct(
+    "start_byte" / Peek(StartCode),
+    "fields" / RawCopy(NakData)
+)
 
 BlockTypes = {
     "RESPONSE": Response,

--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -23,7 +23,6 @@ from construct import (
     Container,
     Enum,
     EnumIntegerString,
-    FixedSized,
     Flag,
     FlagsEnum,
     FocusedSeq,
@@ -748,8 +747,7 @@ ADDRESS_TO_ROOM_TEMP_COIL = {
 ResponseData = Struct(
     "address" / Address,
     "cmd" / Command,
-    "length" / Int8ub,
-    "data" / FixedSized(this.length,
+    "data" / Prefixed(Int8ub,
         Dedupe5C(
             Switch(
                 this.cmd, ResponseTypes,

--- a/nibe/console_scripts/cli.py
+++ b/nibe/console_scripts/cli.py
@@ -223,7 +223,7 @@ def parse_file(file: IO, type: str):
 
     with io.BytesIO(bytes(data)) as stream:
         for packet in parse_stream(stream):
-            click.echo(packet.fields.value)
+            click.echo(packet)
 
         remaining = stream.read()
         if remaining:

--- a/nibe/console_scripts/cli.py
+++ b/nibe/console_scripts/cli.py
@@ -9,37 +9,14 @@ import re
 from typing import IO
 
 import asyncclick as click
-from construct import (
-    Const,
-    ConstructError,
-    FocusedSeq,
-    GreedyRange,
-    Int8ul,
-    Peek,
-    RawCopy,
-    Struct,
-    Switch,
-    this,
-)
+from construct import ConstructError
 
 from ..coil import CoilData
 from ..connection import Connection
 from ..connection.modbus import Modbus
-from ..connection.nibegw import NibeGW, Request, Response
+from ..connection.nibegw import Block, NibeGW
 from ..exceptions import NibeException
 from ..heatpump import HeatPump, Model
-
-Ack = Struct("fields" / RawCopy(Struct("Ack" / Const(0x06, Int8ul))))
-
-Nak = Struct("fields" / RawCopy(Struct("Nak" / Const(0x15, Int8ul))))
-
-Block = FocusedSeq(
-    "data",
-    "start" / Peek(Int8ul),
-    "data" / Switch(this.start, {0x5C: Response, 0xC0: Request, 0x06: Ack, 0x15: Nak}),
-)
-
-Stream = GreedyRange(Block)
 
 
 @click.group()

--- a/tests/connection/test_nibegw_message_parsing.py
+++ b/tests/connection/test_nibegw_message_parsing.py
@@ -20,7 +20,6 @@ class MessageResponseParsingTestCase(unittest.TestCase):
         data = self._parse_hexlified_raw_message("5c41c9f7007f06")
         assert data.address == "HEATPUMP_1"
         assert data.cmd == "HEATPUMP_REQ"
-        assert data.length == 0
         assert data.data == b""
 
     def test_parse_escaped_read_response(self):


### PR DESCRIPTION
This reduces the nesting depth and make the logged output from a parsed block more readable.