### PR TITLE
Apply missing extensions to S1156_S1256 models

### DIFF
--- a/nibe/data/extensions.json
+++ b/nibe/data/extensions.json
@@ -363,7 +363,10 @@
   },
   {
     "description": "M12676EN-1 - S1155/S1255 ",
-    "files": ["s1155_s1255.json"],
+    "files": [
+      "s1155_s1255.json",
+      "s1156_s1256.json"
+    ],
     "data": {
       "31101": {
         "mappings": {
@@ -375,7 +378,10 @@
   },
   {
     "description": "Reversing valve hot water (QN10) - S1155/S1255 ",
-    "files": ["s1155_s1255.json"],
+    "files": [
+      "s1155_s1255.json",
+      "s1156_s1256.json"
+    ],
     "data": {
       "32197": {
         "mappings": {
@@ -469,6 +475,7 @@
       "s330_s332.json",
       "s735.json",
       "s1155_s1255.json",
+      "s1156_s1256.json",
       "s2125.json",
       "smos40.json"],
     "data": {

--- a/nibe/data/s1156_s1256.json
+++ b/nibe/data/s1156_s1256.json
@@ -3057,7 +3057,14 @@
     "title": "Priority",
     "factor": 1,
     "size": "u8",
-    "name": "priority-31029"
+    "name": "priority-31029",
+    "mappings": {
+      "10": "Off",
+      "20": "Hot Water",
+      "30": "Heat",
+      "40": "Pool",
+      "60": "Cooling"
+    }
   },
   "31030": {
     "title": "Operating mode internal add. heat",
@@ -3316,7 +3323,11 @@
     "title": "Compressor status",
     "factor": 1,
     "size": "u8",
-    "name": "compressor-status-31101"
+    "name": "compressor-status-31101",
+    "mappings": {
+      "0": "Off",
+      "1": "On"
+    }
   },
   "31103": {
     "title": "Heating medium pump speed (GP1)",
@@ -3354,7 +3365,11 @@
     "title": "Reversing valve hot water (QN10)",
     "factor": 1,
     "size": "u8",
-    "name": "reversing-valve-hot-water-qn10-32197"
+    "name": "reversing-valve-hot-water-qn10-32197",
+    "mappings": {
+      "0": "Off",
+      "1": "On"
+    }
   },
   "31112": {
     "title": "Cooling activated (FLM 4)",
@@ -4807,7 +4822,13 @@
     "max": 4.0,
     "default": 1.0,
     "name": "hot-water-demand-mode-40057",
-    "write": true
+    "write": true,
+    "mappings": {
+      "0": "Small",
+      "1": "Medium",
+      "2": "Large",
+      "4": "Smart Control"
+    }
   },
   "40059": {
     "title": "Start temperature HW high temperature",
@@ -5936,7 +5957,12 @@
     "factor": 1,
     "size": "u8",
     "name": "oper-mode-40238",
-    "write": true
+    "write": true,
+    "mappings": {
+      "0": "Auto",
+      "1": "Manual",
+      "2": "Add. heat only"
+    }
   },
   "40676": {
     "title": "FLM 4",


### PR DESCRIPTION
Commit 7ce671c separates the models S1156-S1256 from S1155-S1255 but does not apply extensions that were already defined for the original models. This change fixes this.


## Pull Request Type

Please select the type of your PR:

- [X] Add/Update Registries
- [ ] Feature
- [ ] Bug Fix

## Description

**Heatpump model**: S1256

The extensions provides mappings for some registers of the S1155-S1255 heatpumps. The S1256 model also used these mappings because it used the same data file. This was changed recently, but the extensions were not applied to the new data file.

This change updates the extension file and also the result of running `python3 -m nibe.console_scripts.convert_csv`.

## Checklist

- [X] I have followed the instructions
- [ ] I ensured that my changes are well tested
