### PR TITLE
Support parsing data from external heatpump units

### DIFF
--- a/nibe/connection/nibegw.py
+++ b/nibe/connection/nibegw.py
@@ -621,9 +621,14 @@ Command = Enum(
     ECS_DATA_MSG_1=0x55,
     ECS_DATA_MSG_2=0xA0,
     STRING_MSG=0xB1,
-    HEATPUMP_MSG_1=0xF1,
-    HEATPUMP_MSG_2=0xF2,
-    HEATPUMP_REQ=0xF7,
+    HEATPUMP_MSG_A0=0xA0,
+    HEATPUMP_REQ_73=0x73,
+    HEATPUMP_REQ_B7=0xB7,
+    HEATPUMP_REQ_ED=0xED,
+    HEATPUMP_REQ_F1=0xF1,
+    HEATPUMP_REQ_F2=0xF2,
+    HEATPUMP_REQ_F7=0xF7,
+    HEATPUMP_REQ_FC=0xFC,
 )
 
 
@@ -826,7 +831,7 @@ ModbusWriteReq = Struct(
     "value" / Bytes(4),
 )
 
-HeatpumpMessage1 = Struct(
+HeatpumpReqF1 = Struct(
     "unknown1" / Int16ul,
 
     # VVM500 EB101-EP14-BT3 Return Temp (43621).
@@ -871,7 +876,7 @@ RequestTypes = {
     "RMU_WRITE_REQ": RmuWriteReq,
     "MODBUS_READ_REQ": ModbusReadReq,
     "MODBUS_WRITE_REQ": ModbusWriteReq,
-    "HEATPUMP_MSG_1": HeatpumpMessage1,
+    "HEATPUMP_REQ_F1": HeatpumpReqF1,
 }
 
 RequestData = Struct(


### PR DESCRIPTION
## Pull Request Type

Please select the type of your PR:

- [ ] Add/Update Registries
- [x] Feature
- [ ] Bug Fix

## Description

**Heatpump model**: DEH500

**Firmware version**: <!-- e.g. 5.3.11, 5.4.4 -->

<!-- Please describe your changes here. -->

Addition of parsing of data in communication between external heatpump and controller


<!-- IF THIS PR CHANGES REGISTERS. FOLLOW THE INSTRUCTIONS BELOW.

## How to add/update registers in the library

To add/edit registers in the library first of all you need to find documentation how these parameters are officially called. There will be a backward compatibility break if a name will change.

The process contains of mainly next steps: 1. Update source CSV files. 2. Convert CSV files to JSON. 3. Edit extensions.json if needed. 4. Submit PR.

### 1.A For F series pumps

Use [ModbusManager](https://professional.nibe.eu/sv/proffshjalp/kommunikation/nibe-modbus). Do CSV export for the unit you want to update. Find the correct file in `nibe/data` folder. Merge data into that file (Do not change/update any lines. All CSV files are source files they must not be changed).

### 1.B For S serires pumps

Change your pump language to English and do registers export. Merge that data into the correct file in `nibe/data` folder (Do not change/update any lines. All CSV files are source files they must not be changed).

### 2. Convert source CSV files to JSON

```bash
python3 -m nibe.console_scripts.convert_csv
```

### 3. Verify JSON files

Verify that conversion was successful and required lines correctly appeared in the json files. If some modifications are required you need to edit `extensions.json` to fix these.

### 4. Submit PR

Attach your source CSV file for reference so we could verify as well.
-->

## Checklist

- [ ] I have followed the instructions
- [x] I ensured that my changes are well tested
