### PR TITLE
Added Fan Mode to vvm310 and vvm500

### DIFF
--- a/nibe/data/vvm310_vvm500.json
+++ b/nibe/data/vvm310_vvm500.json
@@ -8241,5 +8241,23 @@
     "factor": 1,
     "name": "aux-ers-fire-place-guard-49430",
     "write": true
+  },
+  "47260": {
+    "title": "Fan Mode",
+    "info": "0=Normal 1=Fan speed 1, 2=Fan speed 2, 3=Fan speed 3, 4=Fan speed 4",
+    "size": "u8",
+    "factor": 1,
+    "min": 0,
+    "max": 4,
+    "default": 0,
+    "name": "fan-mode-47260",
+    "write": true,
+    "mappings": {
+      "0": "Normal",
+      "1": "Fan mode 1",
+      "2": "Fan mode 2",
+      "3": "Fan mode 3",
+      "4": "Fan mode 4"
+    }
   }
 }


### PR DESCRIPTION



## Pull Request Type

Please select the type of your PR:

- [X] Add/Update Registries
- [ ] Feature
- [ ] Bug Fix

## Description

**Heatpump model**: VVM500

**Firmware version**: 9721

I was missing the fan mode in my NIBE heat pump that I control via Home Assistant. I added this manually and it immediately worked in Home Assistant (Docker version).

I have just copied the registers from the vvm225_vvm320_vvm325.json. But as stated, I tested it in my own Home Assistant version. I have an ESP32 (ProDino ESP32 from KMP) connected to my heat pump and running the nibeGW component via esphome on the ESP32.

## Checklist

- [x] I have followed the instructions
- [x] I ensured that my changes are well tested
