### PR TITLE
Use Hot water top (BT7) for hot_water_load (water heater coil)

### DIFF
--- a/nibe/coil_groups.py
+++ b/nibe/coil_groups.py
@@ -180,7 +180,7 @@ _WATER_HEATER_COILGROUPS_F = {
 _WATER_HEATER_COILGROUPS_S = {
     "hw1": WaterHeaterCoilGroup(
         name="Hot Water",
-        hot_water_load=30010,
+        hot_water_load=30009,
         hot_water_comfort_mode=31039,
         start_temperature={
             "LOW": 40061,


### PR DESCRIPTION
## Pull Request Type

Please select the type of your PR:

- [x ] Add/Update Registries
- [ ] Feature
- [ ] Bug Fix

## Description

**Heatpump model**: S1255 

**Firmware version**: 4.4.7

Updated the water heater coil group for the nibe S-series to use Hot water top (BT7) for hot_water_load. This is the same value as the app uses to display the water temperature.

## Checklist

- [ x] I have followed the instructions
- [x ] I ensured that my changes are well tested
