### PR TITLE
Add SG Ready mapping to F1245

### DIFF
--- a/nibe/data/extensions.json
+++ b/nibe/data/extensions.json
@@ -695,5 +695,21 @@
         "unit": "DM"
       }
     }
+  },
+   {
+    "description": "SG Ready Operating Mode - F1145/F1245",
+    "files": [
+      "f1145_f1245.json"
+    ],
+    "data": {
+      "44874": {
+        "mappings": {
+          "10": "Blocking",
+          "20": "Normal",
+          "30": "Low Price",
+          "40": "Overcapacity"
+        }
+      }
+    }
   }
 ]

--- a/nibe/data/f1145_f1245.json
+++ b/nibe/data/f1145_f1245.json
@@ -7396,7 +7396,13 @@
     "title": "State SG Ready",
     "size": "u8",
     "factor": 1,
-    "name": "state-sg-ready-44874"
+    "name": "state-sg-ready-44874",
+    "mappings": {
+      "10": "Blocking",
+      "20": "Normal",
+      "30": "Low Price",
+      "40": "Overcapacity"
+    }
   },
   "44878": {
     "title": "SG Ready input A",


### PR DESCRIPTION
## Pull Request Type

Please select the type of your PR:

- [x] Add/Update Registries
- [ ] Feature
- [ ] Bug Fix

## Description

**Heatpump model**: F1245-6

**Firmware version**: 9721R4

<!-- Please describe your changes here. -->
This adds mappings to the SG ready state of the heatpump. Mappings are taken over from installer manual and are different from S-series. S-series has the `10` state as 'normal mode' and `20` as high price, while the F series has `10` state as blocking and `20` as normal mode.

<!-- IF THIS PR CHANGES REGISTERS. FOLLOW THE INSTRUCTIONS BELOW.

## How to add/update registers in the library

To add/edit registers in the library first of all you need to find documentation how these parameters are officially called. There will be a backward compatibility break if a name will change.

The process contains of mainly next steps: 1. Update source CSV files. 2. Convert CSV files to JSON. 3. Edit extensions.json if needed. 4. Submit PR.

### 1.A For F series pumps

Use [ModbusManager](https://professional.nibe.eu/sv/proffshjalp/kommunikation/nibe-modbus). Do CSV export for the unit you want to update. Find the correct file in `nibe/data` folder. Merge data into that file (Do not change/update any lines. All CSV files are source files they must not be changed).

### 1.B For S serires pumps

Change your pump language to English and do registers export. Merge that data into the correct file in `nibe/data` folder (Do not change/update any lines. All CSV files are source files they must not be changed).

### 2. Convert source CSV files to JSON

```bash
python3 -m nibe.console_scripts.convert_csv
```

### 3. Verify JSON files

Verify that conversion was successful and required lines correctly appeared in the json files. If some modifications are required you need to edit `extensions.json` to fix these.

### 4. Submit PR

Attach your source CSV file for reference so we could verify as well.
-->

## Checklist

- [x] I have followed the instructions
- [x] I ensured that my changes are well tested
