### PR TITLE
Add pulse energy meter (BE6) for S1255

### DIFF
--- a/nibe/data/s1155_s1255.csv
+++ b/nibe/data/s1155_s1255.csv
@@ -223,6 +223,7 @@ Seconds of blank time left, charge pump 2	MODBUS_INPUT_REGISTER	391	1		4	0	0	0
 Seconds of blank time left, charge pump 1	MODBUS_INPUT_REGISTER	392	1		4	0	0	0
 Inverter min speed	MODBUS_INPUT_REGISTER	394	1		5	0	0	0
 Inverter max speed	MODBUS_INPUT_REGISTER	395	1		5	0	0	0
+Pulse energy meter (BE6)	MODBUS_INPUT_REGISTER	396	100	kWh	6	0	2147483647	0
 Max fan speed (EB101)	MODBUS_INPUT_REGISTER	402	1	rpm	5	0	0	0
 Min fan speed (EB101)	MODBUS_INPUT_REGISTER	403	1	rpm	5	0	0	0
 Generated power heating (EB101)	MODBUS_INPUT_REGISTER	406	10	kW	5	0	0	0

--- a/nibe/data/s1155_s1255.json
+++ b/nibe/data/s1155_s1255.json
@@ -1492,6 +1492,16 @@
     "size": "u16",
     "name": "inverter-max-speed-30396"
   },
+  "30397": {
+    "title": "Pulse energy meter (BE6)",
+    "factor": 100,
+    "unit": "kWh",
+    "size": "u32",
+    "min": 0.0,
+    "max": 2147483647.0,
+    "default": 0.0,
+    "name": "pulse-energy-meter-be6-30397"
+  },
   "30403": {
     "title": "Max fan speed (EB101)",
     "factor": 1,


### PR DESCRIPTION
Subject says it all: one new data item.

Remark: This may sound much like Issue #138, which I submitted the wrong way and which therefore ended up being closed for delivering something else.

Hint: to run the script **nibe.console_scripts.convert_csv**, I needed to install additional modules:
- pandas
- slugify
- exceptiongroup

Translated to debian:
apt-get install python3-pandas
apt-get install python3-slugify
apt-get install python3-exceptiongroup
May be worth a hint for more users to succeed in using the right way of submission.
