### PR TITLE
Require async_modbus 0.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-async_modbus >= 0.2.0
+async_modbus >= 0.2.2
 async_timeout >= 4.0.0
 black>=22.0.0
 construct >= 2.10.0, < 3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 python_requires = >=3.9
 install_requires =
     construct >= 2.10.0, < 3.0.0
-    async_modbus >= 0.2.0
+    async_modbus >= 0.2.2
     async_timeout >= 4.0.0
     tenacity >= 8.0.0
     exceptiongroup >= 1.0.0


### PR DESCRIPTION
This modbus release contain fixes for numpy incompatibilities.

https://github.com/tiagocoutinho/async_modbus/compare/v0.2.0...v0.2.2