### PR TITLE
[Update Registries] VVM320R energy meter mode mappings

### DIFF
--- a/nibe/data/extensions.json
+++ b/nibe/data/extensions.json
@@ -713,5 +713,37 @@
         }
       }
     }
+  },
+  {
+    "description": "Energy meter mode mappings - VVM225/VVM320/VVM325",
+    "files": [
+      "vvm225_vvm320_vvm325.json"
+    ],
+    "data": {
+      "49287": {
+        "info": "Energy meter X23 in mode Wh/pulse = 0, pulses/kWh = 1, EMK150 = 2, EMK300/310 = 3, EMK500 = 4, EMK300/310/05 = 5",
+        "max": 5.0,
+        "mappings": {
+          "0": "Wh/pulse",
+          "1": "pulses/kWh",
+          "2": "EMK150",
+          "3": "EMK300/310",
+          "4": "EMK500",
+          "5": "EMK300/310/05"
+        }
+      },
+      "49288": {
+        "info": "Energy meter X22 in mode Wh/pulse = 0, pulses/kWh = 1, EMK150 = 2, EMK300/310 = 3, EMK500 = 4, EMK300/310/05 = 5",
+        "max": 5.0,
+        "mappings": {
+          "0": "Wh/pulse",
+          "1": "pulses/kWh",
+          "2": "EMK150",
+          "3": "EMK300/310",
+          "4": "EMK500",
+          "5": "EMK300/310/05"
+        }
+      }
+    }
   }
 ]

--- a/nibe/data/vvm225_vvm320_vvm325.json
+++ b/nibe/data/vvm225_vvm320_vvm325.json
@@ -7695,25 +7695,41 @@
   },
   "49287": {
     "title": "Energy Meter mode X23",
-    "info": "Energy meter X23 in mode Wh/pulse = 0 or pulses/kWh = 1",
+    "info": "Energy meter X23 in mode Wh/pulse = 0, pulses/kWh = 1, EMK150 = 2, EMK300/310 = 3, EMK500 = 4, EMK300/310/05 = 5",
     "size": "u8",
     "factor": 1,
     "min": 0.0,
-    "max": 1.0,
+    "max": 5.0,
     "default": 0.0,
     "name": "energy-meter-mode-x23-49287",
-    "write": true
+    "write": true,
+    "mappings": {
+      "0": "Wh/pulse",
+      "1": "pulses/kWh",
+      "2": "EMK150",
+      "3": "EMK300/310",
+      "4": "EMK500",
+      "5": "EMK300/310/05"
+    }
   },
   "49288": {
     "title": "Energy Meter mode X22",
-    "info": "Energy meter X22 in mode Wh/pulse = 0 or pulses/kWh = 1",
+    "info": "Energy meter X22 in mode Wh/pulse = 0, pulses/kWh = 1, EMK150 = 2, EMK300/310 = 3, EMK500 = 4, EMK300/310/05 = 5",
     "size": "u8",
     "factor": 1,
     "min": 0.0,
-    "max": 1.0,
+    "max": 5.0,
     "default": 0.0,
     "name": "energy-meter-mode-x22-49288",
-    "write": true
+    "write": true,
+    "mappings": {
+      "0": "Wh/pulse",
+      "1": "pulses/kWh",
+      "2": "EMK150",
+      "3": "EMK300/310",
+      "4": "EMK500",
+      "5": "EMK300/310/05"
+    }
   },
   "49289": {
     "title": "Ground water pump speed control ",


### PR DESCRIPTION
## Pull Request Type

- [x] Add/Update Registries
- [ ] Feature
- [ ] Bug Fix

## Description

**Heatpump model**: VVM320R (VVM225/VVM320/VVM325 registry)

**Firmware version**: 9721R6

Updates registers 49287 (X23) and 49288 (X22) to support the six energy-meter modes reported for this firmware:

- Wh/pulse = 0
- pulses/kWh = 1
- EMK150 = 2
- EMK300/310 = 3
- EMK500 = 4
- EMK300/310/05 = 5

The original source export is attached in [issue #309](https://github.com/yozik04/nibe/issues/309): [export.csv](https://github.com/user-attachments/files/30345815/export.csv). Nibe confirmed in [their response](https://github.com/yozik04/nibe/issues/309#issuecomment-5226124802) that the Modbus Manager data was incorrect and the observation is likely correct.

Per the repository instructions, the original CSV source remains unchanged. The correction is applied through `extensions.json`, and the generated VVM JSON was regenerated.

Fixes #309

PS: Didn't dare to check the '_I ensured that my changes are well tested_' as it's my first PR here.

## Checklist

- [x] I have followed the instructions
- [ ] I ensured that my changes are well tested