### PR TITLE
Fix unit of current power consumption for S320

### DIFF
--- a/nibe/data/s320_s325.csv
+++ b/nibe/data/s320_s325.csv
@@ -1237,8 +1237,8 @@ Energy log - Used energy for hot water over the past hour	MODBUS_INPUT_REGISTER	
 Energy log - Used energy for cooling over the past hour	MODBUS_INPUT_REGISTER	2297	100	kWh	6	0	0	0
 Energy log - Used energy by additional heater for heating over the past hour	MODBUS_INPUT_REGISTER	2299	100	kWh	6	0	0	0
 Energy log - Used energy by additional heater for hot water over the past hour	MODBUS_INPUT_REGISTER	2301	100	kWh	6	0	0	0
-Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kWh	6	0	0	0
-Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2408	100	kWh	6	0	0	0
+Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kW	6	0	0	0
+Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2408	100	kW	6	0	0	0
 Compressor, total time energy storage, main unit (EP14)	MODBUS_INPUT_REGISTER	2335	1	h	6	0	2147483647	0
 Compressor, total time energy storage, main unit (EP15)	MODBUS_INPUT_REGISTER	2337	1	h	6	0	2147483647	0
 Compressor, total time energy storage, heat pump 1 (EP14)	MODBUS_INPUT_REGISTER	2339	1	h	6	0	2147483647	0

--- a/nibe/data/s320_s325.json
+++ b/nibe/data/s320_s325.json
@@ -7388,14 +7388,14 @@
   "32306": {
     "title": "Energy log - Current power consumption",
     "factor": 100,
-    "unit": "kWh",
+    "unit": "kW",
     "size": "u32",
     "name": "energy-log-current-power-consumption-32306"
   },
   "32409": {
     "title": "Energy log - Current power consumption, components",
     "factor": 100,
-    "unit": "kWh",
+    "unit": "kW",
     "size": "u32",
     "name": "energy-log-current-power-consumption-components-32409"
   },


### PR DESCRIPTION
Fix unit of Current Power consumption which got wrongly updated to kWh in a previous update but as it's the current power and not energy it should remain in kW iso kWh

This fixes following issue in Home Assistant: https://github.com/home-assistant/core/issues/127832