### PR TITLE
fix unit for current power in smos40

### DIFF
--- a/nibe/data/smos40.csv
+++ b/nibe/data/smos40.csv
@@ -1601,7 +1601,7 @@ Energy log - Used energy for cooling over the past hour	MODBUS_INPUT_REGISTER	22
 Energy log - Used energy by additional heater for heating over the past hour	MODBUS_INPUT_REGISTER	2299	100	kWh	6	0	0	0
 Energy log - Used energy by additional heater for hot water over the past hour	MODBUS_INPUT_REGISTER	2301	100	kWh	6	0	0	0
 Energy log - Energy used by additional heater for pool during current hour	MODBUS_INPUT_REGISTER	2303	100	kWh	6	0	0	0
-Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kWh	6	0	0	0
+Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kW	6	0	0	0
 Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2307	100	kW	6	0	0	0
 Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2408	100	kWh	6	0	0	0
 id:25407	MODBUS_HOLDING_REGISTER	0	1		4	0	0	0

--- a/nibe/data/smos40.json
+++ b/nibe/data/smos40.json
@@ -10161,7 +10161,7 @@
   "32306": {
     "title": "Energy log - Current power consumption",
     "factor": 100,
-    "unit": "kWh",
+    "unit": "kW",
     "size": "u32",
     "name": "energy-log-current-power-consumption-32306"
   },


### PR DESCRIPTION
## Pull Request Type

Please select the type of your PR:

- [ ] Add/Update Registries
- [ ] Feature
- [x] Bug Fix

## Description

**Heatpump model**: SMO S40

**Firmware version**: 

Change unit of current power (2305/32306) from kWh to kW.

- [x] I have followed the instructions
