### PR TITLE
fix unit of power consumption for S-series

### DIFF
--- a/nibe/data/s1156_s1256.csv
+++ b/nibe/data/s1156_s1256.csv
@@ -1724,8 +1724,8 @@ Energy log - Used energy for pool over the past hour	MODBUS_INPUT_REGISTER	2295	
 Energy log - Used energy by additional heater for heating over the past hour	MODBUS_INPUT_REGISTER	2299	100	kWh	u32	0	0	0
 Energy log - Used energy by additional heater for hot water over the past hour	MODBUS_INPUT_REGISTER	2301	100	kWh	u32	0	0	0
 Energy log - Used energy by additional heater for pool over the past hour	MODBUS_INPUT_REGISTER	2303	100	kWh	u32	0	0	0
-Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kWh	u32	0	0	0
-Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2408	100	kWh	u32	0	0	0
+Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kW	u32	0	0	0
+Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2408	100	kW	u32	0	0	0
 Compressor, total time energy storage, main unit (EP14)	MODBUS_INPUT_REGISTER	2335	1	h	u32	0	2147483647	0
 Compressor, total time energy storage, main unit (EP15)	MODBUS_INPUT_REGISTER	2337	1	h	u32	0	2147483647	0
 Compressor, total time energy storage, heat pump 1 (EP14)	MODBUS_INPUT_REGISTER	2339	1	h	u32	0	2147483647	0

--- a/nibe/data/s1156_s1256.json
+++ b/nibe/data/s1156_s1256.json
@@ -10812,14 +10812,14 @@
   "32306": {
     "title": "Energy log - Current power consumption",
     "factor": 100,
-    "unit": "kWh",
+    "unit": "kW",
     "size": "u32",
     "name": "energy-log-current-power-consumption-32306"
   },
   "32409": {
     "title": "Energy log - Current power consumption, components",
     "factor": 100,
-    "unit": "kWh",
+    "unit": "kW",
     "size": "u32",
     "name": "energy-log-current-power-consumption-components-32409"
   },

--- a/nibe/data/s2125.csv
+++ b/nibe/data/s2125.csv
@@ -1179,8 +1179,8 @@ Energy log - Used energy for hot water over the past hour	MODBUS_INPUT_REGISTER	
 Energy log - Used energy for cooling over the past hour	MODBUS_INPUT_REGISTER	2297	100	kWh	6	0	0	0
 Energy log - Used energy by additional heater for heating over the past hour	MODBUS_INPUT_REGISTER	2299	100	kWh	6	0	0	0
 Energy log - Used energy by additional heater for hot water over the past hour	MODBUS_INPUT_REGISTER	2301	100	kWh	6	0	0	0
-Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kWh	6	0	0	0
-Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2408	100	kWh	6	0	0	0
+Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kW	6	0	0	0
+Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2408	100	kW	6	0	0	0
 Compressor, total time energy storage, main unit (EP14)	MODBUS_INPUT_REGISTER	2335	1	h	6	0	2147483647	0
 Compressor, total time energy storage, main unit (EP15)	MODBUS_INPUT_REGISTER	2337	1	h	6	0	2147483647	0
 Compressor, total time energy storage, heat pump 1 (EP14)	MODBUS_INPUT_REGISTER	2339	1	h	6	0	2147483647	0

--- a/nibe/data/s2125.json
+++ b/nibe/data/s2125.json
@@ -7114,14 +7114,14 @@
   "32306": {
     "title": "Energy log - Current power consumption",
     "factor": 100,
-    "unit": "kWh",
+    "unit": "kW",
     "size": "u32",
     "name": "energy-log-current-power-consumption-32306"
   },
   "32409": {
     "title": "Energy log - Current power consumption, components",
     "factor": 100,
-    "unit": "kWh",
+    "unit": "kW",
     "size": "u32",
     "name": "energy-log-current-power-consumption-components-32409"
   },

--- a/nibe/data/s330_s332.csv
+++ b/nibe/data/s330_s332.csv
@@ -1186,8 +1186,8 @@ Energy log - Used energy for heating over the past hour	MODBUS_INPUT_REGISTER	22
 Energy log - Used energy for hot water over the past hour	MODBUS_INPUT_REGISTER	2293	100	kWh	6	0	0	0
 Energy log - Used energy by additional heater for heating over the past hour	MODBUS_INPUT_REGISTER	2299	100	kWh	6	0	0	0
 Energy log - Used energy by additional heater for hot water over the past hour	MODBUS_INPUT_REGISTER	2301	100	kWh	6	0	0	0
-Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kWh	6	0	0	0
-Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2408	100	kWh	6	0	0	0
+Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kW	6	0	0	0
+Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2408	100	kW	6	0	0	0
 Compressor, total time energy storage, main unit (EP14)	MODBUS_INPUT_REGISTER	2335	1	h	6	0	2147483647	0
 Compressor, total time energy storage, main unit (EP15)	MODBUS_INPUT_REGISTER	2337	1	h	6	0	2147483647	0
 Compressor, total time energy storage, heat pump 1 (EP14)	MODBUS_INPUT_REGISTER	2339	1	h	6	0	2147483647	0

--- a/nibe/data/s330_s332.json
+++ b/nibe/data/s330_s332.json
@@ -7250,14 +7250,14 @@
   "32306": {
     "title": "Energy log - Current power consumption",
     "factor": 100,
-    "unit": "kWh",
+    "unit": "kW",
     "size": "u32",
     "name": "energy-log-current-power-consumption-32306"
   },
   "32409": {
     "title": "Energy log - Current power consumption, components",
     "factor": 100,
-    "unit": "kWh",
+    "unit": "kW",
     "size": "u32",
     "name": "energy-log-current-power-consumption-components-32409"
   },

--- a/nibe/data/s735.csv
+++ b/nibe/data/s735.csv
@@ -1467,8 +1467,8 @@ Energy log - Used energy for heating over the past hour	MODBUS_INPUT_REGISTER	22
 Energy log - Used energy for hot water over the past hour	MODBUS_INPUT_REGISTER	2293	100	kWh	6	0	0	0
 Energy log - Used energy by additional heater for heating over the past hour	MODBUS_INPUT_REGISTER	2299	100	kWh	6	0	0	0
 Energy log - Used energy by additional heater for hot water over the past hour	MODBUS_INPUT_REGISTER	2301	100	kWh	6	0	0	0
-Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kWh	6	0	0	0
-Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2408	100	kWh	6	0	0	0
+Energy log - Current power consumption	MODBUS_INPUT_REGISTER	2305	100	kW	6	0	0	0
+Energy log - Current power consumption, components	MODBUS_INPUT_REGISTER	2408	100	kW	6	0	0	0
 Compressor, total time energy storage, main unit (EP14)	MODBUS_INPUT_REGISTER	2335	1	h	6	0	2147483647	0
 Compressor, total time energy storage, main unit (EP15)	MODBUS_INPUT_REGISTER	2337	1	h	6	0	2147483647	0
 Compressor, total time energy storage, heat pump 1 (EP14)	MODBUS_INPUT_REGISTER	2339	1	h	6	0	2147483647	0

--- a/nibe/data/s735.json
+++ b/nibe/data/s735.json
@@ -8253,14 +8253,14 @@
   "32306": {
     "title": "Energy log - Current power consumption",
     "factor": 100,
-    "unit": "kWh",
+    "unit": "kW",
     "size": "u32",
     "name": "energy-log-current-power-consumption-32306"
   },
   "32409": {
     "title": "Energy log - Current power consumption, components",
     "factor": 100,
-    "unit": "kWh",
+    "unit": "kW",
     "size": "u32",
     "name": "energy-log-current-power-consumption-components-32409"
   },


### PR DESCRIPTION
## Pull Request Type

Please select the type of your PR:

- [x] Add/Update Registries
- [ ] Feature
- [ ] Bug Fix

## Description

**Heatpump model**: S1256

**Firmware version**: 4.7.5

Fixing unit of power consumption for all S series heat pumps. I just copy pasted changes in https://github.com/yozik04/nibe/pull/181 and run python3 module to create json files. This should also resolve issue of recent report of one user https://github.com/yozik04/nibe/issues/239

I exported the registers, but there are much more changes.

<!-- IF THIS PR CHANGES REGISTERS. FOLLOW THE INSTRUCTIONS BELOW.

## How to add/update registers in the library

To add/edit registers in the library first of all you need to find documentation how these parameters are officially called. There will be a backward compatibility break if a name will change.

The process contains of mainly next steps: 1. Update source CSV files. 2. Convert CSV files to JSON. 3. Edit extensions.json if needed. 4. Submit PR.

### 1.A For F series pumps

Use [ModbusManager](https://professional.nibe.eu/sv/proffshjalp/kommunikation/nibe-modbus). Do CSV export for the unit you want to update. Find the correct file in `nibe/data` folder. Merge data into that file (Do not change/update any lines. All CSV files are source files they must not be changed).

### 1.B For S serires pumps

Change your pump language to English and do registers export. Merge that data into the correct file in `nibe/data` folder (Do not change/update any lines. All CSV files are source files they must not be changed).

### 2. Convert source CSV files to JSON

```bash
python3 -m nibe.console_scripts.convert_csv
```

### 3. Verify JSON files

Verify that conversion was successful and required lines correctly appeared in the json files. If some modifications are required you need to edit `extensions.json` to fix these.

-> yes, I can see correct units in json files

### 4. Submit PR

Attach your source CSV file for reference so we could verify as well.
-->

## Checklist

- [x] I have followed the instructions
- [x] I ensured that my changes are well tested

Unfortunately I am not able to verify it on other S platforms, but I think it will be only unit issue in the register export. Platform S1256 was verified while editing docker images files + restarting the HA platform.

As a side effect this might hit some people, if they previously added those entities in the individual consumption devices. But this just narrows the situation where it actually were giving bad data and causing untracked devices to show negative values in graphs. Afterwards people are unable to add it to this list. They need to create integral helper first with kWh. Soon I will come with PR for S1256 model (I don't have exports for other models), where there are new register values  _Tot. consumption_ and _Tot. production_

<img width="323" height="209" alt="image" src="https://github.com/user-attachments/assets/cdd0d8e5-74c1-4d82-aee8-cac5e53ece19" />



output of converter:
```
INFO:nibe:Successfully processed files: ['f1145_f1245.csv', 'f1155_f1255.csv', 'f1345.csv', 'f1355.csv', 'f370_f470.csv', 'f730.csv', 'f750.csv', 's1155_s1255.csv', 's1156_s1256.csv', 's2125.csv', 's320_s325.csv', 's330_s332.csv', 's735.csv', 'smo20.csv', 'smo40.csv', 'smos40.csv', 'vvm225_vvm320_vvm325.csv', 'vvm310_vvm500.csv', 'vvms325.csv']
(.venv) 
```

<img width="1162" height="255" alt="image" src="https://github.com/user-attachments/assets/79bba610-8adb-4abc-8521-e5e4b0104b89" />

